### PR TITLE
Don't print a stray blank line when try with catch or finally collects an external

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1839,6 +1839,24 @@ fn collect(
     if nu_experimental::PIPE_FAIL.get() && !ignore_error {
         check_exit_status_future(pipe.exit)?;
     }
+    // A child stream without captured stdout carries no data: the external already wrote
+    // its output to the inherited stdout or a redirection target. Collecting it into a
+    // value would fabricate an empty string, which prints as a stray blank line when the
+    // collected output is displayed (#18765). Wait for the child instead, so a failure
+    // still surfaces as an error, and collect to Empty like a drained stream.
+    #[cfg(feature = "os")]
+    {
+        use nu_protocol::ByteStreamSource;
+        let stdout_uncaptured = matches!(
+            &data,
+            PipelineData::ByteStream(stream, ..)
+                if matches!(stream.source(), ByteStreamSource::Child(child) if child.stdout.is_none())
+        );
+        if stdout_uncaptured {
+            data.drain()?;
+            return Ok(PipelineData::empty());
+        }
+    }
     let value = data.into_value(span)?;
     Ok(PipelineData::value(value, metadata))
 }

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -260,6 +260,58 @@ fn run_in_noninteractive_mode() {
 
 #[test]
 #[deps(NU)]
+fn try_catch_inherited_external_output_has_no_extra_blank_line() {
+    // A `try` with a `catch` or `finally` block collects the block's output to know whether
+    // it failed. When the tried external's stdout is inherited, its output already went to
+    // the terminal; collecting used to turn the data-less stream into an empty string, which
+    // printed as a stray blank line after the external's own output. The `try` must be the
+    // final statement: only the final statement's value is printed, so that is where the
+    // fabricated empty string became visible.
+    // https://github.com/nushell/nushell/issues/18765
+    for (case, script, expected) in [
+        (
+            "catch",
+            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {}",
+            "hi\n",
+        ),
+        (
+            "finally",
+            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } finally {}",
+            "hi\n",
+        ),
+        (
+            "catch and finally",
+            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {} finally {}",
+            "hi\n",
+        ),
+        // The collected stream still reports the external's failure, so `catch` runs.
+        (
+            "catch on failure",
+            "try { ^$env.TEST_NU_BIN -n -c 'exit 1' } catch { print caught }",
+            "caught\n",
+        ),
+    ] {
+        let child_output = std::process::Command::new(NU.path())
+            .args(["-n", "-c", script])
+            .env("TEST_NU_BIN", NU.path())
+            .output()
+            .expect("failed to run nu");
+
+        assert_eq!(
+            expected,
+            String::from_utf8_lossy(&child_output.stdout),
+            "unexpected stdout in the {case} case",
+        );
+        assert!(
+            child_output.stderr.is_empty(),
+            "unexpected stderr in the {case} case: {}",
+            String::from_utf8_lossy(&child_output.stderr),
+        );
+    }
+}
+
+#[test]
+#[deps(NU)]
 fn run_with_no_newline() {
     let child_output = std::process::Command::new(NU.path())
         .args(["-n", "--no-newline", "-c", "\"hello world\""])

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -258,56 +258,43 @@ fn run_in_noninteractive_mode() {
     assert!(child_output.stderr.is_empty());
 }
 
-#[test]
+// A `try` with a `catch` or `finally` block collects the block's output to know whether
+// it failed. When the tried external's stdout is inherited, its output already went to
+// the terminal; collecting used to turn the data-less stream into an empty string, which
+// printed as a stray blank line after the external's own output. The `try` must be the
+// final statement: only the final statement's value is printed, so that is where the
+// fabricated empty string became visible.
+// https://github.com/nushell/nushell/issues/18765
+#[rstest]
+#[case::catch("try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {}", "hi\n")]
+#[case::finally("try { ^$env.TEST_NU_BIN -n -c 'print hi' } finally {}", "hi\n")]
+#[case::catch_and_finally(
+    "try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {} finally {}",
+    "hi\n"
+)]
+// The collected stream still reports the external's failure, so `catch` runs.
+#[case::catch_on_failure(
+    "try { ^$env.TEST_NU_BIN -n -c 'exit 1' } catch { print caught }",
+    "caught\n"
+)]
+#[nu_test_support::test]
 #[deps(NU)]
-fn try_catch_inherited_external_output_has_no_extra_blank_line() {
-    // A `try` with a `catch` or `finally` block collects the block's output to know whether
-    // it failed. When the tried external's stdout is inherited, its output already went to
-    // the terminal; collecting used to turn the data-less stream into an empty string, which
-    // printed as a stray blank line after the external's own output. The `try` must be the
-    // final statement: only the final statement's value is printed, so that is where the
-    // fabricated empty string became visible.
-    // https://github.com/nushell/nushell/issues/18765
-    for (case, script, expected) in [
-        (
-            "catch",
-            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {}",
-            "hi\n",
-        ),
-        (
-            "finally",
-            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } finally {}",
-            "hi\n",
-        ),
-        (
-            "catch and finally",
-            "try { ^$env.TEST_NU_BIN -n -c 'print hi' } catch {} finally {}",
-            "hi\n",
-        ),
-        // The collected stream still reports the external's failure, so `catch` runs.
-        (
-            "catch on failure",
-            "try { ^$env.TEST_NU_BIN -n -c 'exit 1' } catch { print caught }",
-            "caught\n",
-        ),
-    ] {
-        let child_output = std::process::Command::new(NU.path())
-            .args(["-n", "-c", script])
-            .env("TEST_NU_BIN", NU.path())
-            .output()
-            .expect("failed to run nu");
+fn try_catch_inherited_external_output_has_no_extra_blank_line(
+    #[case] script: &str,
+    #[case] expected: &str,
+) {
+    let child_output = std::process::Command::new(NU.path())
+        .args(["-n", "-c", script])
+        .env("TEST_NU_BIN", NU.path())
+        .output()
+        .expect("failed to run nu");
 
-        assert_eq!(
-            expected,
-            String::from_utf8_lossy(&child_output.stdout),
-            "unexpected stdout in the {case} case",
-        );
-        assert!(
-            child_output.stderr.is_empty(),
-            "unexpected stderr in the {case} case: {}",
-            String::from_utf8_lossy(&child_output.stderr),
-        );
-    }
+    assert_eq!(expected, String::from_utf8_lossy(&child_output.stdout));
+    assert!(
+        child_output.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&child_output.stderr),
+    );
 }
 
 #[test]


### PR DESCRIPTION
# Description

Fixes #18765. Byte for byte, before:

```
> nu -c "try { ^nu -c 'print hi' } catch {}" | od -c
0000000   h   i  \n  \n
```

and after:

```
0000000   h   i  \n
```

Since 7f69d752, a `try` block followed by `catch` or `finally` collects the block's output first, so it can tell whether the block failed before anything starts streaming. If the tried command is an external whose stdout was not captured (it is inherited at the statement level, or redirected to a file inside the block), the output has already left the process by the time the collect runs. The collect then converted that data-less child stream into an empty string value, and printing the collected result rendered the empty string as an extra blank line.

The fix is in the shared `collect` helper in `eval_ir.rs`: when the collected data is a byte stream whose child has no captured stdout, wait for the child and produce `Empty`, which is exactly what the plain `try { }` path produces when it drains the same stream. Waiting keeps the failure semantics: a non-zero exit still becomes an error, so `catch` still runs (covered by a test).

Behavior that did not change, verified against an unpatched build:

- Value context still collects and trims the captured output: `let x = (try { ^cmd } catch {})` still gives the trimmed string.
- `$env.LAST_EXIT_CODE` was not set by the collect path before and still is not.

Credit where due: neurolag bisected the inconsistency to 7f69d752, and weirdan showed it is the collection step that differs.

# User-Facing Changes

`try { ^external } catch { }` and `try { ^external } finally { }` no longer print a stray blank line after the external's output. Collecting an uncaptured external (for example `try { ^cmd o> file } catch {}` as the value of an assignment) now produces nothing instead of an empty string.

# Tests + Formatting

Added `try_catch_inherited_external_output_has_no_extra_blank_line` in `tests/shell/mod.rs`. It spawns the real `nu` binary and compares raw stdout bytes for the `catch`, `finally`, and `catch` plus `finally` cases, plus a failing external to prove `catch` still runs. The `try` sits in final statement position on purpose: only the final statement's value is printed, so that is the position where the fabricated empty string became visible. The test fails on current main with exactly the extra `\n` and passes with this change.

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `shell::` suite 255 passed, `commands::try_::` suite 41 passed (includes the pipefail experimental tests)
- `cargo check -p nu-engine --target wasm32-unknown-unknown --no-default-features` compiles (the new block is gated on the `os` feature)

# After Submitting

## Release notes summary - What our users need to know

`try` with a `catch` or `finally` block no longer prints a stray blank line after an external command's output.
