### PR TITLE
reduce ast dependency for ir calls - phase 1

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/attr/example.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/example.rs
@@ -63,7 +63,13 @@ impl Command for AttrExample {
         let (example_content, example_span) =
             example_content_from_value(&working_set, &example_arg)?;
 
-        attr_example_record(call.head, description, example_content, example_span, result)
+        attr_example_record(
+            call.head,
+            description,
+            example_content,
+            example_span,
+            result,
+        )
     }
 
     fn run_const(
@@ -78,12 +84,14 @@ impl Command for AttrExample {
         // Const evaluation still passes an AST call; blocks are not constant-evaluable as values.
         // Read the example expression shape for block source text, or evaluate string examples.
         let call_ast = call.assert_ast_call()?;
-        let example_expr = call_ast.positional_iter().nth(1).ok_or(
-            ShellError::MissingParameter {
-                param_name: "example".into(),
-                span: call.head,
-            },
-        )?;
+        let example_expr =
+            call_ast
+                .positional_iter()
+                .nth(1)
+                .ok_or(ShellError::MissingParameter {
+                    param_name: "example".into(),
+                    span: call.head,
+                })?;
 
         let (example_content, example_span) = if let Some(block_id) = example_expr.as_block() {
             let block = working_set.get_block(block_id);
@@ -94,7 +102,13 @@ impl Command for AttrExample {
             (example_string, example_expr.span)
         };
 
-        attr_example_record(call.head, description, example_content, example_span, result)
+        attr_example_record(
+            call.head,
+            description,
+            example_content,
+            example_span,
+            result,
+        )
     }
 
     fn is_const(&self) -> bool {
@@ -118,8 +132,12 @@ fn example_content_from_value(
     example_arg: &Value,
 ) -> Result<(String, Span), ShellError> {
     match example_arg {
-        Value::String { val, internal_span, .. } => Ok((val.clone(), *internal_span)),
-        Value::Closure { val, internal_span, .. } => {
+        Value::String {
+            val, internal_span, ..
+        } => Ok((val.clone(), *internal_span)),
+        Value::Closure {
+            val, internal_span, ..
+        } => {
             let content = block_source_from_closure(working_set, val, *internal_span)?;
             Ok((content, *internal_span))
         }

--- a/crates/nu-cmd-lang/src/core_commands/attr/example.rs
+++ b/crates/nu-cmd-lang/src/core_commands/attr/example.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::Closure;
 
 #[derive(Clone)]
 pub struct AttrExample;
@@ -8,8 +9,9 @@ impl Command for AttrExample {
         "attr example"
     }
 
-    // TODO: When const closure are available, switch to using them for the `example` argument
-    // rather than a block. That should remove the need for `requires_ast_for_arguments` to be true
+    // Example blocks are accepted so their source text can be extracted for help output.
+    // Runtime uses evaluated string/closure values; const still uses the AST call for blocks
+    // (const closures are not implemented yet — see devdocs/ir_call_migration.md phase 2).
     fn signature(&self) -> Signature {
         Signature::build("attr example")
             .input_output_types(vec![(
@@ -55,25 +57,13 @@ impl Command for AttrExample {
     ) -> Result<PipelineData, ShellError> {
         let description: Spanned<String> = call.req(engine_state, stack, 0)?;
         let result: Option<Value> = call.get_flag(engine_state, stack, "result")?;
-
-        let example_string: Result<String, _> = call.req(engine_state, stack, 1);
-        let example_expr = call
-            .positional_nth(stack, 1)
-            .ok_or(ShellError::MissingParameter {
-                param_name: "example".into(),
-                span: call.head,
-            })?;
+        let example_arg: Value = call.req(engine_state, stack, 1)?;
 
         let working_set = StateWorkingSet::new(engine_state);
+        let (example_content, example_span) =
+            example_content_from_value(&working_set, &example_arg)?;
 
-        attr_example_impl(
-            example_expr,
-            example_string,
-            &working_set,
-            call,
-            description,
-            result,
-        )
+        attr_example_record(call.head, description, example_content, example_span, result)
     }
 
     fn run_const(
@@ -85,29 +75,29 @@ impl Command for AttrExample {
         let description: Spanned<String> = call.req_const(working_set, 0)?;
         let result: Option<Value> = call.get_flag_const(working_set, "result")?;
 
-        let example_string: Result<String, _> = call.req_const(working_set, 1);
-        let example_expr = call.assert_ast_call()?.positional_iter().nth(1).ok_or(
+        // Const evaluation still passes an AST call; blocks are not constant-evaluable as values.
+        // Read the example expression shape for block source text, or evaluate string examples.
+        let call_ast = call.assert_ast_call()?;
+        let example_expr = call_ast.positional_iter().nth(1).ok_or(
             ShellError::MissingParameter {
                 param_name: "example".into(),
                 span: call.head,
             },
         )?;
 
-        attr_example_impl(
-            example_expr,
-            example_string,
-            working_set,
-            call,
-            description,
-            result,
-        )
+        let (example_content, example_span) = if let Some(block_id) = example_expr.as_block() {
+            let block = working_set.get_block(block_id);
+            let span = block.span.expect("a block must have a span");
+            (block_source_string(working_set, span), example_expr.span)
+        } else {
+            let example_string: String = call.req_const(working_set, 1)?;
+            (example_string, example_expr.span)
+        };
+
+        attr_example_record(call.head, description, example_content, example_span, result)
     }
 
     fn is_const(&self) -> bool {
-        true
-    }
-
-    fn requires_ast_for_arguments(&self) -> bool {
         true
     }
 
@@ -123,36 +113,67 @@ impl Command for AttrExample {
     }
 }
 
-fn attr_example_impl(
-    example_expr: &nu_protocol::ast::Expression,
-    example_string: Result<String, ShellError>,
+fn example_content_from_value(
     working_set: &StateWorkingSet<'_>,
-    call: &Call<'_>,
+    example_arg: &Value,
+) -> Result<(String, Span), ShellError> {
+    match example_arg {
+        Value::String { val, internal_span, .. } => Ok((val.clone(), *internal_span)),
+        Value::Closure { val, internal_span, .. } => {
+            let content = block_source_from_closure(working_set, val, *internal_span)?;
+            Ok((content, *internal_span))
+        }
+        other => Err(ShellError::CantConvert {
+            to_type: "string or block".into(),
+            from_type: other.get_type().to_string(),
+            span: other.span(),
+            help: None,
+        }),
+    }
+}
+
+fn block_source_from_closure(
+    working_set: &StateWorkingSet<'_>,
+    closure: &Closure,
+    span: Span,
+) -> Result<String, ShellError> {
+    let block = working_set.get_block(closure.block_id);
+    let block_span = block.span.ok_or_else(|| ShellError::CantConvert {
+        to_type: "string".into(),
+        from_type: "closure".into(),
+        span,
+        help: Some(format!(
+            "unable to retrieve block contents for closure with id {}",
+            closure.block_id.get()
+        )),
+    })?;
+    Ok(block_source_string(working_set, block_span))
+}
+
+fn block_source_string(working_set: &StateWorkingSet<'_>, span: Span) -> String {
+    let contents = working_set.get_span_contents(span);
+    let contents = contents
+        .strip_prefix(b"{")
+        .and_then(|x| x.strip_suffix(b"}"))
+        .unwrap_or(contents)
+        .trim_ascii();
+    String::from_utf8_lossy(contents).into_owned()
+}
+
+fn attr_example_record(
+    head: Span,
     description: Spanned<String>,
+    example_content: String,
+    example_span: Span,
     result: Option<Value>,
 ) -> Result<PipelineData, ShellError> {
-    let example_content = match example_expr.as_block() {
-        Some(block_id) => {
-            let block = working_set.get_block(block_id);
-            let contents =
-                working_set.get_span_contents(block.span.expect("a block must have a span"));
-            let contents = contents
-                .strip_prefix(b"{")
-                .and_then(|x| x.strip_suffix(b"}"))
-                .unwrap_or(contents)
-                .trim_ascii();
-            String::from_utf8_lossy(contents).into_owned()
-        }
-        None => example_string?,
-    };
-
     let mut rec = record! {
         "description" => Value::string(description.item, description.span),
-        "example" => Value::string(example_content, example_expr.span),
+        "example" => Value::string(example_content, example_span),
     };
     if let Some(result) = result {
         rec.push("result", result);
     }
 
-    Ok(Value::record(rec, call.head).into_pipeline_data())
+    Ok(Value::record(rec, head).into_pipeline_data())
 }

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -1,9 +1,6 @@
 use super::util::{build_metadata_record, extend_record_with_metadata};
 use nu_engine::command_prelude::*;
-use nu_protocol::{
-    PipelineMetadata,
-    ast::{Expr, Expression},
-};
+use nu_protocol::PipelineMetadata;
 
 #[derive(Clone)]
 pub struct Metadata;
@@ -29,11 +26,6 @@ impl Command for Metadata {
             .category(Category::Debug)
     }
 
-    // Needed so IR retains the argument Expression for var/cell-path origin lookup.
-    fn requires_ast_for_arguments(&self) -> bool {
-        true
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,
@@ -41,61 +33,24 @@ impl Command for Metadata {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let arg = call.positional_nth(stack, 0);
         let head = call.head;
+        let arg: Option<Value> = call.opt(engine_state, stack, 0)?;
 
         if !matches!(input, PipelineData::Empty)
-            && let Some(arg_expr) = arg
+            && let Some(ref arg_val) = arg
         {
             return Err(ShellError::IncompatibleParameters {
                 left_message: "pipeline input was provided".into(),
                 left_span: head,
                 right_message: "but a positional metadata expression was also given".into(),
-                right_span: arg_expr.span,
+                right_span: arg_val.span(),
             });
         }
 
         match arg {
-            Some(Expression {
-                expr: Expr::FullCellPath(full_cell_path),
-                span,
-                ..
-            }) => {
-                if full_cell_path.tail.is_empty() {
-                    match &full_cell_path.head {
-                        Expression {
-                            expr: Expr::Var(var_id),
-                            ..
-                        } => {
-                            let origin = stack.get_var_with_origin(*var_id, *span)?;
-                            Ok(
-                                build_metadata_record_value(&origin, input.metadata_ref(), head)
-                                    .into_pipeline_data(),
-                            )
-                        }
-                        _ => {
-                            let val: Value = call.req(engine_state, stack, 0)?;
-                            Ok(
-                                build_metadata_record_value(&val, input.metadata_ref(), head)
-                                    .into_pipeline_data(),
-                            )
-                        }
-                    }
-                } else {
-                    let val: Value = call.req(engine_state, stack, 0)?;
-                    Ok(
-                        build_metadata_record_value(&val, input.metadata_ref(), head)
-                            .into_pipeline_data(),
-                    )
-                }
-            }
-            Some(_) => {
-                let val: Value = call.req(engine_state, stack, 0)?;
-                Ok(
-                    build_metadata_record_value(&val, input.metadata_ref(), head)
-                        .into_pipeline_data(),
-                )
-            }
+            Some(val) => Ok(
+                build_metadata_record_value(&val, input.metadata_ref(), head).into_pipeline_data(),
+            ),
             None => {
                 Ok(Value::record(build_metadata_record(&input, head), head).into_pipeline_data())
             }

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -34,7 +34,15 @@ impl Command for Metadata {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let arg: Option<Value> = call.opt(engine_state, stack, 0)?;
+        // Do not use `call.opt`: it filters out `Value::Nothing`, so `metadata $null` (and
+        // optional/rest bindings that are nothing) would be treated as "no positional" and
+        // return pipeline metadata without a `span` field. Callers like `assert equal $x null`
+        // always evaluate `(metadata $right).span` when building error labels.
+        let arg = if call.has_positional_args(stack, 0) {
+            Some(call.req::<Value>(engine_state, stack, 0)?)
+        } else {
+            None
+        };
 
         if !matches!(input, PipelineData::Empty)
             && let Some(ref arg_val) = arg

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -1,5 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block, redirect_env};
-use nu_protocol::engine::CommandType;
+use nu_protocol::engine::{Closure, CommandType};
 
 #[derive(Clone)]
 pub struct ExportEnv;
@@ -33,11 +33,6 @@ impl Command for ExportEnv {
         CommandType::Keyword
     }
 
-    // Needed so IR retains the block Expression for `as_block()`.
-    fn requires_ast_for_arguments(&self) -> bool {
-        true
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,
@@ -45,13 +40,9 @@ impl Command for ExportEnv {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let block_id = call
-            .positional_nth(caller_stack, 0)
-            .expect("checked through parser")
-            .as_block()
-            .expect("internal error: missing block");
-
-        let block = engine_state.get_block(block_id);
+        // Blocks compile to closure values under IR; use the block id from the evaluated arg.
+        let closure: Closure = call.req(engine_state, caller_stack, 0)?;
+        let block = engine_state.get_block(closure.block_id);
         let mut callee_stack = caller_stack
             .gather_captures(engine_state, &block.captures)
             .reset_pipes();

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -1,11 +1,7 @@
 use std::{borrow::Cow, ops::Deref};
 
 use nu_engine::{ClosureEval, command_prelude::*};
-use nu_protocol::{
-    ListStream, ReportMode, ShellWarning, Signals,
-    ast::{Expr, Expression},
-    report_shell_warning,
-};
+use nu_protocol::{ListStream, ReportMode, ShellWarning, Signals, report_shell_warning};
 
 #[derive(Clone)]
 pub struct Default;
@@ -38,11 +34,6 @@ impl Command for Default {
             .category(Category::Filters)
     }
 
-    // FIXME remove once deprecation warning is no longer needed
-    fn requires_ast_for_arguments(&self) -> bool {
-        true
-    }
-
     fn description(&self) -> &str {
         "Sets a default value if a row's column is missing or null."
     }
@@ -58,10 +49,7 @@ impl Command for Default {
         let columns: Vec<String> = call.rest(engine_state, stack, 1)?;
         let empty = call.has_flag(engine_state, stack, "empty")?;
 
-        // FIXME for deprecation of closure passed via variable
-        let default_value_expr = call.positional_nth(stack, 0);
-        let default_value =
-            DefaultValue::new(engine_state, stack, default_value, default_value_expr);
+        let default_value = DefaultValue::new(engine_state, stack, default_value);
 
         default(
             engine_state,
@@ -249,16 +237,13 @@ enum DefaultValue {
 }
 
 impl DefaultValue {
-    fn new(
-        engine_state: &EngineState,
-        stack: &Stack,
-        value: Value,
-        expr: Option<&Expression>,
-    ) -> Self {
+    fn new(engine_state: &EngineState, stack: &Stack, value: Value) -> Self {
         let span = value.span();
 
-        // FIXME temporary workaround to warn people of breaking change from #15654
-        let value = match closure_variable_warning(stack, engine_state, value, expr) {
+        // FIXME temporary workaround to warn people of breaking change from #15654.
+        // Detects closures passed via `$var` by checking whether the value span's source starts
+        // with `$` (no AST required under IR).
+        let value = match closure_variable_warning(stack, engine_state, value) {
             Ok(val) => val,
             Err(default_value) => return default_value,
         };
@@ -321,50 +306,41 @@ fn closure_variable_warning(
     stack: &Stack,
     engine_state: &EngineState,
     value: Value,
-    value_expr: Option<&Expression>,
 ) -> Result<Value, DefaultValue> {
-    // only warn if we are passed a closure inside a variable
-    let from_variable = matches!(
-        value_expr,
-        Some(Expression {
-            expr: Expr::FullCellPath(_),
-            ..
-        })
-    );
-
     let span = value.span();
-    match (&value, from_variable) {
-        // this is a closure from inside a variable
-        (Value::Closure { .. }, true) => {
-            let span_contents = String::from_utf8_lossy(engine_state.get_span_contents(span));
-            let carapace_suggestion = "re-run carapace init with version v1.3.3 or later\nor, change this to `{ $carapace_completer }`";
-            let label = match span_contents {
-                Cow::Borrowed("$carapace_completer") => carapace_suggestion.to_string(),
-                Cow::Owned(s) if s.deref() == "$carapace_completer" => {
-                    carapace_suggestion.to_string()
-                }
-                _ => format!("change this to {{ {span_contents} }}").to_string(),
-            };
+    // Closures passed as `$var` keep a use-site span whose source starts with `$`.
+    // Closure literals use the block span (starts with `{`).
+    let from_variable = matches!(value, Value::Closure { .. })
+        && engine_state.get_span_contents(span).starts_with(b"$");
 
-            report_shell_warning(
-                Some(stack),
-                engine_state,
-                &ShellWarning::Deprecated {
-                    dep_type: "Behavior".to_string(),
-                    label,
-                    span,
-                    help: Some(
-                        "Since 0.105.0, closure literals passed to default are lazily evaluated, rather than returned as a value.
+    if from_variable {
+        let span_contents = String::from_utf8_lossy(engine_state.get_span_contents(span));
+        let carapace_suggestion = "re-run carapace init with version v1.3.3 or later\nor, change this to `{ $carapace_completer }`";
+        let label = match span_contents {
+            Cow::Borrowed("$carapace_completer") => carapace_suggestion.to_string(),
+            Cow::Owned(s) if s.deref() == "$carapace_completer" => carapace_suggestion.to_string(),
+            _ => format!("change this to {{ {span_contents} }}").to_string(),
+        };
+
+        report_shell_warning(
+            Some(stack),
+            engine_state,
+            &ShellWarning::Deprecated {
+                dep_type: "Behavior".to_string(),
+                label,
+                span,
+                help: Some(
+                    "Since 0.105.0, closure literals passed to default are lazily evaluated, rather than returned as a value.
 In a future release, closures passed by variable will also be lazily evaluated.".to_string(),
-                    ),
-                    report_mode: ReportMode::FirstUse,
-                },
-            );
+                ),
+                report_mode: ReportMode::FirstUse,
+            },
+        );
 
-            // bypass the normal DefaultValue::new logic
-            Err(DefaultValue::Calculated(value))
-        }
-        _ => Ok(value),
+        // bypass the normal DefaultValue::new logic
+        Err(DefaultValue::Calculated(value))
+    } else {
+        Ok(value)
     }
 }
 

--- a/crates/nu-command/tests/requires_ast_for_arguments.rs
+++ b/crates/nu-command/tests/requires_ast_for_arguments.rs
@@ -1,16 +1,24 @@
-//! Inventory guard for commands that still opt into IR argument AST retention.
+//! Regression guard for `Command::requires_ast_for_arguments`.
 //!
-//! New entries must be deliberate — see `devdocs/ir_call_migration.md`.
-//! Prefer redesigning the command so it does not need `requires_ast_for_arguments`.
+//! When true, the IR compiler retains full argument AST nodes (`IrAstRef`) for that
+//! decl — expensive and an obstacle to IR-only calls. After migration phases 0–1, no
+//! builtin should opt in.
+//!
+//! This test walks all decls and asserts the set of opt-ins equals
+//! [`ALLOWED_REQUIRES_AST_FOR_ARGUMENTS`]. That list is **empty on purpose**: it locks
+//! in “zero opt-ins.” If someone adds `requires_ast_for_arguments => true` without
+//! updating the allowlist, CI fails. Prefer redesigning the command instead of
+//! re-adding an entry; see `devdocs/ir_call_migration.md`.
 
 use nu_protocol::engine::EngineState;
 use std::collections::BTreeSet;
 
-/// Commands that are still allowed to require AST argument nodes under IR evaluation.
+/// Expected names of decls that may still set `requires_ast_for_arguments` to true.
 ///
-/// Update this list only when adding or removing a deliberate opt-in.
-const ALLOWED_REQUIRES_AST_FOR_ARGUMENTS: &[&str] =
-    &["attr example", "default", "export-env", "metadata"];
+/// Empty after phase 1 — not dead code. An empty allowlist means we expect *none* and
+/// will fail if any appear. Only add a name for a deliberate, temporary exception
+/// (and document it in `devdocs/ir_call_migration.md`).
+const ALLOWED_REQUIRES_AST_FOR_ARGUMENTS: &[&str] = &[];
 
 fn engine_state_with_commands() -> EngineState {
     let engine_state = nu_cmd_lang::create_default_context();

--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -212,7 +212,11 @@ impl BlockBuilder {
             Instruction::Drop { src } => allocate(&[*src], &[]),
             Instruction::Drain { src } => allocate(&[*src], &[]),
             Instruction::DrainIfEnd { src } => allocate(&[*src], &[]),
-            Instruction::LoadVariable { dst, var_id: _ } => allocate(&[], &[*dst]),
+            Instruction::LoadVariable {
+                dst,
+                var_id: _,
+                preserve_origin: _,
+            } => allocate(&[], &[*dst]),
             Instruction::StoreVariable { var_id: _, src } => allocate(&[*src], &[*src]),
             Instruction::DropVariable { var_id: _ } => Ok(()),
             Instruction::LoadEnv { dst, key: _ } => allocate(&[], &[*dst]),

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -243,9 +243,7 @@ pub(crate) fn compile_call(
                 let arg_reg = builder.next_register()?;
 
                 // Bare variables for `metadata` load with origin span preserved.
-                if preserve_var_origin
-                    && let Some(var_id) = bare_var_id(expr)
-                {
+                if preserve_var_origin && let Some(var_id) = bare_var_id(expr) {
                     builder.push(
                         Instruction::LoadVariable {
                             dst: arg_reg,

--- a/crates/nu-engine/src/compile/call.rs
+++ b/crates/nu-engine/src/compile/call.rs
@@ -219,6 +219,8 @@ pub(crate) fn compile_call(
 
     // Keep AST if the decl needs it.
     let requires_ast = decl.requires_ast_for_arguments();
+    // `metadata $var` needs the variable's definition span, not the use-site span.
+    let preserve_var_origin = decl.name() == "metadata";
 
     // It's important that we evaluate the args first before trying to set up the argument
     // state for the call.
@@ -239,6 +241,21 @@ pub(crate) fn compile_call(
             .expr()
             .map(|expr| {
                 let arg_reg = builder.next_register()?;
+
+                // Bare variables for `metadata` load with origin span preserved.
+                if preserve_var_origin
+                    && let Some(var_id) = bare_var_id(expr)
+                {
+                    builder.push(
+                        Instruction::LoadVariable {
+                            dst: arg_reg,
+                            var_id,
+                            preserve_origin: true,
+                        }
+                        .into_spanned(expr.span),
+                    )?;
+                    return Ok(arg_reg);
+                }
 
                 compile_expression(
                     working_set,
@@ -448,6 +465,18 @@ pub(crate) fn compile_external_call(
     )
 }
 
+/// Extract a bare variable id from `$var` or a FullCellPath with empty tail.
+fn bare_var_id(expr: &Expression) -> Option<nu_protocol::VarId> {
+    match &expr.expr {
+        Expr::Var(var_id) => Some(*var_id),
+        Expr::FullCellPath(cell_path) if cell_path.tail.is_empty() => match &cell_path.head.expr {
+            Expr::Var(var_id) => Some(*var_id),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 pub(crate) fn compile_unlet(
     _working_set: &StateWorkingSet,
     builder: &mut BlockBuilder,
@@ -461,24 +490,9 @@ pub(crate) fn compile_unlet(
     for arg in call.positional_iter() {
         iter_empty = false;
 
-        // Extract variable ID from the expression
         // Handle both direct variable references (Expr::Var) and full cell paths (Expr::FullCellPath)
         // that represent simple variables (e.g., $var parsed as FullCellPath with empty tail).
-        // This allows unlet to work with variables parsed in different contexts.
-        let var_id = match &arg.expr {
-            nu_protocol::ast::Expr::Var(var_id) => Some(*var_id),
-            nu_protocol::ast::Expr::FullCellPath(cell_path) => {
-                if cell_path.tail.is_empty() {
-                    match &cell_path.head.expr {
-                        nu_protocol::ast::Expr::Var(var_id) => Some(*var_id),
-                        _ => None,
-                    }
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        };
+        let var_id = bare_var_id(arg);
 
         match var_id {
             Some(var_id) => {

--- a/crates/nu-engine/src/compile/expression.rs
+++ b/crates/nu-engine/src/compile/expression.rs
@@ -146,6 +146,7 @@ pub(crate) fn compile_expression(
                     Instruction::LoadVariable {
                         dst: out_reg,
                         var_id: IN_VARIABLE_ID,
+                        preserve_origin: false,
                     }
                     .into_spanned(expr.span),
                 )?;
@@ -155,6 +156,7 @@ pub(crate) fn compile_expression(
                     Instruction::LoadVariable {
                         dst: out_reg,
                         var_id: *var_id,
+                        preserve_origin: false,
                     }
                     .into_spanned(expr.span),
                 )?;

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -413,6 +413,7 @@ pub(crate) fn compile_let(
             Instruction::LoadVariable {
                 dst: io_reg,
                 var_id,
+                preserve_origin: false,
             }
             .into_spanned(call.head),
         )?;

--- a/crates/nu-engine/src/compile/operator.rs
+++ b/crates/nu-engine/src/compile/operator.rs
@@ -419,6 +419,7 @@ pub(crate) fn compile_load_env(
             Instruction::LoadVariable {
                 dst: out_reg,
                 var_id: ENV_VARIABLE_ID,
+                preserve_origin: false,
             }
             .into_spanned(span),
         )?,

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1588,7 +1588,9 @@ fn gather_arguments(
                     }
                     callee_stack.add_var(var_id, val);
                 } else {
-                    rest_span = Some(rest_span.map_or(val.span(), |s| s.append(val.span())));
+                    // Use the argument's call-site span (not val.span()) so rest spans stay in
+                    // source order. Values may keep definition/origin spans (e.g. metadata).
+                    rest_span = Some(rest_span.map_or(span, |s| s.append(span)));
                     let val = if expand_glob_args {
                         expand_external_glob_arg(val)
                     } else {

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -533,12 +533,29 @@ fn eval_instruction<D: DebugContext>(
             ctx.put_reg(*src, PipelineExecutionData::from(res));
             Ok(Continue)
         }
-        Instruction::LoadVariable { dst, var_id } => {
+        Instruction::LoadVariable {
+            dst,
+            var_id,
+            preserve_origin,
+        } => {
             // Restore pipeline metadata for `$ans` (e.g. ls path_columns / colors on `.last`).
             // Truncation warning is deferred until after print so data is visible first.
             let data = if *var_id == nu_protocol::LAST_VARIABLE_ID {
                 ctx.stack.defer_last_result_truncation_warning();
                 ctx.stack.last_result_pipeline_data(*span)
+            } else if *preserve_origin {
+                // Keep definition span (e.g. `metadata $x`).
+                let value = ctx
+                    .stack
+                    .get_var_with_origin(*var_id, *span)
+                    .or_else(|err| {
+                        if let Some(const_val) = ctx.engine_state.get_constant(*var_id).cloned() {
+                            Ok(const_val)
+                        } else {
+                            Err(err)
+                        }
+                    })?;
+                value.into_pipeline_data()
             } else {
                 let value = get_var(ctx, *var_id, *span)?;
                 value.into_pipeline_data()
@@ -616,7 +633,9 @@ fn eval_instruction<D: DebugContext>(
             }
         }
         Instruction::PushPositional { src } => {
-            let val = ctx.collect_reg(*src, *span)?.with_span(*span);
+            // Keep the value's own span (e.g. definition span from load-variable-origin for
+            // `metadata $var`). Argument::span still records where the arg appears in the call.
+            let val = ctx.collect_reg(*src, *span)?;
             ctx.stack.arguments.push(Argument::Positional {
                 span: *span,
                 val,
@@ -625,7 +644,7 @@ fn eval_instruction<D: DebugContext>(
             Ok(Continue)
         }
         Instruction::AppendRest { src } => {
-            let vals = ctx.collect_reg(*src, *span)?.with_span(*span);
+            let vals = ctx.collect_reg(*src, *span)?;
             ctx.stack.arguments.push(Argument::Spread {
                 span: *span,
                 vals,

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -98,9 +98,21 @@ impl fmt::Display for FmtInstruction<'_> {
             Instruction::DrainIfEnd { src } => {
                 write!(f, "{:WIDTH$} {src}", "drain-if-end")
             }
-            Instruction::LoadVariable { dst, var_id } => {
+            Instruction::LoadVariable {
+                dst,
+                var_id,
+                preserve_origin,
+            } => {
                 let var = FmtVar::new(self.engine_state, *var_id);
-                write!(f, "{:WIDTH$} {dst}, {var}", "load-variable")
+                if *preserve_origin {
+                    write!(
+                        f,
+                        "{:WIDTH$} {dst}, {var}",
+                        "load-variable-origin"
+                    )
+                } else {
+                    write!(f, "{:WIDTH$} {dst}, {var}", "load-variable")
+                }
             }
             Instruction::StoreVariable { var_id, src } => {
                 let var = FmtVar::new(self.engine_state, *var_id);

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -105,11 +105,7 @@ impl fmt::Display for FmtInstruction<'_> {
             } => {
                 let var = FmtVar::new(self.engine_state, *var_id);
                 if *preserve_origin {
-                    write!(
-                        f,
-                        "{:WIDTH$} {dst}, {var}",
-                        "load-variable-origin"
-                    )
+                    write!(f, "{:WIDTH$} {dst}, {var}", "load-variable-origin")
                 } else {
                     write!(f, "{:WIDTH$} {dst}, {var}", "load-variable")
                 }

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -155,8 +155,17 @@ pub enum Instruction {
     /// Drain the value/stream in a register and discard only if this is the last pipeline element.
     // TODO: see if it's possible to remove this
     DrainIfEnd { src: RegId },
-    /// Load the value of a variable into the `dst` register
-    LoadVariable { dst: RegId, var_id: VarId },
+    /// Load the value of a variable into the `dst` register.
+    ///
+    /// When `preserve_origin` is false (the default), the value is re-spanned to this
+    /// instruction's span so error labels point at the use site. When true, the value keeps
+    /// the span from where it was defined (used by `metadata $var`).
+    LoadVariable {
+        dst: RegId,
+        var_id: VarId,
+        #[serde(default)]
+        preserve_origin: bool,
+    },
     /// Store the value of a variable from the `src` register
     StoreVariable { var_id: VarId, src: RegId },
     /// Remove a variable from the stack, freeing up whatever resources were associated with it


### PR DESCRIPTION
## Description

Runtime block evaluation has been IR-only for a long time (`eval_block` → `eval_ir_block`). Some commands still forced the IR compiler to retain full argument **AST** nodes via `Command::requires_ast_for_arguments()`, which is expensive and blocks collapsing the dual `engine::Call` / `CallImpl::{Ast*, Ir*}` surface.

This PR finishes **phases 0 and 1** of the IR-only **call** migration:

- Removes every remaining `requires_ast_for_arguments` override.
- Adds a regression inventory test so new opt-ins are deliberate.
- Redesigns the last AST-arg consumers so they work from evaluated values / IR special cases.

Parser AST is **not** removed. It remains the compile-time intermediate (parse → AST → IR → VM). The goal is IR-only **command invocation**, not “delete the AST.”

Several commands still opted into `requires_ast_for_arguments`, forcing the compiler to retain full argument AST nodes under IR. This PR removes all of those opt-ins (phases 0–1):

- **Phase 0:** drop unused `timeit` flag; treat `unlet` as IR-only (`compile_unlet` + stubbed `run`); add inventory test; document the plan.
- **Phase 1:** redesign remaining consumers:
  - `export-env` — evaluated `Closure` / block id
  - `metadata` — value-only run + `LoadVariable { preserve_origin }` for bare vars; stop re-stamping spans on `PushPositional` / `AppendRest`
  - `default` — deprecation warning via span source starting with `$`
  - `attr example` — runtime without AST; const still uses AST call for block source until phase 2 (const closures / IR-shaped `run_const`)

## User-facing changes (Release notes)

- None expected for normal scripts.
- Internal: IR `load-variable` may show as `load-variable-origin` when preserving definition spans for `metadata $var`.
- `default $closure_var` deprecation detection is span-based rather than AST-based (same intended warning for typical `$var` usage).

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->