### PR TITLE
Show deprecation entries in `scope commands` output

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -174,6 +174,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             if self.visibility.is_decl_id_visible(decl_id)
                 && !self.engine_state.get_decl(*decl_id).is_alias()
             {
+                let command_name = String::from_utf8_lossy(command_name);
                 let decl = self.engine_state.get_decl(*decl_id);
                 let signature = decl.signature();
 
@@ -206,8 +207,22 @@ impl<'e, 's> ScopeData<'e, 's> {
                     })
                     .collect();
 
+                let deprecations = decl
+                    .deprecation_info()
+                    .into_iter()
+                    .map(|entry| {
+                        Value::record(
+                            record! {
+                                "type" => Value::string(entry.type_name(), span),
+                                "label" => Value::string(entry.label(&command_name), span)
+                            },
+                            span,
+                        )
+                    })
+                    .collect();
+
                 let record = record! {
-                    "name" => Value::string(String::from_utf8_lossy(command_name), span),
+                    "name" => Value::string(command_name, span),
                     "category" => Value::string(signature.category.to_string(), span),
                     "signatures" => self.collect_signatures(&signature, span),
                     "description" => Value::string(decl.description(), span),
@@ -224,6 +239,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                         Some(CommandWideCompleter::External) => Value::string("external", span),
                         None => Value::nothing(span),
                     },
+                    "deprecation_info" => Value::list(deprecations, span),
                     "decl_id" => Value::int(decl_id.get() as i64, span),
                 };
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -210,15 +210,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 let deprecations = decl
                     .deprecation_info()
                     .into_iter()
-                    .map(|entry| {
-                        Value::record(
-                            record! {
-                                "type" => Value::string(entry.type_name(), span),
-                                "label" => Value::string(entry.label(&command_name), span)
-                            },
-                            span,
-                        )
-                    })
+                    .map(|entry| entry.into_value(&command_name, span))
                     .collect();
 
                 let record = record! {

--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -1,4 +1,4 @@
-use crate::{FromValue, ParseWarning, ShellError, Type, Value, ast::Call};
+use crate::{FromValue, IntoValue, ParseWarning, ShellError, Type, Value, ast::Call, record};
 
 // Make nu_protocol available in this namespace, consumers of this crate will
 // have this without such an export.
@@ -100,14 +100,14 @@ impl DeprecationEntry {
         }
     }
 
-    pub fn type_name(&self) -> String {
+    fn type_name(&self) -> String {
         match &self.ty {
             DeprecationType::Command => "Command".to_string(),
             DeprecationType::Flag(_) => "Flag".to_string(),
         }
     }
 
-    pub fn label(&self, command_name: &str) -> String {
+    fn label(&self, command_name: &str) -> String {
         let name = match &self.ty {
             DeprecationType::Command => command_name,
             DeprecationType::Flag(flag) => &format!("{command_name} --{flag}"),
@@ -149,5 +149,22 @@ impl DeprecationEntry {
             report_mode,
             help: self.help,
         })
+    }
+
+    // We don't implement the trait here because we need to pass a command_name to generate the label.
+    pub fn into_value(self, command_name: &str, span: Span) -> Value {
+        let record = record! {
+            "type" => self.type_name().into_value(span),
+            "label" => self.label(command_name).into_value(span),
+            "flag" => match self.ty {
+                DeprecationType::Command => None,
+                DeprecationType::Flag(flag) => Some(flag),
+            }.into_value(span),
+            "since" => self.since.into_value(span),
+            "expected_removal" => self.expected_removal.into_value(span),
+            "help" => self.help.into_value(span),
+        };
+
+        Value::record(record, span)
     }
 }

--- a/crates/nu-protocol/src/deprecation.rs
+++ b/crates/nu-protocol/src/deprecation.rs
@@ -100,14 +100,14 @@ impl DeprecationEntry {
         }
     }
 
-    fn type_name(&self) -> String {
+    pub fn type_name(&self) -> String {
         match &self.ty {
             DeprecationType::Command => "Command".to_string(),
             DeprecationType::Flag(_) => "Flag".to_string(),
         }
     }
 
-    fn label(&self, command_name: &str) -> String {
+    pub fn label(&self, command_name: &str) -> String {
         let name = match &self.ty {
             DeprecationType::Command => command_name,
             DeprecationType::Flag(flag) => &format!("{command_name} --{flag}"),

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -550,3 +550,35 @@ fn scope_aliases_shows_local_alias_in_if_block() -> Result {
 
     test().run(code).expect_value_eq(1)
 }
+
+#[test]
+fn scope_commands_shows_deprecated_command() -> Result {
+    let code = "
+        if true {
+            @deprecated --since '0.114.2'
+            def depr [] {}
+            scope commands | where name == 'depr' | get 0?.deprecation_info.type?
+        }
+    ";
+
+    test().run(code).expect_value_eq(["Command"])
+}
+
+#[test]
+fn scope_commands_shows_deprecated_flags() -> Result {
+    let code = "
+        if true {
+            @deprecated --flag foo
+            @deprecated --flag bar
+            def depr [--foo, --bar, --baz] {}
+
+            scope commands
+            | where name == 'depr'
+            | get 0?.deprecation_info
+            | each {|entry|
+                $entry.type == 'Flag' and $entry.label starts-with 'depr --'
+            }
+        }
+    ";
+    test().run(code).expect_value_eq([true, true])
+}

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -576,7 +576,7 @@ fn scope_commands_shows_deprecated_flags() -> Result {
             | where name == 'depr'
             | get 0?.deprecation_info
             | each {|entry|
-                $entry.type == 'Flag' and $entry.label starts-with 'depr --'
+                $entry.type == 'Flag' and $entry.flag != null
             }
         }
     ";


### PR DESCRIPTION
## Description

This PR adds a `deprecation_info` column to the output of `scope commands`, which is a list of all `DeprecationEntry`s taken from that command's signature.

## User-facing changes (Release notes)

### Added deprecation metadata to `scope commands`

You can now programmatically access information about deprecated flags and commands using `scope commands`.

```nu
> scope commands | where name == "str downcase" | first | get deprecation_info.0
╭────────────────────┬──────────────────────────────────────────────────────────────────────────────────╮
│ type               │ Command                                                                          │
│ label              │ str downcase was deprecated in 0.114.0 and will be removed in a future release.  │
│ flag               │                                                                                  │
│ since              │ 0.114.0                                                                          │
│ expected_removal   │                                                                                  │
│ help               │ Use `str lowercase` instead.                                                     │
╰────────────────────┴──────────────────────────────────────────────────────────────────────────────────╯
```

## Additional notes

~~Not sure if this is the best format, or if the separate DeprecationEntry fields like `since`, etc. should be used instead of (or alongside of?) the final built label. Would be happy to change that.~~

Edit: Decided to add the additional fields.
