### PR TITLE
Bump devicons to 0.6.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "devicons"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e47e2f330cf4fdd5a958dcef921b9523ffc21ab6713aa5e77ba2cce03904b"
+checksum = "777b2f88eb5418ba48f117570ecd0320404da0bdc39c66edf23d4d23550354b7"
 dependencies = [
  "lazy_static",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ csv = "1.4"
 ctrlc = "3.5"
 derive_more = "2.1.1"
 derive_setters = "0.1.9"
-devicons = "0.6.12"
+devicons = "0.6.13"
 digest = { default-features = false, version = "0.11.3" }
 dirs = "6.0"
 dirs-sys = "0.5"


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description

Bump devicons version to **0.6.13** to fix an issue where the icon for folders with dot were treated as file when using command like `ls | grid -ic`

### Before:
<img width="410" height="270" alt="image" src="https://github.com/user-attachments/assets/6e5554a9-566c-481f-946c-3f60b9524b4a" />

### After:
<img width="393" height="252" alt="image" src="https://github.com/user-attachments/assets/1c70adaa-6331-42d1-9d0e-8407a192f969" />


<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)

Fixed an issue where the icon for a folder with a dot was treated as a file.

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->