### PR TITLE
View source dependencies

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -33,13 +33,15 @@ impl Command for ViewSource {
     }
 
     fn extra_description(&self) -> &str {
-        "The `def` header is rebuilt from the signature instead of being quoted from the source, so
-`export` and attributes are lost. That holds with or without `--dependencies`.
+        "The `def` header is rebuilt from the signature instead of being quoted from
+the source, so `export` and attributes are lost. That holds with or without
+`--dependencies`.
 
-`--dependencies` applies to a custom command; on an alias, a module, a closure or a block id it does
-nothing. It follows only the calls the parser can see, so a closure written inside the body is
-followed even when it is run through a variable, but one that arrives as an argument is not. And a
-command built on a large module can pull in a lot of output."
+`--dependencies` applies to a custom command; on an alias, a module, a
+closure or a block id it does nothing. It follows only the calls the parser
+can see, so a closure written inside the body is followed even when it is run
+through a variable, but one that arrives as an argument is not. And a command
+built on a large module can pull in a lot of output."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{Config, PipelineMetadata, Span, shell_error::generic::GenericError};
+use nu_protocol::{Config, DeclId, PipelineMetadata, Span, shell_error::generic::GenericError};
 
 use std::fmt::Write;
 
@@ -111,12 +111,6 @@ impl Command for ViewSource {
                 if let Some(decl_id) = engine_state.find_decl(val.as_bytes(), &[]) {
                     // arg is a command
                     let decl = engine_state.get_decl(decl_id);
-                    let sig = decl.signature();
-                    let vec_of_required = &sig.required_positional;
-                    let vec_of_optional = &sig.optional_positional;
-                    let rest = &sig.rest_positional;
-                    let vec_of_flags = &sig.named;
-                    let type_signatures = &sig.input_output_types;
 
                     if decl.is_alias() {
                         if let Some(alias) = &decl.as_alias() {
@@ -140,98 +134,9 @@ impl Command for ViewSource {
                         }
                     }
                     // gets vector of positionals.
-                    else if let Some(block_id) = decl.block_id() {
-                        let block = engine_state.get_block(block_id);
-                        if let Some(block_span) = block.span {
-                            let contents = engine_state.get_span_contents(block_span);
-                            // name of function
-                            let mut final_contents = String::new();
-                            // Collect def flags based on block and signature properties
-                            let flags: Vec<&str> = [
-                                block.redirect_env.then_some("--env"),
-                                sig.allows_unknown_args.then_some("--wrapped"),
-                            ]
-                            .into_iter()
-                            .flatten()
-                            .collect();
-                            let flags_str = if flags.is_empty() {
-                                String::new()
-                            } else {
-                                format!("{} ", flags.join(" "))
-                            };
-                            if val.contains(' ') {
-                                let _ = write!(&mut final_contents, "def {flags_str}\"{val}\" [");
-                            } else {
-                                let _ = write!(&mut final_contents, "def {flags_str}{val} [");
-                            };
-                            if !vec_of_required.is_empty()
-                                || !vec_of_optional.is_empty()
-                                || vec_of_flags.len() != 1
-                                || rest.is_some()
-                            {
-                                final_contents.push(' ');
-                            }
-                            for n in vec_of_required {
-                                let _ = write!(&mut final_contents, "{}: {} ", n.name, n.shape);
-                                // positional arguments
-                            }
-                            for n in vec_of_optional {
-                                if let Some(s) = n.default_value.clone() {
-                                    let _ = write!(
-                                        &mut final_contents,
-                                        "{}: {} = {} ",
-                                        n.name,
-                                        n.shape,
-                                        s.to_expanded_string(" ", &Config::default())
-                                    );
-                                } else {
-                                    let _ =
-                                        write!(&mut final_contents, "{}?: {} ", n.name, n.shape);
-                                }
-                            }
-                            for n in vec_of_flags {
-                                // skip adding the help flag
-                                if n.long == "help" {
-                                    continue;
-                                }
-                                let _ = write!(&mut final_contents, "--{}", n.long);
-                                if let Some(short) = n.short {
-                                    let _ = write!(&mut final_contents, "(-{short})");
-                                }
-                                if let Some(arg) = &n.arg {
-                                    let _ = write!(&mut final_contents, ": {arg}");
-                                }
-                                final_contents.push(' ');
-                            }
-                            if let Some(rest_arg) = rest {
-                                let _ = write!(
-                                    &mut final_contents,
-                                    "...{}:{}",
-                                    rest_arg.name, rest_arg.shape
-                                );
-                            }
-                            let len = type_signatures.len();
-                            if len != 0 {
-                                final_contents.push_str("]: [");
-                                let mut c = 0;
-                                for (insig, outsig) in type_signatures {
-                                    c += 1;
-                                    let s = format!("{insig} -> {outsig}");
-                                    final_contents.push_str(&s);
-                                    if c != len {
-                                        final_contents.push_str(", ")
-                                    }
-                                }
-                            }
-                            final_contents.push_str("] ");
-                            final_contents.push_str(&String::from_utf8_lossy(contents));
-
-                            Ok(make_output(
-                                engine_state,
-                                final_contents,
-                                Some(block_span),
-                                call.head,
-                            ))
+                    else if decl.block_id().is_some() {
+                        if let Some((src, block_span)) = render_def(engine_state, &val, decl_id) {
+                            Ok(make_output(engine_state, src, Some(block_span), call.head))
                         } else {
                             Err(ShellError::Generic(GenericError::new(
                                 "Cannot view string value",
@@ -304,6 +209,106 @@ impl Command for ViewSource {
             }
         }
     }
+}
+
+// Helper function to render a custom command as a `def` header followed by the original text of its
+// body. The header is rebuilt from the signature.
+// Why: a custom command records only the span of its body, so the header cannot be quoted from the
+// source. That also means `export` and attributes cannot be recovered.
+fn render_def(engine_state: &EngineState, name: &str, decl_id: DeclId) -> Option<(String, Span)> {
+    let decl = engine_state.get_decl(decl_id);
+    let sig = decl.signature();
+    let vec_of_required = &sig.required_positional;
+    let vec_of_optional = &sig.optional_positional;
+    let rest = &sig.rest_positional;
+    let vec_of_flags = &sig.named;
+    let type_signatures = &sig.input_output_types;
+
+    let block = engine_state.get_block(decl.block_id()?);
+    let block_span = block.span?;
+    let contents = engine_state.get_span_contents(block_span);
+    // name of function
+    let mut final_contents = String::new();
+    // Collect def flags based on block and signature properties
+    let flags: Vec<&str> = [
+        block.redirect_env.then_some("--env"),
+        sig.allows_unknown_args.then_some("--wrapped"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    let flags_str = if flags.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", flags.join(" "))
+    };
+    if name.contains(' ') {
+        let _ = write!(&mut final_contents, "def {flags_str}\"{name}\" [");
+    } else {
+        let _ = write!(&mut final_contents, "def {flags_str}{name} [");
+    };
+    if !vec_of_required.is_empty()
+        || !vec_of_optional.is_empty()
+        || vec_of_flags.len() != 1
+        || rest.is_some()
+    {
+        final_contents.push(' ');
+    }
+    for n in vec_of_required {
+        let _ = write!(&mut final_contents, "{}: {} ", n.name, n.shape);
+        // positional arguments
+    }
+    for n in vec_of_optional {
+        if let Some(s) = n.default_value.clone() {
+            let _ = write!(
+                &mut final_contents,
+                "{}: {} = {} ",
+                n.name,
+                n.shape,
+                s.to_expanded_string(" ", &Config::default())
+            );
+        } else {
+            let _ = write!(&mut final_contents, "{}?: {} ", n.name, n.shape);
+        }
+    }
+    for n in vec_of_flags {
+        // skip adding the help flag
+        if n.long == "help" {
+            continue;
+        }
+        let _ = write!(&mut final_contents, "--{}", n.long);
+        if let Some(short) = n.short {
+            let _ = write!(&mut final_contents, "(-{short})");
+        }
+        if let Some(arg) = &n.arg {
+            let _ = write!(&mut final_contents, ": {arg}");
+        }
+        final_contents.push(' ');
+    }
+    if let Some(rest_arg) = rest {
+        let _ = write!(
+            &mut final_contents,
+            "...{}:{}",
+            rest_arg.name, rest_arg.shape
+        );
+    }
+    let len = type_signatures.len();
+    if len != 0 {
+        final_contents.push_str("]: [");
+        let mut c = 0;
+        for (insig, outsig) in type_signatures {
+            c += 1;
+            let s = format!("{insig} -> {outsig}");
+            final_contents.push_str(&s);
+            if c != len {
+                final_contents.push_str(", ")
+            }
+        }
+    }
+    final_contents.push_str("] ");
+    final_contents.push_str(&String::from_utf8_lossy(contents));
+
+    Some((final_contents, block_span))
 }
 
 // Helper function to find the file path associated with a given span, if any.

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,6 +1,11 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{Config, DeclId, PipelineMetadata, Span, shell_error::generic::GenericError};
+use nu_protocol::{
+    Config, DeclId, PipelineMetadata, Span,
+    ast::{Expr, Expression, Traverse},
+    shell_error::generic::GenericError,
+};
 
+use std::collections::HashSet;
 use std::fmt::Write;
 
 #[derive(Clone)]
@@ -19,7 +24,22 @@ impl Command for ViewSource {
         Signature::build("view source")
             .input_output_types(vec![(Type::Nothing, Type::String)])
             .required("item", SyntaxShape::Any, "Name or block to view.")
+            .switch(
+                "dependencies",
+                "Also show the source of every custom command the item calls, transitively.",
+                Some('d'),
+            )
             .category(Category::Debug)
+    }
+
+    fn extra_description(&self) -> &str {
+        "The `def` header is rebuilt from the signature instead of being quoted from the source, so
+`export` and attributes are lost. That holds with or without `--dependencies`.
+
+`--dependencies` applies to a custom command; on an alias, a module, a closure or a block id it does
+nothing. It follows only the calls the parser can see, so a closure written inside the body is
+followed even when it is run through a variable, but one that arrives as an argument is not. And a
+command built on a large module can pull in a lot of output."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -62,6 +82,13 @@ impl Command for ViewSource {
                 description: "View the source of an alias.",
                 example: "alias hello = echo hi; view source hello",
                 result: Some(Value::test_string("echo hi")),
+            },
+            Example {
+                description: "View a command together with the commands it calls.",
+                example: "def helper [] { 42 }; def caller [] { helper }; view source caller --dependencies",
+                result: Some(Value::test_string(
+                    "def caller [] { helper }\n\ndef helper [] { 42 }",
+                )),
             },
             Example {
                 description: "View the file where a definition lives via metadata.",
@@ -136,7 +163,40 @@ impl Command for ViewSource {
                     // gets vector of positionals.
                     else if decl.block_id().is_some() {
                         if let Some((src, block_span)) = render_def(engine_state, &val, decl_id) {
-                            Ok(make_output(engine_state, src, Some(block_span), call.head))
+                            let mut sources = vec![src];
+
+                            if call.has_flag(engine_state, stack, "dependencies")? {
+                                let mut emitted = vec![block_span];
+                                // Why: the root is already rendered above, under the name the user
+                                // typed — which for an imported command is the qualified one.
+                                for dep in
+                                    decls_with_deps(engine_state, decl_id).into_iter().skip(1)
+                                {
+                                    // Why: the defining name, not the name the caller imported it
+                                    // under. Bodies are quoted verbatim, so a renamed header would
+                                    // disagree with its own call sites.
+                                    let name = engine_state.get_decl(dep).name();
+                                    let Some((dep_src, dep_span)) =
+                                        render_def(engine_state, name, dep)
+                                    else {
+                                        continue;
+                                    };
+                                    // Why: a `def` nested inside another body is already printed as
+                                    // part of that body, so emitting it again just duplicates text.
+                                    if emitted.iter().any(|s| s.contains_span(dep_span)) {
+                                        continue;
+                                    }
+                                    emitted.push(dep_span);
+                                    sources.push(dep_src);
+                                }
+                            }
+
+                            Ok(make_output(
+                                engine_state,
+                                sources.join("\n\n"),
+                                Some(block_span),
+                                call.head,
+                            ))
                         } else {
                             Err(ShellError::Generic(GenericError::new(
                                 "Cannot view string value",
@@ -309,6 +369,47 @@ fn render_def(engine_state: &EngineState, name: &str, decl_id: DeclId) -> Option
     final_contents.push_str(&String::from_utf8_lossy(contents));
 
     Some((final_contents, block_span))
+}
+
+// Helper function to collect a command and every custom command it calls, transitively, in
+// breadth-first order.
+// Why: every `Expr::Call` carries a `decl_id` bound at parse time, so a command private to a module
+// is reachable here even though `find_decl` in the caller's scope cannot see it by name.
+fn decls_with_deps(engine_state: &EngineState, root: DeclId) -> Vec<DeclId> {
+    let working_set = StateWorkingSet::new(engine_state);
+    // Why: commands may call each other in a cycle, so the walk needs a visited set to stop.
+    let mut seen = HashSet::from([root]);
+    let mut order = vec![root];
+    let mut next = 0;
+
+    while next < order.len() {
+        let decl_id = order[next];
+        next += 1;
+
+        let Some(block_id) = engine_state.get_decl(decl_id).block_id() else {
+            continue;
+        };
+        // `flat_map` takes `Fn`, not `FnMut`, so the closure cannot touch the visited set — it is
+        // updated after the traversal returns.
+        let leaf = |expr: &Expression| match &expr.expr {
+            Expr::Call(call) => vec![call.decl_id],
+            _ => Vec::new(),
+        };
+        let mut called = Vec::new();
+        engine_state
+            .get_block(block_id)
+            .flat_map(&working_set, &leaf, &mut called);
+
+        for dep in called {
+            // Why: having a block is the single filter that drops builtins, keywords, known
+            // externals and plugins — none of them have a body to show.
+            if engine_state.get_decl(dep).block_id().is_some() && seen.insert(dep) {
+                order.push(dep);
+            }
+        }
+    }
+
+    order
 }
 
 // Helper function to find the file path associated with a given span, if any.

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,9 +1,10 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::{
-    Config, DeclId, PipelineMetadata, Span,
+    Config, DeclId, PipelineMetadata, Span, VarId,
     ast::{Expr, Expression, Traverse},
     shell_error::generic::GenericError,
 };
+use nuon::{ToNuonConfig, to_nuon};
 
 use std::collections::HashSet;
 use std::fmt::Write;
@@ -26,7 +27,7 @@ impl Command for ViewSource {
             .required("item", SyntaxShape::Any, "Name or block to view.")
             .switch(
                 "dependencies",
-                "Also show the source of every custom command the item calls, transitively.",
+                "Also show every custom command the item calls, transitively, and every constant those bodies read.",
                 Some('d'),
             )
             .category(Category::Debug)
@@ -41,7 +42,13 @@ the source, so `export` and attributes are lost. That holds with or without
 closure or a block id it does nothing. It follows only the calls the parser
 can see, so a closure written inside the body is followed even when it is run
 through a variable, but one that arrives as an argument is not. And a command
-built on a large module can pull in a lot of output."
+built on a large module can pull in a lot of output.
+
+A constant is rebuilt the same way, as `const <name> = <value>`, because only
+the name is recorded with a source span. So the value is the one the command
+actually reads: an expression such as `path self` shows up already resolved,
+and an explicit type annotation is lost. `$nu` and the record bound by `use
+<module>` are left out — neither is written as a `const` anywhere."
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
@@ -168,12 +175,11 @@ built on a large module can pull in a lot of output."
                             let mut sources = vec![src];
 
                             if call.has_flag(engine_state, stack, "dependencies")? {
+                                let (decls, consts) = decls_with_deps(engine_state, decl_id);
                                 let mut emitted = vec![block_span];
                                 // Why: the root is already rendered above, under the name the user
                                 // typed — which for an imported command is the qualified one.
-                                for dep in
-                                    decls_with_deps(engine_state, decl_id).into_iter().skip(1)
-                                {
+                                for dep in decls.into_iter().skip(1) {
                                     // Why: the defining name, not the name the caller imported it
                                     // under. Bodies are quoted verbatim, so a renamed header would
                                     // disagree with its own call sites.
@@ -191,6 +197,20 @@ built on a large module can pull in a lot of output."
                                     emitted.push(dep_span);
                                     sources.push(dep_src);
                                 }
+                                // Why: a `const` written inside a body is already printed with that
+                                // body, so only one declared elsewhere is worth a line of its own.
+                                // Every body is rendered by now, so `emitted` is complete.
+                                let const_sources: Vec<String> = consts
+                                    .into_iter()
+                                    .filter(|var_id| {
+                                        let span = engine_state.get_var(*var_id).declaration_span;
+                                        !emitted.iter().any(|s| s.contains_span(span))
+                                    })
+                                    .filter_map(|var_id| render_const(engine_state, var_id))
+                                    .collect();
+                                // Why: constants come first, the way a module writes them — a body
+                                // reading `$FOO` is easier to follow when `$FOO` is already read.
+                                sources.splice(0..0, const_sources);
                             }
 
                             Ok(make_output(
@@ -373,15 +393,26 @@ fn render_def(engine_state: &EngineState, name: &str, decl_id: DeclId) -> Option
     Some((final_contents, block_span))
 }
 
+// A reference found in a command body, before it is known to be worth showing.
+enum Dep {
+    Decl(DeclId),
+    Const(VarId),
+}
+
 // Helper function to collect a command and every custom command it calls, transitively, in
-// breadth-first order.
+// breadth-first order, together with every constant those bodies read.
 // Why: every `Expr::Call` carries a `decl_id` bound at parse time, so a command private to a module
-// is reachable here even though `find_decl` in the caller's scope cannot see it by name.
-fn decls_with_deps(engine_state: &EngineState, root: DeclId) -> Vec<DeclId> {
+// is reachable here even though `find_decl` in the caller's scope cannot see it by name. The same
+// holds for `Expr::Var` and a module-private constant.
+fn decls_with_deps(engine_state: &EngineState, root: DeclId) -> (Vec<DeclId>, Vec<VarId>) {
     let working_set = StateWorkingSet::new(engine_state);
     // Why: commands may call each other in a cycle, so the walk needs a visited set to stop.
     let mut seen = HashSet::from([root]);
     let mut order = vec![root];
+    // Why: a constant is a leaf — its value is already evaluated, so it cannot reach a further
+    // command or constant — and so it never joins the queue the loop below walks.
+    let mut seen_consts = HashSet::new();
+    let mut consts = Vec::new();
     let mut next = 0;
 
     while next < order.len() {
@@ -391,27 +422,72 @@ fn decls_with_deps(engine_state: &EngineState, root: DeclId) -> Vec<DeclId> {
         let Some(block_id) = engine_state.get_decl(decl_id).block_id() else {
             continue;
         };
-        // `flat_map` takes `Fn`, not `FnMut`, so the closure cannot touch the visited set — it is
-        // updated after the traversal returns.
+        // `flat_map` takes `Fn`, not `FnMut`, so the closure cannot touch the visited sets — they
+        // are updated after the traversal returns.
         let leaf = |expr: &Expression| match &expr.expr {
-            Expr::Call(call) => vec![call.decl_id],
+            Expr::Call(call) => vec![Dep::Decl(call.decl_id)],
+            Expr::Var(var_id) => vec![Dep::Const(*var_id)],
             _ => Vec::new(),
         };
-        let mut called = Vec::new();
+        let mut found = Vec::new();
         engine_state
             .get_block(block_id)
-            .flat_map(&working_set, &leaf, &mut called);
+            .flat_map(&working_set, &leaf, &mut found);
 
-        for dep in called {
-            // Why: having a block is the single filter that drops builtins, keywords, known
-            // externals and plugins — none of them have a body to show.
-            if engine_state.get_decl(dep).block_id().is_some() && seen.insert(dep) {
-                order.push(dep);
+        for dep in found {
+            match dep {
+                // Why: having a block is the single filter that drops builtins, keywords, known
+                // externals and plugins — none of them have a body to show.
+                Dep::Decl(dep) => {
+                    if engine_state.get_decl(dep).block_id().is_some() && seen.insert(dep) {
+                        order.push(dep);
+                    }
+                }
+                Dep::Const(dep) => {
+                    if engine_state.get_var(dep).const_val.is_some() && seen_consts.insert(dep) {
+                        consts.push(dep);
+                    }
+                }
             }
         }
     }
 
-    order
+    (order, consts)
+}
+
+// Helper function to render a constant as a `const` line, carrying the value the engine holds.
+// Why: only the span of the name is recorded, not the span of the whole statement, so the
+// right-hand side cannot be quoted from the source. The value is what the command actually reads,
+// which is the point of showing it — but an expression like `path self` shows up already resolved,
+// and an explicit type annotation is lost.
+fn render_const(engine_state: &EngineState, var_id: VarId) -> Option<String> {
+    let var = engine_state.get_var(var_id);
+    let value = to_nuon(
+        engine_state,
+        var.const_val.as_ref()?,
+        ToNuonConfig::default(),
+    )
+    .ok()?;
+    let name = const_name(engine_state, var_id)?;
+
+    Some(format!("const {name} = {value}"))
+}
+
+// Helper function to read the name of a variable, but only when a `const` statement is what
+// declared it.
+// Why: not every constant was written as one. `$nu` is a constant, and `use <module>` binds a
+// record of the module's exported constants under the module's own name. The name has to be read
+// from the declaration span, since that is the only name the engine keeps a source location for —
+// and for these two that span is not their name: the record carries the span of the `use` call,
+// `$nu` carries no span at all. So a constant is one worth showing exactly when the span it was
+// declared at spells the name it is bound under.
+fn const_name(engine_state: &EngineState, var_id: VarId) -> Option<String> {
+    let var = engine_state.get_var(var_id);
+    let bound = String::from_utf8_lossy(var.name.as_ref()?).to_string();
+    let declared =
+        String::from_utf8_lossy(engine_state.get_span_contents(var.declaration_span)).to_string();
+
+    (bound.trim_start_matches('$') == declared.trim_start_matches('$')).then_some(declared)
 }
 
 // Helper function to find the file path associated with a given span, if any.

--- a/crates/nu-command/tests/commands/debug/view_source.rs
+++ b/crates/nu-command/tests/commands/debug/view_source.rs
@@ -144,3 +144,83 @@ fn datasource_filepath_metadata() -> Result {
         Ok(())
     })
 }
+
+#[test]
+fn prepends_constants_the_body_reads() -> Result {
+    // Why: constants come first so a body reading `$G` is read after `$G` itself.
+    let code = "const G = 42; def caller [] { $G }; view source caller --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("const G = 42\n\ndef caller [] { $G }")
+}
+
+#[test]
+fn reaches_module_private_constants() -> Result {
+    // A private constant cannot be named to `view source` at all, same as a private command.
+    let code = r#"
+        module m4 { const P = 7; export def bar [] { $P } }
+        use m4
+        view source "m4 bar" --dependencies
+    "#;
+    test()
+        .run(code)
+        .expect_value_eq("const P = 7\n\ndef \"m4 bar\" [] { $P }")
+}
+
+#[test]
+fn skips_constants_nobody_wrote_as_one() -> Result {
+    // `$nu` is a constant holding the whole record, and printing it would bury the output. The
+    // custom dependency is here so that removing the feature fails this test instead of passing it.
+    let code = "def helper [] { 42 }; def m [] { $env.PWD; $nu.home-path; helper }; view source m --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def m [] { $env.PWD; $nu.home-path; helper }\n\ndef helper [] { 42 }")
+}
+
+#[test]
+fn skips_the_record_bound_by_use() -> Result {
+    // `use m5` binds a record of the module's exported constants under the module's own name. It is
+    // a constant, but it is declared at the span of the `use` call, not at a name of its own.
+    let code = "
+        module m5 { export const E = 1 }
+        use m5
+        def caller [] { $m5.E }
+        view source caller --dependencies
+    ";
+    test().run(code).expect_value_eq("def caller [] { $m5.E }")
+}
+
+#[test]
+fn does_not_repeat_a_constant_declared_in_the_body() -> Result {
+    // The text of `X` is already inside the printed body. `G` is here so that removing the feature
+    // fails this test instead of satisfying it.
+    let code = "const G = 1; def foo [] { const X = 2; $X + $G }; view source foo --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("const G = 1\n\ndef foo [] { const X = 2; $X + $G }")
+}
+
+#[test]
+fn skips_ordinary_variables() -> Result {
+    // Only a constant has a value to show; a parameter and a `let` binding have none until the
+    // command runs.
+    let code = "def loc [a] { let b = 2; $a + $b }; view source loc --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def loc [ a: any ] { let b = 2; $a + $b }")
+}
+
+#[test]
+fn follows_a_constant_imported_by_name() -> Result {
+    // Importing a constant by name reuses the variable the module declared, so it keeps the span of
+    // its own `const` -- unlike the record `use m6` alone would bind.
+    let code = "
+        module m6 { export const E = 5 }
+        use m6 E
+        def c [] { $E }
+        view source c --dependencies
+    ";
+    test()
+        .run(code)
+        .expect_value_eq("const E = 5\n\ndef c [] { $E }")
+}

--- a/crates/nu-command/tests/commands/debug/view_source.rs
+++ b/crates/nu-command/tests/commands/debug/view_source.rs
@@ -8,6 +8,122 @@ fn view_source_returns_string() -> Result {
 }
 
 #[test]
+fn appends_called_commands() -> Result {
+    let code = "def helper [] { 42 }; def caller [] { helper }; view source caller --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def caller [] { helper }\n\ndef helper [] { 42 }")
+}
+
+#[test]
+fn reaches_module_private_commands() -> Result {
+    // A private command cannot be named to `view source` at all, so expanding it is the whole point
+    // of the flag.
+    let code = r#"
+        module m2 { def helper [] { 42 }; export def bar [] { helper } }
+        use m2
+        view source "m2 bar" --dependencies
+    "#;
+    test()
+        .run(code)
+        .expect_value_eq("def \"m2 bar\" [] { helper }\n\ndef helper [] { 42 }")
+}
+
+#[test]
+fn without_the_flag_output_is_unchanged() -> Result {
+    let code = "def helper [] { 42 }; def caller [] { helper }; view source caller";
+    test().run(code).expect_value_eq("def caller [] { helper }")
+}
+
+#[test]
+fn skips_builtins() -> Result {
+    // Why: the custom dependency has to be there, otherwise this passes with the whole feature
+    // removed and proves nothing about builtins.
+    let code = "def helper [] { 42 }; def mixed [] { ls | sort-by name; helper }; view source mixed --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def mixed [] { ls | sort-by name; helper }\n\ndef helper [] { 42 }")
+}
+
+#[test]
+fn stops_on_mutual_recursion() -> Result {
+    let code = "def a [] { b }; def b [] { a }; view source a --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def a [] { b }\n\ndef b [] { a }")
+}
+
+#[test]
+fn finds_calls_inside_closures() -> Result {
+    let code = "def helper [] { 42 }; def caller [] { [1] | each { helper } }; view source caller --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def caller [] { [1] | each { helper } }\n\ndef helper [] { 42 }")
+}
+
+#[test]
+fn follows_an_alias_to_its_target() -> Result {
+    // The parser folds an alias call into the target's decl, so the dependency is the target.
+    let code = "def t [] { 1 }; alias al = t; def c [] { al }; view source c --dependencies";
+    test()
+        .run(code)
+        .expect_value_eq("def c [] { al }\n\ndef t [] { 1 }")
+}
+
+#[test]
+fn does_not_repeat_a_nested_def() -> Result {
+    // The text of `inner` is already inside the printed body of `outer`. `helper` is here so that
+    // removing the feature fails this test instead of satisfying it.
+    let code = "def helper [] { 42 }; def outer [] { def inner [] { 1 }; inner; helper }; view source outer --dependencies";
+    test().run(code).expect_value_eq(
+        "def outer [] { def inner [] { 1 }; inner; helper }\n\ndef helper [] { 42 }",
+    )
+}
+
+#[test]
+fn names_a_dep_the_way_its_call_site_does() -> Result {
+    // `main` is imported under the module's name, but the quoted body calls it `main`, so that is
+    // the name the header has to use.
+    let code = "
+        module m3 { export def main [] { 1 }; export def caller [] { main } }
+        use m3 *
+        view source caller --dependencies
+    ";
+    test()
+        .run(code)
+        .expect_value_eq("def caller [] { main }\n\ndef main [] { 1 }")
+}
+
+#[test]
+fn keeps_metadata_of_the_root() -> Result {
+    Playground::setup("view_source_dependencies_metadata", |dirs, sandbox| {
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
+            "mdata.nu",
+            "
+                def helper [] { 42 }
+                def foo [] { helper }
+            ",
+        )]);
+
+        // Why: assert the dependency is there too, otherwise the metadata alone would still pass
+        // with the whole feature removed.
+        let expanded: String = test()
+            .cwd(dirs.test())
+            .run("source mdata.nu; view source foo --dependencies")?;
+        assert_contains("def helper [] { 42 }", expanded);
+
+        let code = "
+            source mdata.nu
+            view source foo --dependencies | metadata | get source
+        ";
+
+        let outcome: String = test().cwd(dirs.test()).run(code)?;
+        assert_contains("mdata.nu", outcome);
+        Ok(())
+    })
+}
+
+#[test]
 fn datasource_filepath_metadata() -> Result {
     Playground::setup("cd_ds_filepath_1", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContentToBeTrimmed(


### PR DESCRIPTION
Disclosure: the code was written by an AI agent (Claude) under my direction; I can't review Rust line-by-line myself. What was verified so far: `toolkit fmt`, `toolkit clippy` (lib with `-D clippy::unwrap_used`, and tests), and the `view_source` integration tests — all on top of current `main`.

## Description

`view source <name>` shows one command. Reading a command that is built on other custom commands meant looking each one up by hand — and a command private to a module could not be looked up at all, since `find_decl` does not see it and `scope modules` does not list it. `view source "log info" --dependencies` returns all eight definitions behind it, seven of them private to `std/log`, and the five constants those bodies read.

The output is a reading aid, not a script. The `def` header is rebuilt from the signature instead of being quoted from the source, so `export`, attributes and some type spellings do not survive. That was already true without the flag.

Dependencies come from the `decl_id` the parser already binds into every `Expr::Call`, walked with `Traverse::flat_map`. No name lookup is involved, which is exactly what makes a module-private command reachable. A visited set stops mutual recursion; a decl with no block — builtin, keyword, known external, plugin — is skipped, having no source to show; and a `def` nested in a body is not repeated, since its text is already inside the parent's block.

A dependency is printed under its defining name, not the name the caller imported it under: bodies are quoted verbatim, so a renamed header would disagree with its own call sites. That surfaces on a module's `main`, and is deliberate rather than a slip:

```nushell
module m { export def main [] { 1 }; export def caller [] { main } }
use m *
view source caller --dependencies
# => def caller [] { main }
# =>
# => def main [] { 1 }
```

Constants are collected by the same walk, from `Expr::Var`, and printed before the definitions, the way a module writes them. They are leaves — a constant's value is already evaluated, so it cannot reach a further command or constant. Only the span of the *name* is recorded, not the statement, so the right-hand side is the value the engine holds, rendered as NUON: that is what the running command actually reads, which is the thing being audited. The cost is that `path self | path dirname` shows up already resolved and a type annotation is lost — the same class of loss as the rebuilt `def` header, and documented next to it.

Not every constant was written as one, and two of those would be wrong to print: `$nu`, and the record `use <module>` binds under the module's own name (its declaration span is the `use` call — printing it by span gave the literal `const use = {...}`). A constant is shown exactly when the span it was declared at spells the name it is bound under. A constant declared inside a printed body is not repeated, same as a nested `def`.

The flag applies to a custom command; on an alias, a module, a closure or a block id it does nothing. Without the flag the output is byte-identical to before.

The first commit is a pure extraction with no behaviour change: it lifts the `def` renderer out of `run` into `render_def` so the dependency loop can call it. Checking that one with `git diff --color-moved` leaves the two `feat` commits as the actual new logic.

## User-facing changes (Release notes)

Added `--dependencies` (`-d`) to `view source`. It appends the source of every custom command the target calls, transitively — including commands private to a module, which cannot be viewed any other way — and prepends every constant those bodies read, with the value the engine holds:

```nushell
module m { const LIMIT = 42; def helper [] { $LIMIT }; export def bar [] { helper } }
use m
view source "m bar" --dependencies
# => const LIMIT = 42
# =>
# => def "m bar" [] { helper }
# =>
# => def helper [] { $LIMIT }
```

## Additional notes

Design feedback welcome on the flag name and on printing a module's `main` under its defining name.

Noticed while working here, pre-existing on `main` and deliberately left alone: three of the existing `examples()` for `view source` carry `result:` strings that do not match what the command prints (`...rest:string` rendered where the example claims `...rest: string`, and a trailing space in the module example).
That is why this file still has no `test_examples` block — adding one would fail on those three and turn this into a mixed PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

