### PR TITLE
fix(stor): reject a missing file in stor import instead of discarding the in-memory database

### DIFF
--- a/crates/nu-command/src/stor/import.rs
+++ b/crates/nu-command/src/stor/import.rs
@@ -47,7 +47,8 @@ impl Command for StorImport {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
-        let file_name_opt: Option<String> = call.get_flag(engine_state, stack, "file-name")?;
+        let file_name_opt: Option<Spanned<String>> =
+            call.get_flag(engine_state, stack, "file-name")?;
         let file_name = match file_name_opt {
             Some(file_name) => file_name,
             None => {
@@ -58,12 +59,25 @@ impl Command for StorImport {
             }
         };
 
+        // `Connection::restore` opens the source with `OpenFlags::default()`, which includes
+        // `SQLITE_OPEN_CREATE`, so a missing path is created as an empty database and then
+        // restored over the in-memory one, discarding its contents without reporting an
+        // error. Reject the path up front so that cannot happen.
+        let path = std::path::PathBuf::from(&file_name.item);
+        match path.try_exists() {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(IoError::new(ErrorKind::FileNotFound, file_name.span, path).into());
+            }
+            Err(err) => return Err(IoError::new(err, file_name.span, path).into()),
+        }
+
         let mut conn = get_shared_mem_conn()?;
         let db = Box::new(SQLiteDatabase::new(
             std::path::Path::new(MEMORY_DB),
             engine_state.signals().clone(),
         ));
-        db.restore_database_from_file(&mut conn, file_name)
+        db.restore_database_from_file(&mut conn, file_name.item)
             .map_err(|err| {
                 ShellError::Generic(GenericError::new_internal(
                     "Failed to open SQLite connection to the in-memory database from import",

--- a/crates/nu-command/tests/commands/stor.rs
+++ b/crates/nu-command/tests/commands/stor.rs
@@ -53,12 +53,12 @@ fn stor_import_missing_file_errors() -> Result {
 fn stor_import_missing_file_keeps_existing_data() -> Result {
     Playground::setup("stor_import_keeps_existing_data", |dirs, _| {
         let missing = dirs.test().join("missing.sqlite");
-        let code = r#"
+        let code = "
             stor create --table-name stor_import_table --columns { id: int };
             stor insert -t stor_import_table --data-record { id: 1 };
             try { stor import --file-name $env.MISSING_DB };
             stor open | query db 'select id from stor_import_table' | get 0.id
-        "#;
+        ";
 
         test()
             .env("MISSING_DB", missing.to_string_lossy().into_owned())

--- a/crates/nu-command/tests/commands/stor.rs
+++ b/crates/nu-command/tests/commands/stor.rs
@@ -34,21 +34,35 @@ fn stor_update_with_quote() -> Result {
         .expect_value_eq("This didn't work, but should now.")
 }
 
+// `stor import` hands the path to sqlite, which resolves a relative one against the process
+// working directory. The test harness does not keep that in sync with `$env.PWD`, so these
+// tests use an absolute path inside the playground rather than setting `cwd`.
 #[test]
 fn stor_import_missing_file_errors() -> Result {
-    test()
-        .run::<Value>("stor import --file-name nonexistent_stor_import.sqlite")
-        .expect_error_code_eq("nu::shell::io::file_not_found")
+    Playground::setup("stor_import_missing_file", |dirs, _| {
+        let missing = dirs.test().join("missing.sqlite");
+
+        test()
+            .env("MISSING_DB", missing.to_string_lossy().into_owned())
+            .run::<Value>("stor import --file-name $env.MISSING_DB")
+            .expect_error_code_eq("nu::shell::io::file_not_found")
+    })
 }
 
 #[test]
 fn stor_import_missing_file_keeps_existing_data() -> Result {
-    let code = r#"
-        stor create --table-name stor_import_table --columns { id: int };
-        stor insert -t stor_import_table --data-record { id: 1 };
-        try { stor import --file-name nonexistent_stor_import.sqlite };
-        stor open | query db 'select id from stor_import_table' | get 0.id
-    "#;
+    Playground::setup("stor_import_keeps_existing_data", |dirs, _| {
+        let missing = dirs.test().join("missing.sqlite");
+        let code = r#"
+            stor create --table-name stor_import_table --columns { id: int };
+            stor insert -t stor_import_table --data-record { id: 1 };
+            try { stor import --file-name $env.MISSING_DB };
+            stor open | query db 'select id from stor_import_table' | get 0.id
+        "#;
 
-    test().run(code).expect_value_eq(1i64)
+        test()
+            .env("MISSING_DB", missing.to_string_lossy().into_owned())
+            .run(code)
+            .expect_value_eq(1i64)
+    })
 }

--- a/crates/nu-command/tests/commands/stor.rs
+++ b/crates/nu-command/tests/commands/stor.rs
@@ -33,3 +33,22 @@ fn stor_update_with_quote() -> Result {
         .run(code)
         .expect_value_eq("This didn't work, but should now.")
 }
+
+#[test]
+fn stor_import_missing_file_errors() -> Result {
+    test()
+        .run::<Value>("stor import --file-name nonexistent_stor_import.sqlite")
+        .expect_error_code_eq("nu::shell::io::file_not_found")
+}
+
+#[test]
+fn stor_import_missing_file_keeps_existing_data() -> Result {
+    let code = r#"
+        stor create --table-name stor_import_table --columns { id: int };
+        stor insert -t stor_import_table --data-record { id: 1 };
+        try { stor import --file-name nonexistent_stor_import.sqlite };
+        stor open | query db 'select id from stor_import_table' | get 0.id
+    "#;
+
+    test().run(code).expect_value_eq(1i64)
+}


### PR DESCRIPTION
## Description

`stor import --file-name <path>` destroys the in-memory database when the path does not exist. It reports success, and the tables that were there are gone. Reported by @youk in https://github.com/nushell/nushell/discussions/18692.

The chain is:

- `stor import` calls `SQLiteDatabase::restore_database_from_file` in `crates/nu-command/src/database/values/sqlite.rs`, which calls rusqlite's `Connection::restore`.
- `Connection::restore` opens the source through `Connection::open`, which uses `OpenFlags::default()`. That set includes `SQLITE_OPEN_CREATE`, so a path that does not exist is created rather than rejected.
- SQLite creates the file at open time but only writes the header on the first write, and a restore never writes to its source, which is why the created file stays at 0 bytes.
- A zero length file is a valid empty database, so the backup handle is built against a legitimate source that holds no pages, copies all zero of them over `main`, and reports success. There is already a hint of this in the progress callback, which special cases `p.pagecount == 0`.

The same sequence reproduces with the `sqlite3` CLI, whose `.restore` goes through the same `sqlite3_backup` API that rusqlite wraps:

```
sqlite> CREATE TABLE t(a);
sqlite> INSERT INTO t VALUES(1),(2),(3);
sqlite> SELECT count(*) FROM t;
3
sqlite> .restore nope.db          -- nope.db does not exist
sqlite> SELECT count(*) FROM sqlite_master;
0
```

No error, exit status fine, and `nope.db` is now on disk at 0 bytes.

`Connection::restore` takes no `OpenFlags`, so `SQLITE_OPEN_READ_ONLY` cannot be requested at the call site without dropping down to `Backup::new_with_names` and reimplementing the progress reporting. Checking the path before the call is the smaller change, and it gives a better message than a sqlite error would. It follows what `source` already does for a missing file in `crates/nu-command/src/misc/source.rs`, including the `try_exists` error arm so that a path which cannot be read is reported as itself rather than as missing.

`--file-name` is now read as `Spanned<String>` so the error underlines the argument rather than the command name.

`stor export` is not affected. It goes through `conn.backup(...)`, where creating the destination file is the correct behavior, so create on open is only wrong in the import direction.

## User-facing changes (Release notes)

- Fixed an issue where `stor import --file-name` with a path that does not exist created an empty file and discarded the contents of the in-memory database without reporting an error. It now fails with a file not found error and leaves the in-memory database untouched.

## Additional notes

Two regression tests in `crates/nu-command/tests/commands/stor.rs`. Against the unpatched command they fail in exactly the two ways the bug shows up:

```
test commands::stor::stor_import_missing_file_errors ... FAILED
    kind: GotValue { got: Custom(SQLiteDatabase { path: "file:memdb1?mode=memory&cache=shared", .. }) }

test commands::stor::stor_import_missing_file_keeps_existing_data ... FAILED
    error: "Failed to query SQLite database", msg: "no such table: stor_import_table"
```

The first is the command reporting success and handing back the database it had just emptied. The second is the row, and the table it lived in, being gone. Both pass with the check in place.

The tests point at an absolute path inside a `Playground`. sqlite resolves a relative path against the process working directory, which the test harness deliberately does not keep in sync with `$env.PWD`, so a relative name would have written into the crate directory.

Out of scope here: `--file-name` is declared as `SyntaxShape::String`, so it does not get the path expansion that `save` gives its argument. Such a path still fails, it just now fails with a clear file not found error rather than a generic sqlite one.

Checked with `cargo test -p nu-command --test tests -- stor` on macOS x86_64, rustc 1.97.1.
