### PR TITLE
feat: forward flags correctly in run-internal dynamic dispatch

### DIFF
--- a/crates/nu-command/src/system/run_internal.rs
+++ b/crates/nu-command/src/system/run_internal.rs
@@ -48,13 +48,24 @@ impl Command for RunInternal {
             .ok_or(ShellError::CommandNotFound { span: head })?;
 
         let decl = engine_state.get_decl(decl_id);
+        let signature = decl.signature();
         // Preserve spread markers here so `%($cmd) ...$args` forwards the same argument shape the
         // target builtin would receive in a direct call.
         let rest_args: Vec<(Value, bool)> = call.rest_preserving_spreads(engine_state, stack, 1)?;
 
         // Build an IR call frame for the target builtin, preserving spread arguments.
         let mut builder = ir::Call::build(decl_id, head);
-        for (val, is_spread) in rest_args {
+
+        // Because `args` is parsed with `SyntaxShape::Any` at parse time (the target command
+        // isn't known until runtime), flag-like tokens such as `-r` or `--recursive` arrive
+        // here as plain string values instead of being resolved against the target's
+        // signature the way a normal call would resolve them. Re-classify them now, mirroring
+        // the parser's own long/short flag handling, so flags meant for the target builtin
+        // (e.g. `run-internal cp -- -r $src $dest`) are actually recognized as flags instead of
+        // being forwarded as stray positional arguments.
+        let mut end_of_flags = false;
+        let mut iter = rest_args.into_iter().peekable();
+        while let Some((val, is_spread)) = iter.next() {
             if is_spread {
                 // Skip empty spreads so builtins with no-argument defaults (e.g. `ls`
                 // listing the cwd when called with no path) are not confused by an
@@ -66,9 +77,74 @@ impl Command for RunInternal {
                         builder.add_spread(stack, head, val);
                     }
                 }
-            } else {
-                builder.add_positional(stack, head, val);
+                continue;
             }
+
+            if !end_of_flags && let Value::String { val: s, .. } = &val {
+                let span = val.span();
+
+                // A bare `--` ends flag parsing for the target command, just like it
+                // would in a normal call; everything after it is passed through as-is.
+                if s == "--" {
+                    end_of_flags = true;
+                    continue;
+                }
+
+                if let Some(long_name) = s.strip_prefix("--") {
+                    let (long_name, inline_value) = match long_name.split_once('=') {
+                        Some((n, v)) => (n, Some(v)),
+                        None => (long_name, None),
+                    };
+
+                    if let Some(flag) = signature.get_long_flag(long_name) {
+                        add_flag_to_builder(
+                            &mut builder,
+                            stack,
+                            &flag,
+                            span,
+                            inline_value.map(|v| Value::string(v, span)),
+                            &mut iter,
+                        )?;
+                        continue;
+                    }
+                } else if s.starts_with('-') && s.len() > 1 {
+                    let short_flags: Vec<char> = s[1..].chars().collect();
+                    let resolved: Option<Vec<Flag>> = short_flags
+                        .iter()
+                        .map(|c| signature.get_short_flag(*c))
+                        .collect();
+
+                    if let Some(flags) = resolved {
+                        // All characters in the batch matched a known short flag for the
+                        // target command, so treat the whole token as a short-flag batch
+                        // (e.g. `-rf`), matching how the parser treats a normal call.
+                        let last = flags.len().saturating_sub(1);
+                        for (i, flag) in flags.into_iter().enumerate() {
+                            if i == last {
+                                add_flag_to_builder(
+                                    &mut builder,
+                                    stack,
+                                    &flag,
+                                    span,
+                                    None,
+                                    &mut iter,
+                                )?;
+                            } else {
+                                // Only the last flag in a batch may take a value.
+                                builder.add_flag(
+                                    stack,
+                                    &flag.long,
+                                    flag.short.map(String::from).unwrap_or_default(),
+                                    span,
+                                );
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+
+            builder.add_positional(stack, head, val);
         }
 
         // `builder.with` is a scoped guard: it registers temporary IR argument slots,
@@ -77,4 +153,43 @@ impl Command for RunInternal {
             decl.run(engine_state, stack, engine_call, input)
         })
     }
+}
+
+/// Add a single resolved flag to the call being built. If the flag takes a value and none was
+/// supplied inline (e.g. via `--name=value`), the next non-spread rest argument is consumed as
+/// the value, mirroring how the parser pulls a long/short flag's argument from the following
+/// token.
+fn add_flag_to_builder(
+    builder: &mut ir::CallBuilder,
+    stack: &mut Stack,
+    flag: &Flag,
+    span: Span,
+    inline_value: Option<Value>,
+    iter: &mut std::iter::Peekable<std::vec::IntoIter<(Value, bool)>>,
+) -> Result<(), ShellError> {
+    let short = flag.short.map(String::from).unwrap_or_default();
+
+    if flag.arg.is_some() {
+        let value = if let Some(value) = inline_value {
+            value
+        } else {
+            match iter.peek() {
+                Some((_, false)) => {
+                    let (value, _) = iter.next().expect("peeked Some");
+                    value
+                }
+                _ => {
+                    return Err(ShellError::MissingParameter {
+                        param_name: flag.long.clone(),
+                        span,
+                    });
+                }
+            }
+        };
+        builder.add_named(stack, &flag.long, short, span, value);
+    } else {
+        builder.add_flag(stack, &flag.long, short, span);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
The problem was that `run-internal`, the internal that `run-internal` was running was not making flags meant for the running internal be recognized. Now it does.
## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

Before:
```nushell
run-internal cp -- -r '7' '8'
Error: nu::shell::io::not_found

  × Not found
   ╭─[repl_entry #4:1:20]
 1 │ run-internal cp -- -r '7' '8'
   ·                    ─┬
   ·                     ╰── Not found
   ╰────
  help: '/home/user/tmp/-r' does not exist
  ```
  After:
  ```nushell
  run-internal cp -- -r '7' '8'
  ls -D 8
┌───┬──────┬──────┬──────┬────────────────┐
│ # │ name │ type │ size │    modified    │
├───┼──────┼──────┼──────┼────────────────┤
│ 0 │ 8    │ dir  │ 14 B │ 40 seconds ago │
└───┴──────┴──────┴──────┴────────────────┘
```

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
Closes https://github.com/nushell/nushell/issues/18790.