### PR TITLE
fix(completion): stop the cache reordering the answer it stands in for

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -446,7 +446,10 @@ impl NarrowingCache {
             return Suggestions::default();
         };
 
-        let mut matcher = NuMatcher::new(search_token, options, true);
+        // Don't re-sort: the producing completer ranks a directory by its bare name and
+        // appends the separator afterwards, so sorting here would rank it `config/` and
+        // land it after `config.nu`. Filtering alone preserves the order it chose.
+        let mut matcher = NuMatcher::new(search_token, options, false);
 
         base_suggestions
             .iter()
@@ -2015,6 +2018,41 @@ mod completer_tests {
         assert!(
             next_prompt.complete("ls | c", 6).is_pending(),
             "a disabled cache must not answer a query it could have answered"
+        );
+    }
+
+    /// A cached answer stands in for the computed one, so the two must agree on order.
+    /// Re-sorting the cache put `config/` after `config.nu`, inverting every keystroke.
+    #[test]
+    fn a_narrowed_cache_answer_keeps_the_order_it_was_given() {
+        let cache = NarrowingCache::default();
+        let env = CacheEnv::of(&test_engine(), &Stack::new());
+        let span = reedline::Span::new(3, 5);
+
+        // The order file completion produces: the directory first, ranked as `config`.
+        let cached: Suggestions = ["config/", "config.nu"]
+            .iter()
+            .map(|value| Suggestion {
+                value: (*value).to_string(),
+                span,
+                ..Default::default()
+            })
+            .collect::<Vec<_>>()
+            .into();
+
+        cache.store(CompletionQuery::new("ls co", 5), env, cached);
+
+        let narrowed = cache.narrowed_fallback(
+            &CompletionQuery::new("ls con", 6),
+            env,
+            &CompletionOptions::default(),
+        );
+
+        let values: Vec<&str> = narrowed.iter().map(|s| s.value.as_str()).collect();
+        assert_eq!(
+            values,
+            ["config/", "config.nu"],
+            "the cached answer must not reorder what it stands in for"
         );
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
A cached answer stands in while the real one computes, so any disagreement between the two is visible. With a directory and a file sharing a prefix, the menu swapped their order on every keystroke before settling.

## User-facing changes (Release notes)
A cached answer stands in while the real one computes, so any disagreement between the two is visible. With a directory and a file sharing a prefix, the menu swapped their order on every keystroke before settling.
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->