### PR TITLE
fix: allow semver to have coloring, add `--loose` flag

### DIFF
--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -157,7 +157,7 @@ fn get_suggestions_by_value(
             })
             .collect(),
         Value::Custom { val, .. } => match val.type_name().as_str() {
-            "semver" => ["major", "minor", "patch", "pre", "build"]
+            "semver" => ["major", "minor", "patch", "pre", "build", "prefix"]
                 .into_iter()
                 .map(|s| to_suggestion(s.to_string(), None))
                 .collect(),

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -2998,7 +2998,7 @@ fn custom_value_cell_path_completions() {
 
     let completion_str = "$v.";
     let suggestions = completer.complete_blocking(completion_str, completion_str.len());
-    let expected = ["major", "minor", "patch", "pre", "build"];
+    let expected = ["major", "minor", "patch", "pre", "build", "prefix"];
     let received: Vec<_> = suggestions.iter().map(|s| s.value.as_str()).collect();
     assert!(
         expected

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -354,6 +354,23 @@ mod tests {
                 assert_eq!(val.get("major").unwrap().as_int().unwrap(), 1);
                 assert_eq!(val.get("minor").unwrap().as_int().unwrap(), 2);
                 assert_eq!(val.get("patch").unwrap().as_int().unwrap(), 3);
+                assert_eq!(val.get("prefix").unwrap().as_str().unwrap(), "");
+            }
+            _ => panic!("Expected Record value"),
+        }
+    }
+
+    #[test]
+    fn test_parse_semver_into_record_with_prefix() {
+        let semver_val = SemverValue::parse("v1.2.3", true).unwrap();
+        let result = parse_semver_into_record(&semver_val, Span::test_data());
+
+        match result {
+            Value::Record { val, .. } => {
+                assert_eq!(val.get("major").unwrap().as_int().unwrap(), 1);
+                assert_eq!(val.get("minor").unwrap().as_int().unwrap(), 2);
+                assert_eq!(val.get("patch").unwrap().as_int().unwrap(), 3);
+                assert_eq!(val.get("prefix").unwrap().as_str().unwrap(), "v");
             }
             _ => panic!("Expected Record value"),
         }
@@ -402,6 +419,7 @@ fn parse_semver_into_record(semver: &SemverValue, span: Span) -> Value {
             "patch" => Value::int(version.patch as i64, span),
             "pre" => Value::string(version.pre.to_string(), span),
             "build" => Value::string(version.build.to_string(), span),
+            "prefix" => Value::string(semver.prefix.clone(), span),
             "pre_identifiers" => Value::list(pre_identifiers, span),
             "build_identifiers" => Value::list(build_identifiers, span),
         },

--- a/crates/nu-command/src/conversions/into/semver.rs
+++ b/crates/nu-command/src/conversions/into/semver.rs
@@ -1,5 +1,5 @@
 use crate::semver::value::SemverValue;
-use nu_cmd_base::input_handler::{CellPathOnlyArgs, operate};
+use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
 
@@ -28,6 +28,11 @@ impl Command for IntoSemver {
                 // Relaxed case to support heterogeneous lists
                 (Type::Any, Type::custom("semver")),
             ])
+            .switch(
+                "loose",
+                "Allow common non-strict prefixes such as v1.2.3, v.1.2.3, v:1.2.3, v-1.2.3, or v_1.2.3",
+                Some('l'),
+            )
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
@@ -53,13 +58,12 @@ impl Command for IntoSemver {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let cell_paths = call.rest(engine_state, stack, 0)?;
-        operate(
-            into_semver,
-            cell_paths.into(),
-            input,
-            head,
-            engine_state.signals(),
-        )
+        let loose = call.has_flag(engine_state, stack, "loose")?;
+        let args = Arguments {
+            cell_paths: (!cell_paths.is_empty()).then_some(cell_paths),
+            loose,
+        };
+        operate(into_semver, args, input, head, engine_state.signals())
     }
 
     fn examples(&self) -> Vec<Example<'static>> {
@@ -79,26 +83,54 @@ impl Command for IntoSemver {
                 example: "{major: 1, minor: 2, patch: 3} | into semver",
                 result: None,
             },
+            Example {
+                description: "Parse a version with a common leading v prefix",
+                example: "'v1.2.3' | into semver --loose",
+                result: None,
+            },
+            Example {
+                description: "Parse versions like v.1.2.3, v:1.2.3, v-1.2.3, or v_1.2.3",
+                example: "['v.1.2.3' 'v:2.0.0' 'v-3.0.0' 'v_4.0.0'] | into semver --loose",
+                result: None,
+            },
         ]
     }
 }
 
-fn into_semver(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
+struct Arguments {
+    cell_paths: Option<Vec<CellPath>>,
+    loose: bool,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        self.cell_paths.take()
+    }
+}
+
+fn into_semver(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
         Value::Custom { val, .. } if val.type_name() == "semver" => input.clone(),
-        Value::String { val, .. } => match semver::Version::parse(val) {
-            Ok(version) => Value::custom(Box::new(SemverValue::new(version)), head),
-            Err(_) => Value::error(
-                ShellError::Generic(
-                    GenericError::new(
-                        format!("Cannot convert \"{val}\" to a semver"),
-                        "the given string is not a valid semver version",
-                        head,
-                    )
-                    .with_help("expected format: major.minor.patch (e.g. 1.2.3)"),
-                ),
-                head,
-            ),
+        Value::String { val, .. } => match SemverValue::parse(val, args.loose) {
+            Ok(version) => Value::custom(Box::new(version), head),
+            Err(_) => {
+                let help = if args.loose {
+                    "expected format: major.minor.patch (e.g. 1.2.3), optionally with a v/V, v., v:, v-, or v_ prefix"
+                } else {
+                    "expected format: major.minor.patch (e.g. 1.2.3); use --loose for prefixes like v1.2.3"
+                };
+                Value::error(
+                    ShellError::Generic(
+                        GenericError::new(
+                            format!("Cannot convert \"{val}\" to a semver"),
+                            "the given string is not a valid semver version",
+                            head,
+                        )
+                        .with_help(help),
+                    ),
+                    head,
+                )
+            }
         },
         Value::Record { val, .. } => parse_record_to_semver(val, head),
         _ => Value::error(
@@ -224,6 +256,13 @@ mod tests {
     use nu_test_support::Result;
     use nu_test_support::prelude::*;
 
+    fn args(loose: bool) -> Arguments {
+        Arguments {
+            cell_paths: None,
+            loose,
+        }
+    }
+
     fn get_custom_value(value: &Value) -> &SemverValue {
         match value {
             Value::Custom { val, .. } => val.as_any().downcast_ref::<SemverValue>().unwrap(),
@@ -234,17 +273,18 @@ mod tests {
     #[test]
     fn test_into_semver_from_string() {
         let value = Value::string("1.2.3", Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         assert!(matches!(result, Value::Custom { .. }));
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3");
+        assert!(semver_val.prefix.is_empty());
     }
 
     #[test]
     fn test_into_semver_from_string_with_prerelease() {
         let value = Value::string("1.2.3-alpha.1+build.2", Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3-alpha.1+build.2");
@@ -253,8 +293,35 @@ mod tests {
     #[test]
     fn test_into_semver_from_invalid_string() {
         let value = Value::string("not-a-version", Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
+        assert!(matches!(result, Value::Error { .. }));
+    }
+
+    #[test]
+    fn test_into_semver_loose_prefixes() {
+        for (input, prefix, version) in [
+            ("v1.2.3", "v", "1.2.3"),
+            ("V1.2.3", "V", "1.2.3"),
+            ("v.1.2.3", "v.", "1.2.3"),
+            ("v:1.2.3", "v:", "1.2.3"),
+            ("v-1.2.3", "v-", "1.2.3"),
+            ("v_1.2.3", "v_", "1.2.3"),
+            ("v1.2.3-alpha.1+build", "v", "1.2.3-alpha.1+build"),
+        ] {
+            let value = Value::string(input, Span::test_data());
+            let result = into_semver(&value, &args(true), Span::test_data());
+            let semver_val = get_custom_value(&result);
+            assert_eq!(semver_val.prefix, prefix, "input={input}");
+            assert_eq!(semver_val.version.to_string(), version, "input={input}");
+            assert_eq!(semver_val.display(), input);
+        }
+    }
+
+    #[test]
+    fn test_into_semver_loose_required_for_prefix() {
+        let value = Value::string("v1.2.3", Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
         assert!(matches!(result, Value::Error { .. }));
     }
 
@@ -262,7 +329,7 @@ mod tests {
     fn test_into_semver_from_semver() {
         let original = SemverValue::new(semver::Version::parse("1.2.3").unwrap());
         let value = Value::custom(Box::new(original), Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         // Should return the same value
         let semver_val = get_custom_value(&result);
@@ -277,7 +344,7 @@ mod tests {
             "patch" => Value::int(3, Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3");
@@ -292,7 +359,7 @@ mod tests {
             "pre" => Value::string("alpha.1", Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3-alpha.1");
@@ -307,7 +374,7 @@ mod tests {
             "build" => Value::string("build.2", Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3+build.2");
@@ -323,7 +390,7 @@ mod tests {
             "build" => Value::string("build", Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3-alpha+build");
@@ -336,7 +403,7 @@ mod tests {
             "patch" => Value::int(3, Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         assert!(matches!(result, Value::Error { .. }));
     }
@@ -349,7 +416,7 @@ mod tests {
             "patch" => Value::int(3, Span::test_data()),
         };
         let value = Value::record(record, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         assert!(matches!(result, Value::Error { .. }));
     }
@@ -357,7 +424,7 @@ mod tests {
     #[test]
     fn test_into_semver_from_unsupported_type() {
         let value = Value::int(42, Span::test_data());
-        let result = into_semver(&value, &vec![].into(), Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
 
         assert!(matches!(result, Value::Error { .. }));
     }
@@ -391,6 +458,13 @@ mod tests {
         test()
             .run_with_data("into semver", value)
             .expect_value_eq(vec!["3.1.0", "0.10.5"])
+    }
+
+    #[test]
+    fn test_into_semver_loose_list() -> Result {
+        test()
+            .run("['v1.0.0' 'v.2.0.0' 'v:3.0.0'] | into semver --loose")
+            .expect_value_eq(vec!["v1.0.0", "v.2.0.0", "v:3.0.0"])
     }
 
     #[test]

--- a/crates/nu-command/src/conversions/into/semver.rs
+++ b/crates/nu-command/src/conversions/into/semver.rs
@@ -42,7 +42,13 @@ impl Command for IntoSemver {
     }
 
     fn description(&self) -> &str {
-        "Convert a value to a semantic version."
+        "Convert a value (string, record, or semver) to a semantic version."
+    }
+
+    fn extra_description(&self) -> &str {
+        "From a record: major/minor/patch are required; pre, build, and prefix are optional. \
+         prefix is display-only metadata (e.g. \"v\"); re-parsing from text with --loose only \
+         accepts recognized loose prefixes (v/V with optional . : - _)."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -210,6 +216,14 @@ fn parse_record_to_semver(record: &nu_protocol::Record, head: Span) -> Value {
         .and_then(|v| v.as_str().ok())
         .unwrap_or("");
 
+    // Display-only; any string is accepted so `into record` → `into semver` round-trips.
+    // Text re-parse via `into semver --loose` only recognizes known loose prefixes.
+    let prefix = record
+        .get("prefix")
+        .and_then(|v| v.as_str().ok())
+        .unwrap_or("")
+        .to_string();
+
     let pre = match semver::Prerelease::new(pre) {
         Ok(p) => p,
         Err(e) => {
@@ -246,7 +260,7 @@ fn parse_record_to_semver(record: &nu_protocol::Record, head: Span) -> Value {
         build,
     };
 
-    Value::custom(Box::new(SemverValue::new(version)), head)
+    Value::custom(Box::new(SemverValue::with_prefix(version, prefix)), head)
 }
 
 #[cfg(test)]
@@ -394,6 +408,30 @@ mod tests {
 
         let semver_val = get_custom_value(&result);
         assert_eq!(semver_val.version.to_string(), "1.2.3-alpha+build");
+    }
+
+    #[test]
+    fn test_into_semver_from_record_with_prefix() {
+        let record = record! {
+            "major" => Value::int(1, Span::test_data()),
+            "minor" => Value::int(2, Span::test_data()),
+            "patch" => Value::int(3, Span::test_data()),
+            "prefix" => Value::string("v", Span::test_data()),
+        };
+        let value = Value::record(record, Span::test_data());
+        let result = into_semver(&value, &args(false), Span::test_data());
+
+        let semver_val = get_custom_value(&result);
+        assert_eq!(semver_val.prefix, "v");
+        assert_eq!(semver_val.version.to_string(), "1.2.3");
+        assert_eq!(semver_val.display(), "v1.2.3");
+    }
+
+    #[test]
+    fn test_into_semver_record_round_trip_preserves_prefix() -> Result {
+        test()
+            .run("'v1.2.3' | into semver --loose | into record | into semver | to text")
+            .expect_value_eq("v1.2.3")
     }
 
     #[test]

--- a/crates/nu-command/src/conversions/into/semver_range.rs
+++ b/crates/nu-command/src/conversions/into/semver_range.rs
@@ -1,3 +1,4 @@
+use crate::semver::parse;
 use crate::semver::range::SemverRangeValue;
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::generic::GenericError;
@@ -19,6 +20,11 @@ impl Command for IntoSemverRange {
                     Type::Custom("semver-range".into()),
                 ),
             ])
+            .switch(
+                "loose",
+                "Allow common non-strict version prefixes such as v1.2.3, v.1.2.3, v:1.2.3, v-1.2.3, or v_1.2.3 inside the range",
+                Some('l'),
+            )
             .category(Category::Conversions)
     }
 
@@ -33,14 +39,15 @@ impl Command for IntoSemverRange {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let loose = call.has_flag(engine_state, stack, "loose")?;
 
         input.map(
-            move |value| into_semver_range(&value, head),
+            move |value| into_semver_range(&value, head, loose),
             engine_state.signals(),
         )
     }
@@ -57,26 +64,38 @@ impl Command for IntoSemverRange {
                 example: "'^1.2.3' | into semver-range",
                 result: None,
             },
+            Example {
+                description: "Parse a range with a leading v on the version",
+                example: "'>=v1.0.0' | into semver-range --loose",
+                result: None,
+            },
         ]
     }
 }
 
-fn into_semver_range(input: &Value, head: Span) -> Value {
+fn into_semver_range(input: &Value, head: Span, loose: bool) -> Value {
     match input {
         Value::Custom { val, .. } if val.type_name() == "semver-range" => input.clone(),
-        Value::String { val, .. } => match semver::VersionReq::parse(val) {
+        Value::String { val, .. } => match parse::parse_version_req(val, loose) {
             Ok(requirement) => Value::custom(Box::new(SemverRangeValue::new(requirement)), head),
-            Err(_) => Value::error(
-                ShellError::Generic(
-                    GenericError::new(
-                        format!("Cannot convert \"{val}\" to a semver range"),
-                        "the given string is not a valid semver requirement",
-                        head,
-                    )
-                    .with_help("expected format: >=1.0.0, ^1.2.3, ~1.2, etc."),
-                ),
-                head,
-            ),
+            Err(_) => {
+                let help = if loose {
+                    "expected format: >=1.0.0, ^1.2.3, ~1.2, etc.; version numbers may use a v/V, v., v:, v-, or v_ prefix"
+                } else {
+                    "expected format: >=1.0.0, ^1.2.3, ~1.2, etc.; use --loose for prefixes like v1.2.3"
+                };
+                Value::error(
+                    ShellError::Generic(
+                        GenericError::new(
+                            format!("Cannot convert \"{val}\" to a semver range"),
+                            "the given string is not a valid semver requirement",
+                            head,
+                        )
+                        .with_help(help),
+                    ),
+                    head,
+                )
+            }
         },
         _ => Value::error(
             ShellError::Generic(GenericError::new(
@@ -103,7 +122,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_from_string() {
         let value = Value::string(">=1.0.0", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         assert!(matches!(result, Value::Custom { .. }));
         let range_val = get_custom_value(&result);
@@ -113,7 +132,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_caret() {
         let value = Value::string("^1.2.3", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         let range_val = get_custom_value(&result);
         assert_eq!(range_val.requirement.to_string(), "^1.2.3");
@@ -122,7 +141,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_tilde() {
         let value = Value::string("~1.2", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         let range_val = get_custom_value(&result);
         assert_eq!(range_val.requirement.to_string(), "~1.2");
@@ -131,7 +150,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_complex() {
         let value = Value::string(">=1.0.0, <2.0.0", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         let range_val = get_custom_value(&result);
         assert_eq!(range_val.requirement.to_string(), ">=1.0.0, <2.0.0");
@@ -140,7 +159,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_wildcard() {
         let value = Value::string("*", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         let range_val = get_custom_value(&result);
         assert_eq!(range_val.requirement.to_string(), "*");
@@ -150,7 +169,7 @@ mod tests {
     fn test_into_semver_range_from_semver_range() {
         let original = SemverRangeValue::new(semver::VersionReq::parse(">=1.0.0").unwrap());
         let value = Value::custom(Box::new(original), Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         // Should return the same value
         let range_val = get_custom_value(&result);
@@ -160,7 +179,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_invalid() {
         let value = Value::string("not-a-range", Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         assert!(matches!(result, Value::Error { .. }));
     }
@@ -168,7 +187,7 @@ mod tests {
     #[test]
     fn test_into_semver_range_unsupported_type() {
         let value = Value::int(42, Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
         assert!(matches!(result, Value::Error { .. }));
     }
@@ -179,8 +198,30 @@ mod tests {
         use crate::semver::value::SemverValue;
         let semver = SemverValue::new(semver::Version::parse("1.2.3").unwrap());
         let value = Value::custom(Box::new(semver), Span::test_data());
-        let result = into_semver_range(&value, Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
 
+        assert!(matches!(result, Value::Error { .. }));
+    }
+
+    #[test]
+    fn test_into_semver_range_loose() {
+        for (input, expected) in [
+            (">=v1.0.0", ">=1.0.0"),
+            ("^v1.2.3", "^1.2.3"),
+            ("~v1.2", "~1.2"),
+            // Bare versions become caret requirements in the cargo semver crate.
+            ("v1.2.3", "^1.2.3"),
+            (">=v:1.0.0, <v.2.0.0", ">=1.0.0, <2.0.0"),
+            (">=v-1.0.0, <v_2.0.0", ">=1.0.0, <2.0.0"),
+        ] {
+            let value = Value::string(input, Span::test_data());
+            let result = into_semver_range(&value, Span::test_data(), true);
+            let range_val = get_custom_value(&result);
+            assert_eq!(range_val.requirement.to_string(), expected, "input={input}");
+        }
+
+        let value = Value::string(">=v1.0.0", Span::test_data());
+        let result = into_semver_range(&value, Span::test_data(), false);
         assert!(matches!(result, Value::Error { .. }));
     }
 }

--- a/crates/nu-command/src/semver/bump.rs
+++ b/crates/nu-command/src/semver/bump.rs
@@ -26,6 +26,11 @@ impl Command for SemverBump {
                 "Preserve the existing build metadata from the input version",
                 Some('p'),
             )
+            .switch(
+                "loose",
+                "Allow common non-strict prefixes such as v1.2.3, v.1.2.3, v:1.2.3, v-1.2.3, or v_1.2.3 when parsing string input; the prefix is preserved on the result",
+                Some('l'),
+            )
             .named(
                 "build-metadata",
                 SyntaxShape::String,
@@ -87,6 +92,16 @@ impl Command for SemverBump {
                 example: "'1.2.3+build.5' | into semver | semver bump patch --preserve-build-metadata",
                 result: Some(SemverValue::test_value("1.2.4+build.5")),
             },
+            Example {
+                description: "Bump a loosely-prefixed version string",
+                example: "'v1.2.3' | semver bump patch --loose",
+                result: Some(SemverValue::test_value("v1.2.4")),
+            },
+            Example {
+                description: "Bump after converting with --loose (prefix is preserved)",
+                example: "'v1.2.3' | into semver --loose | semver bump major",
+                result: Some(SemverValue::test_value("v2.0.0")),
+            },
         ]
     }
 
@@ -103,6 +118,7 @@ impl Command for SemverBump {
             call.get_flag(engine_state, stack, "build-metadata")?;
         let preserve_build_metadata =
             call.has_flag(engine_state, stack, "preserve-build-metadata")?;
+        let loose = call.has_flag(engine_state, stack, "loose")?;
         let head = call.head;
 
         input.map(
@@ -114,6 +130,7 @@ impl Command for SemverBump {
                     ignore_errors,
                     build_metadata.as_deref(),
                     preserve_build_metadata,
+                    loose,
                 )
                 .unwrap_or_else(|err| Value::error(err, head))
             },
@@ -129,8 +146,9 @@ fn bump_value_with_options(
     ignore_errors: bool,
     build_metadata: Option<&str>,
     preserve_build_metadata: bool,
+    loose: bool,
 ) -> Result<Value, ShellError> {
-    let semver_val = match SemverValue::try_from(input) {
+    let semver_val = match SemverValue::try_from_value(input, loose) {
         Ok(semver) => semver,
         Err(err) => {
             if ignore_errors {
@@ -167,6 +185,7 @@ fn bump_value_with_options(
                 build: original_build,
                 ..result.version
             },
+            prefix: result.prefix,
         },
         (None, false) => result,
     };
@@ -187,168 +206,189 @@ mod tests {
         match value {
             Value::Custom { val, .. } => {
                 let semver = val.as_any().downcast_ref::<SemverValue>().unwrap();
-                semver.version.to_string()
+                semver.display()
             }
             _ => panic!("Expected Custom value"),
         }
     }
 
+    fn bump(
+        input: &Value,
+        level: &str,
+        ignore_errors: bool,
+        build_metadata: Option<&str>,
+        preserve_build_metadata: bool,
+        loose: bool,
+    ) -> Result<Value, ShellError> {
+        bump_value_with_options(
+            input,
+            level,
+            Span::test_data(),
+            ignore_errors,
+            build_metadata,
+            preserve_build_metadata,
+            loose,
+        )
+    }
+
     #[test]
     fn test_bump_major() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "major", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "2.0.0");
     }
 
     #[test]
     fn test_bump_minor() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "minor", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "minor", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.3.0");
     }
 
     #[test]
     fn test_bump_patch() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "patch", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "patch", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.4");
     }
 
     #[test]
     fn test_bump_alpha() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "alpha", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "alpha", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.3-alpha.1");
     }
 
     #[test]
     fn test_bump_beta() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "beta", Span::test_data(), false, None, false).unwrap();
+        let result = bump(&input, "beta", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.3-beta.1");
     }
 
     #[test]
     fn test_bump_rc() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "rc", Span::test_data(), false, None, false).unwrap();
+        let result = bump(&input, "rc", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.3-rc.1");
     }
 
     #[test]
     fn test_bump_release() {
         let input = create_semver_value("1.2.3-alpha.1");
-        let result =
-            bump_value_with_options(&input, "release", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "release", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.3");
     }
 
     #[test]
     fn test_bump_invalid_level() {
         let input = create_semver_value("1.2.3");
-        let result =
-            bump_value_with_options(&input, "invalid", Span::test_data(), false, None, false);
+        let result = bump(&input, "invalid", false, None, false, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_bump_string_input_is_supported() {
         let input = Value::string("1.2.3", Span::test_data());
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "major", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "2.0.0");
     }
 
     #[test]
     fn test_bump_string_input_with_build_metadata() {
         let input = Value::string("1.2.3", Span::test_data());
-        let result = bump_value_with_options(
-            &input,
-            "minor",
-            Span::test_data(),
-            false,
-            Some("build"),
-            false,
-        )
-        .unwrap();
+        let result = bump(&input, "minor", false, Some("build"), false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.3.0+build");
     }
 
     #[test]
     fn test_bump_ignore_errors_for_invalid_input() {
         let input = Value::string("not-a-version", Span::test_data());
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), true, None, false).unwrap();
+        let result = bump(&input, "major", true, None, false, false).unwrap();
         assert!(matches!(result, Value::String { .. }));
     }
 
     #[test]
     fn test_bump_wrong_custom_value() {
         let input = Value::int(42, Span::test_data());
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), false, None, false);
+        let result = bump(&input, "major", false, None, false, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_bump_with_prerelease() {
         let input = create_semver_value("1.2.3-alpha.1");
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "major", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "2.0.0");
     }
 
     #[test]
     fn test_bump_with_build_metadata() {
         let input = create_semver_value("1.2.3+build.1");
-        let result =
-            bump_value_with_options(&input, "minor", Span::test_data(), false, None, false)
-                .unwrap();
+        let result = bump(&input, "minor", false, None, false, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.3.0");
     }
 
     #[test]
     fn test_bump_preserve_build_metadata() {
         let input = create_semver_value("1.2.3+build.5");
-        let result =
-            bump_value_with_options(&input, "patch", Span::test_data(), false, None, true).unwrap();
+        let result = bump(&input, "patch", false, None, true, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.4+build.5");
     }
 
     #[test]
     fn test_bump_preserve_build_metadata_major() {
         let input = create_semver_value("1.2.3+build.1");
-        let result =
-            bump_value_with_options(&input, "major", Span::test_data(), false, None, true).unwrap();
+        let result = bump(&input, "major", false, None, true, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "2.0.0+build.1");
     }
 
     #[test]
     fn test_bump_build_metadata_takes_precedence() {
         let input = create_semver_value("1.2.3+build.1");
-        let result = bump_value_with_options(
-            &input,
-            "patch",
-            Span::test_data(),
-            false,
-            Some("override"),
-            true,
-        )
-        .unwrap();
+        let result = bump(&input, "patch", false, Some("override"), true, false).unwrap();
         assert_eq!(get_semver_from_value(&result), "1.2.4+override");
+    }
+
+    #[test]
+    fn test_bump_loose_string_preserves_prefix() {
+        let input = Value::string("v1.2.3", Span::test_data());
+        let result = bump(&input, "major", false, None, false, true).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v2.0.0");
+
+        let input = Value::string("v.1.2.3", Span::test_data());
+        let result = bump(&input, "patch", false, None, false, true).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v.1.2.4");
+
+        let input = Value::string("v:1.2.3", Span::test_data());
+        let result = bump(&input, "minor", false, None, false, true).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v:1.3.0");
+
+        let input = Value::string("v-1.2.3", Span::test_data());
+        let result = bump(&input, "major", false, None, false, true).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v-2.0.0");
+
+        let input = Value::string("v_1.2.3", Span::test_data());
+        let result = bump(&input, "patch", false, None, false, true).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v_1.2.4");
+    }
+
+    #[test]
+    fn test_bump_loose_required_for_prefixed_string() {
+        let input = Value::string("v1.2.3", Span::test_data());
+        let result = bump(&input, "major", false, None, false, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_bump_preserves_prefix_from_semver_value() {
+        let input = Value::custom(
+            Box::new(SemverValue::parse("v1.2.3", true).unwrap()),
+            Span::test_data(),
+        );
+        // Prefix is already on the value; --loose is not required to keep it.
+        let result = bump(&input, "major", false, None, false, false).unwrap();
+        assert_eq!(get_semver_from_value(&result), "v2.0.0");
     }
 }
 

--- a/crates/nu-command/src/semver/bump.rs
+++ b/crates/nu-command/src/semver/bump.rs
@@ -93,14 +93,18 @@ impl Command for SemverBump {
                 result: Some(SemverValue::test_value("1.2.4+build.5")),
             },
             Example {
+                // Assert via `to text` so the example locks the display prefix;
+                // SemverValue equality ignores prefix by design.
                 description: "Bump a loosely-prefixed version string",
-                example: "'v1.2.3' | semver bump patch --loose",
-                result: Some(SemverValue::test_value("v1.2.4")),
+                example: "'v1.2.3' | semver bump patch --loose | to text",
+                result: Some(Value::test_string("v1.2.4")),
             },
             Example {
+                // Assert via `to text` so the example locks the display prefix;
+                // SemverValue equality ignores prefix by design.
                 description: "Bump after converting with --loose (prefix is preserved)",
-                example: "'v1.2.3' | into semver --loose | semver bump major",
-                result: Some(SemverValue::test_value("v2.0.0")),
+                example: "'v1.2.3' | into semver --loose | semver bump major | to text",
+                result: Some(Value::test_string("v2.0.0")),
             },
         ]
     }
@@ -180,13 +184,13 @@ fn bump_value_with_options(
 
     let result = match (build_metadata, preserve_build_metadata) {
         (Some(metadata), _) => result.set_build_metadata(metadata)?,
-        (None, true) => SemverValue {
-            version: semver::Version {
+        (None, true) => SemverValue::with_prefix(
+            semver::Version {
                 build: original_build,
                 ..result.version
             },
-            prefix: result.prefix,
-        },
+            result.prefix,
+        ),
         (None, false) => result,
     };
 

--- a/crates/nu-command/src/semver/mod.rs
+++ b/crates/nu-command/src/semver/mod.rs
@@ -8,6 +8,7 @@
 //! | [`Semver`] | Display this help message |
 //! | [`SemverBump`] | Increment major/minor/patch or add/advance prerelease |
 
+pub mod parse;
 pub mod range;
 pub mod value;
 

--- a/crates/nu-command/src/semver/parse.rs
+++ b/crates/nu-command/src/semver/parse.rs
@@ -77,27 +77,30 @@ pub fn parse_version(s: &str, loose: bool) -> Result<(semver::Version, String), 
 /// - `>=v:1.0.0, <v.2.0.0` → `>=1.0.0, <2.0.0`
 /// - `>=v-1.0.0, <v_2.0.0` → `>=1.0.0, <2.0.0`
 pub fn normalize_loose_range(s: &str) -> String {
-    let bytes = s.as_bytes();
     let mut out = String::with_capacity(s.len());
-    let mut i = 0;
+    let mut rest = s;
 
-    while i < bytes.len() {
-        let at_boundary = i == 0
+    while !rest.is_empty() {
+        let at_boundary = out.is_empty()
             || matches!(
-                bytes[i - 1],
-                b' ' | b',' | b'<' | b'>' | b'=' | b'^' | b'~' | b'!'
+                out.chars().next_back(),
+                Some(' ' | ',' | '<' | '>' | '=' | '^' | '~' | '!')
             );
 
         if at_boundary {
-            let (prefix, _rest) = strip_loose_version_prefix(&s[i..]);
+            let (prefix, after) = strip_loose_version_prefix(rest);
             if !prefix.is_empty() {
-                i += prefix.len();
+                rest = after;
                 continue;
             }
         }
 
-        out.push(bytes[i] as char);
-        i += 1;
+        let mut chars = rest.chars();
+        let Some(ch) = chars.next() else {
+            break;
+        };
+        out.push(ch);
+        rest = chars.as_str();
     }
 
     out
@@ -190,5 +193,9 @@ mod tests {
         let req = parse_version_req(">=v1.0.0", true).unwrap();
         assert_eq!(req.to_string(), ">=1.0.0");
         assert!(parse_version_req(">=v1.0.0", false).is_err());
+
+        // Non-ASCII must not be split into replacement chars (byte-wise push).
+        assert_eq!(normalize_loose_range("≥v1.0.0"), "≥v1.0.0");
+        assert_eq!(normalize_loose_range("≥ v1.0.0"), "≥ 1.0.0");
     }
 }

--- a/crates/nu-command/src/semver/parse.rs
+++ b/crates/nu-command/src/semver/parse.rs
@@ -1,0 +1,194 @@
+//! Loose semver parsing helpers.
+//!
+//! Strict SemVer 2.0.0 does not allow a leading `v` (or similar). In practice many
+//! tools publish tags like `v1.2.3`, `v.1.2.3`, or `v:1.2.3`. Loose mode strips a
+//! single leading prefix of that form before parsing.
+
+/// Strip a loose leading version prefix: `v`/`V`, optionally followed by `.`, `:`,
+/// `-`, or `_`, only when the remainder starts with a digit.
+///
+/// Returns `(prefix, rest)`. When no prefix is recognized, returns `("", s)`.
+///
+/// # Examples
+///
+/// - `v1.2.3` → `("v", "1.2.3")`
+/// - `V1.2.3` → `("V", "1.2.3")`
+/// - `v.1.2.3` → `("v.", "1.2.3")`
+/// - `v:1.2.3` → `("v:", "1.2.3")`
+/// - `v-1.2.3` → `("v-", "1.2.3")`
+/// - `v_1.2.3` → `("v_", "1.2.3")`
+/// - `1.2.3` → `("", "1.2.3")`
+pub fn strip_loose_version_prefix(s: &str) -> (&str, &str) {
+    let after_v = match s.strip_prefix('v').or_else(|| s.strip_prefix('V')) {
+        Some(rest) => rest,
+        None => return ("", s),
+    };
+
+    // v.1.2.3, v:1.2.3, v-1.2.3, or v_1.2.3
+    if let Some(after_sep) = after_v
+        .strip_prefix('.')
+        .or_else(|| after_v.strip_prefix(':'))
+        .or_else(|| after_v.strip_prefix('-'))
+        .or_else(|| after_v.strip_prefix('_'))
+        && after_sep.starts_with(|c: char| c.is_ascii_digit())
+    {
+        let prefix_len = s.len() - after_sep.len();
+        return (&s[..prefix_len], after_sep);
+    }
+
+    // v1.2.3
+    if after_v.starts_with(|c: char| c.is_ascii_digit()) {
+        let prefix_len = s.len() - after_v.len();
+        return (&s[..prefix_len], after_v);
+    }
+
+    ("", s)
+}
+
+/// Parse a version string, optionally accepting a loose leading prefix.
+///
+/// Returns the parsed version and the captured prefix (empty when strict or none).
+pub fn parse_version(s: &str, loose: bool) -> Result<(semver::Version, String), semver::Error> {
+    match semver::Version::parse(s) {
+        Ok(version) => Ok((version, String::new())),
+        Err(strict_err) => {
+            if !loose {
+                return Err(strict_err);
+            }
+            let (prefix, rest) = strip_loose_version_prefix(s);
+            if prefix.is_empty() {
+                return Err(strict_err);
+            }
+            let version = semver::Version::parse(rest)?;
+            Ok((version, prefix.to_string()))
+        }
+    }
+}
+
+/// Normalize a version requirement for loose parsing by stripping `v`/`V`
+/// (optionally followed by `.`, `:`, `-`, or `_`) before version numbers at
+/// comparator boundaries.
+///
+/// # Examples
+///
+/// - `>=v1.0.0` → `>=1.0.0`
+/// - `^v1.2.3` → `^1.2.3`
+/// - `v1.2.3` → `1.2.3`
+/// - `>=v:1.0.0, <v.2.0.0` → `>=1.0.0, <2.0.0`
+/// - `>=v-1.0.0, <v_2.0.0` → `>=1.0.0, <2.0.0`
+pub fn normalize_loose_range(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let at_boundary = i == 0
+            || matches!(
+                bytes[i - 1],
+                b' ' | b',' | b'<' | b'>' | b'=' | b'^' | b'~' | b'!'
+            );
+
+        if at_boundary {
+            let (prefix, _rest) = strip_loose_version_prefix(&s[i..]);
+            if !prefix.is_empty() {
+                i += prefix.len();
+                continue;
+            }
+        }
+
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+
+    out
+}
+
+/// Parse a version requirement string, optionally accepting loose version prefixes.
+pub fn parse_version_req(s: &str, loose: bool) -> Result<semver::VersionReq, semver::Error> {
+    match semver::VersionReq::parse(s) {
+        Ok(req) => Ok(req),
+        Err(strict_err) => {
+            if !loose {
+                return Err(strict_err);
+            }
+            let normalized = normalize_loose_range(s);
+            if normalized == s {
+                return Err(strict_err);
+            }
+            semver::VersionReq::parse(&normalized)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_prefix_variants() {
+        assert_eq!(strip_loose_version_prefix("v1.2.3"), ("v", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("V1.2.3"), ("V", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("v.1.2.3"), ("v.", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("v:1.2.3"), ("v:", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("V:1.2.3"), ("V:", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("v-1.2.3"), ("v-", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("v_1.2.3"), ("v_", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("V-1.2.3"), ("V-", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("V_1.2.3"), ("V_", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("1.2.3"), ("", "1.2.3"));
+        assert_eq!(strip_loose_version_prefix("version"), ("", "version"));
+        assert_eq!(
+            strip_loose_version_prefix("v1.2.3-alpha.1+build"),
+            ("v", "1.2.3-alpha.1+build")
+        );
+        // Hyphen before a non-digit is not a loose prefix (prerelease-like).
+        assert_eq!(strip_loose_version_prefix("v-alpha"), ("", "v-alpha"));
+    }
+
+    #[test]
+    fn parse_version_loose() {
+        let (v, p) = parse_version("v1.2.3", true).unwrap();
+        assert_eq!(v.to_string(), "1.2.3");
+        assert_eq!(p, "v");
+
+        let (v, p) = parse_version("v.2.0.0", true).unwrap();
+        assert_eq!(v.to_string(), "2.0.0");
+        assert_eq!(p, "v.");
+
+        let (v, p) = parse_version("v:3.1.4", true).unwrap();
+        assert_eq!(v.to_string(), "3.1.4");
+        assert_eq!(p, "v:");
+
+        let (v, p) = parse_version("v-4.5.6", true).unwrap();
+        assert_eq!(v.to_string(), "4.5.6");
+        assert_eq!(p, "v-");
+
+        let (v, p) = parse_version("v_7.8.9", true).unwrap();
+        assert_eq!(v.to_string(), "7.8.9");
+        assert_eq!(p, "v_");
+
+        assert!(parse_version("v1.2.3", false).is_err());
+        let (v, p) = parse_version("1.2.3", true).unwrap();
+        assert_eq!(v.to_string(), "1.2.3");
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn normalize_and_parse_range_loose() {
+        assert_eq!(normalize_loose_range(">=v1.0.0"), ">=1.0.0");
+        assert_eq!(normalize_loose_range("^v1.2.3"), "^1.2.3");
+        assert_eq!(normalize_loose_range("v1.2.3"), "1.2.3");
+        assert_eq!(
+            normalize_loose_range(">=v:1.0.0, <v.2.0.0"),
+            ">=1.0.0, <2.0.0"
+        );
+        assert_eq!(
+            normalize_loose_range(">=v-1.0.0, <v_2.0.0"),
+            ">=1.0.0, <2.0.0"
+        );
+
+        let req = parse_version_req(">=v1.0.0", true).unwrap();
+        assert_eq!(req.to_string(), ">=1.0.0");
+        assert!(parse_version_req(">=v1.0.0", false).is_err());
+    }
+}

--- a/crates/nu-command/src/semver/value.rs
+++ b/crates/nu-command/src/semver/value.rs
@@ -12,7 +12,10 @@ use std::ops::Deref;
 /// A semantic version value, optionally carrying a display prefix from loose parsing.
 ///
 /// Equality and ordering compare only [`version`]; `prefix` is presentation metadata
-/// (e.g. `"v"` from `v1.2.3` parsed with `--loose`).
+/// (e.g. `"v"` from `v1.2.3` parsed with `--loose`). That means `v1.0.0` and `1.0.0`
+/// compare equal, and command `example` `result:` values that use [`SemverValue`] only
+/// lock the version identity—not the display form. Prefer `display()` / `to text` when
+/// tests need to assert a preserved prefix.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemverValue {
     pub version: semver::Version,
@@ -21,6 +24,7 @@ pub struct SemverValue {
     pub prefix: String,
 }
 
+/// Compares only the underlying SemVer version; `prefix` is ignored.
 impl PartialEq for SemverValue {
     fn eq(&self, other: &Self) -> bool {
         self.version == other.version
@@ -115,6 +119,7 @@ impl nu_protocol::CustomValue for SemverValue {
             "patch" => Ok(Value::int(self.version.patch as i64, path_span)),
             "pre" => Ok(Value::string(self.version.pre.to_string(), path_span)),
             "build" => Ok(Value::string(self.version.build.to_string(), path_span)),
+            "prefix" => Ok(Value::string(self.prefix.clone(), path_span)),
             _ => Err(ShellError::CantFindColumn {
                 col_name: col,
                 span: Some(path_span),
@@ -221,46 +226,46 @@ impl SemverValue {
     /// Parse from a string. When `loose` is true, accepts prefixes like `v`, `v.`, `v:`.
     pub fn parse(s: &str, loose: bool) -> Result<Self, semver::Error> {
         let (version, prefix) = parse::parse_version(s, loose)?;
-        Ok(Self { version, prefix })
+        Ok(Self::with_prefix(version, prefix))
     }
 
     pub fn bump_major(&self) -> Self {
-        Self {
-            version: semver::Version {
+        Self::with_prefix(
+            semver::Version {
                 major: self.version.major + 1,
                 minor: 0,
                 patch: 0,
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
-            prefix: self.prefix.clone(),
-        }
+            self.prefix.clone(),
+        )
     }
 
     pub fn bump_minor(&self) -> Self {
-        Self {
-            version: semver::Version {
+        Self::with_prefix(
+            semver::Version {
                 major: self.version.major,
                 minor: self.version.minor + 1,
                 patch: 0,
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
-            prefix: self.prefix.clone(),
-        }
+            self.prefix.clone(),
+        )
     }
 
     pub fn bump_patch(&self) -> Self {
-        Self {
-            version: semver::Version {
+        Self::with_prefix(
+            semver::Version {
                 major: self.version.major,
                 minor: self.version.minor,
                 patch: self.version.patch + 1,
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
-            prefix: self.prefix.clone(),
-        }
+            self.prefix.clone(),
+        )
     }
 
     pub fn bump_prerelease(&self, tag: &str) -> Result<Self, ShellError> {
@@ -291,29 +296,29 @@ impl SemverValue {
             ))
         })?;
 
-        Ok(Self {
-            version: semver::Version {
+        Ok(Self::with_prefix(
+            semver::Version {
                 major: self.version.major,
                 minor: self.version.minor,
                 patch: self.version.patch,
                 pre,
                 build: self.version.build.clone(),
             },
-            prefix: self.prefix.clone(),
-        })
+            self.prefix.clone(),
+        ))
     }
 
     pub fn bump_release(&self) -> Self {
-        Self {
-            version: semver::Version {
+        Self::with_prefix(
+            semver::Version {
                 major: self.version.major,
                 minor: self.version.minor,
                 patch: self.version.patch,
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
-            prefix: self.prefix.clone(),
-        }
+            self.prefix.clone(),
+        )
     }
 
     pub fn set_build_metadata(&self, metadata: &str) -> Result<Self, ShellError> {
@@ -325,16 +330,16 @@ impl SemverValue {
             ))
         })?;
 
-        Ok(Self {
-            version: semver::Version {
+        Ok(Self::with_prefix(
+            semver::Version {
                 major: self.version.major,
                 minor: self.version.minor,
                 patch: self.version.patch,
                 pre: self.version.pre.clone(),
                 build,
             },
-            prefix: self.prefix.clone(),
-        })
+            self.prefix.clone(),
+        ))
     }
 
     /// Convert a pipeline value into a [`SemverValue`].
@@ -374,14 +379,9 @@ impl SemverValue {
 
     /// For use by tests and examples only.
     pub fn test_value(s: &str) -> Value {
-        let (version, prefix) = parse::parse_version(s, true).unwrap_or_else(|_| {
-            (
-                s.parse::<semver::Version>()
-                    .unwrap_or_else(|_| semver::Version::new(0, 0, 0)),
-                String::new(),
-            )
-        });
-        Value::test_custom_value(Box::new(Self { version, prefix }))
+        let semver =
+            Self::parse(s, true).unwrap_or_else(|_| Self::new(semver::Version::new(0, 0, 0)));
+        Value::test_custom_value(Box::new(semver))
     }
 }
 
@@ -755,5 +755,43 @@ mod tests {
         // Test as_any
         let any = version.as_any();
         assert!(any.downcast_ref::<SemverValue>().is_some());
+    }
+
+    #[test]
+    fn test_follow_path_prefix() {
+        let plain = SemverValue::new(parse_version("1.2.3"));
+        let prefix = plain
+            .follow_path_string(
+                Span::test_data(),
+                "prefix".into(),
+                Span::test_data(),
+                false,
+                Casing::Sensitive,
+            )
+            .unwrap();
+        assert!(matches!(prefix, Value::String { val, .. } if val.is_empty()));
+
+        let prefixed = SemverValue::parse("v1.2.3", true).unwrap();
+        let prefix = prefixed
+            .follow_path_string(
+                Span::test_data(),
+                "prefix".into(),
+                Span::test_data(),
+                false,
+                Casing::Sensitive,
+            )
+            .unwrap();
+        assert!(matches!(prefix, Value::String { val, .. } if val == "v"));
+
+        let major = prefixed
+            .follow_path_string(
+                Span::test_data(),
+                "major".into(),
+                Span::test_data(),
+                false,
+                Casing::Sensitive,
+            )
+            .unwrap();
+        assert!(matches!(major, Value::Int { val: 1, .. }));
     }
 }

--- a/crates/nu-command/src/semver/value.rs
+++ b/crates/nu-command/src/semver/value.rs
@@ -1,3 +1,4 @@
+use super::parse;
 use nu_protocol::{
     CustomValue, ShellError, Span, Value,
     ast::{Comparison, Operator},
@@ -8,9 +9,36 @@ use std::any::Any;
 use std::cmp::Ordering;
 use std::ops::Deref;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+/// A semantic version value, optionally carrying a display prefix from loose parsing.
+///
+/// Equality and ordering compare only [`version`]; `prefix` is presentation metadata
+/// (e.g. `"v"` from `v1.2.3` parsed with `--loose`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SemverValue {
     pub version: semver::Version,
+    /// Original loose prefix such as `"v"`, `"v."`, or `"v:"`. Empty when none.
+    #[serde(default)]
+    pub prefix: String,
+}
+
+impl PartialEq for SemverValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version
+    }
+}
+
+impl Eq for SemverValue {}
+
+impl PartialOrd for SemverValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SemverValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.version.cmp(&other.version)
+    }
 }
 
 #[typetag::serde]
@@ -24,7 +52,7 @@ impl nu_protocol::CustomValue for SemverValue {
     }
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
-        Ok(Value::string(self.version.to_string(), span))
+        Ok(Value::string(self.display(), span))
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -50,16 +78,20 @@ impl nu_protocol::CustomValue for SemverValue {
                         .to_base_value(other.span())
                         .ok()
                         .and_then(|value| match value {
-                            Value::String { val, .. } => semver::Version::parse(&val).ok(),
+                            // Accept loose prefixes so cross-crate fallback still works
+                            // when display form is e.g. "v1.2.3".
+                            Value::String { val, .. } => {
+                                parse::parse_version(&val, true).ok().map(|(v, _)| v)
+                            }
                             _ => None,
                         })
                         .and_then(|other_version| self.version.partial_cmp(&other_version));
                 }
                 None
             }
-            Value::String { val, .. } => semver::Version::parse(val)
+            Value::String { val, .. } => parse::parse_version(val, true)
                 .ok()
-                .and_then(|other_version| self.version.partial_cmp(&other_version)),
+                .and_then(|(other_version, _)| self.version.partial_cmp(&other_version)),
             _ => None,
         }
     }
@@ -164,7 +196,32 @@ impl nu_protocol::CustomValue for SemverValue {
 
 impl SemverValue {
     pub fn new(version: semver::Version) -> Self {
-        Self { version }
+        Self {
+            version,
+            prefix: String::new(),
+        }
+    }
+
+    pub fn with_prefix(version: semver::Version, prefix: impl Into<String>) -> Self {
+        Self {
+            version,
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Display form including any loose prefix (e.g. `v1.2.3`).
+    pub fn display(&self) -> String {
+        if self.prefix.is_empty() {
+            self.version.to_string()
+        } else {
+            format!("{}{}", self.prefix, self.version)
+        }
+    }
+
+    /// Parse from a string. When `loose` is true, accepts prefixes like `v`, `v.`, `v:`.
+    pub fn parse(s: &str, loose: bool) -> Result<Self, semver::Error> {
+        let (version, prefix) = parse::parse_version(s, loose)?;
+        Ok(Self { version, prefix })
     }
 
     pub fn bump_major(&self) -> Self {
@@ -176,6 +233,7 @@ impl SemverValue {
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
+            prefix: self.prefix.clone(),
         }
     }
 
@@ -188,6 +246,7 @@ impl SemverValue {
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
+            prefix: self.prefix.clone(),
         }
     }
 
@@ -200,6 +259,7 @@ impl SemverValue {
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
+            prefix: self.prefix.clone(),
         }
     }
 
@@ -239,6 +299,7 @@ impl SemverValue {
                 pre,
                 build: self.version.build.clone(),
             },
+            prefix: self.prefix.clone(),
         })
     }
 
@@ -251,6 +312,7 @@ impl SemverValue {
                 pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             },
+            prefix: self.prefix.clone(),
         }
     }
 
@@ -271,34 +333,23 @@ impl SemverValue {
                 pre: self.version.pre.clone(),
                 build,
             },
+            prefix: self.prefix.clone(),
         })
     }
 
-    /// For use by tests and examples only.
-    pub fn test_value(s: &str) -> Value {
-        Value::test_custom_value(Box::new(Self {
-            version: s
-                .parse::<semver::Version>()
-                .unwrap_or_else(|_| semver::Version::new(0, 0, 0)),
-        }))
-    }
-}
-
-impl<'a> TryFrom<&'a Value> for SemverValue {
-    type Error = ShellError;
-
-    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+    /// Convert a pipeline value into a [`SemverValue`].
+    ///
+    /// When `loose` is true, string inputs may use prefixes like `v1.2.3`.
+    pub fn try_from_value(value: &Value, loose: bool) -> Result<Self, ShellError> {
         let span = value.span();
 
         match value {
             Value::String { val, .. } => {
-                semver::Version::parse(val)
-                    .map(SemverValue::new)
-                    .map_err(|e| ShellError::IncorrectValue {
-                        msg: format!("Value is not a valid semver version: {e}"),
-                        val_span: span,
-                        call_span: span,
-                    })
+                Self::parse(val, loose).map_err(|e| ShellError::IncorrectValue {
+                    msg: format!("Value is not a valid semver version: {e}"),
+                    val_span: span,
+                    call_span: span,
+                })
             }
             Value::Custom { val, .. } => {
                 if let Some(semver) = val.as_any().downcast_ref::<Self>() {
@@ -319,6 +370,26 @@ impl<'a> TryFrom<&'a Value> for SemverValue {
                 help: None,
             }),
         }
+    }
+
+    /// For use by tests and examples only.
+    pub fn test_value(s: &str) -> Value {
+        let (version, prefix) = parse::parse_version(s, true).unwrap_or_else(|_| {
+            (
+                s.parse::<semver::Version>()
+                    .unwrap_or_else(|_| semver::Version::new(0, 0, 0)),
+                String::new(),
+            )
+        });
+        Value::test_custom_value(Box::new(Self { version, prefix }))
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for SemverValue {
+    type Error = ShellError;
+
+    fn try_from(value: &'a Value) -> Result<Self, Self::Error> {
+        Self::try_from_value(value, false)
     }
 }
 
@@ -672,6 +743,10 @@ mod tests {
         // Test to_base_value
         let base = version.to_base_value(Span::test_data()).unwrap();
         assert!(matches!(base, Value::String { val, .. } if val == "1.2.3"));
+
+        let prefixed = SemverValue::parse("v1.2.3", true).unwrap();
+        let base = prefixed.to_base_value(Span::test_data()).unwrap();
+        assert!(matches!(base, Value::String { val, .. } if val == "v1.2.3"));
 
         // Test clone_value
         let cloned = version.clone_value(Span::test_data());

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -716,16 +716,18 @@ fn build_table_batch(
     opts: TableOpts<'_>,
     span: Span,
 ) -> StringResult {
-    // convert each custom value to its base value so it can be properly
-    // displayed in a table
+    // Expand structured custom values (records/lists) so they render as native
+    // table rows/columns. Leave primitive custom values as Custom so type-specific
+    // color_config keys (e.g. "semver") still apply via style_primitive.
     for val in &mut vals {
-        let span = val.span();
+        let val_span = val.span();
 
         if let Value::Custom { val: custom, .. } = val {
-            *val = custom
-                .to_base_value(span)
-                .or_else(|err| Result::<_, ShellError>::Ok(Value::error(err, span)))
-                .expect("error converting custom value to base value")
+            match custom.to_base_value(val_span) {
+                Ok(base @ (Value::Record { .. } | Value::List { .. })) => *val = base,
+                Ok(_) => {}
+                Err(err) => *val = Value::error(err, val_span),
+            }
         }
     }
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -481,11 +481,23 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
             // instead of stdout.
             Err(*error)
         }
-        PipelineData::Value(Value::Custom { val, .. }, metadata) => {
-            let base_pipeline = val
-                .to_base_value(span)?
-                .into_pipeline_data_with_metadata(metadata);
-            Table.run(input.engine_state, input.stack, input.call, base_pipeline)
+        PipelineData::Value(value @ Value::Custom { .. }, metadata) => {
+            // Expand structured custom values (records/lists) into native table
+            // shapes. Keep primitive customs (e.g. semver) as Custom so
+            // type-specific color_config keys still apply via style_primitive.
+            let base = value.as_custom_value()?.to_base_value(span)?;
+            match base {
+                Value::Record { .. } | Value::List { .. } => {
+                    let base_pipeline = base.into_pipeline_data_with_metadata(metadata);
+                    Table.run(input.engine_state, input.stack, input.call, base_pipeline)
+                }
+                _ => {
+                    let signals = input.engine_state.signals().clone();
+                    let stream = ListStream::new(std::iter::once(value), span, signals);
+                    input.data = PipelineData::empty();
+                    handle_row_stream(input, stream, metadata)
+                }
+            }
         }
         PipelineData::Value(Value::Range { val, .. }, metadata) => {
             let signals = input.engine_state.signals().clone();

--- a/crates/nu-command/tests/commands/table/display.rs
+++ b/crates/nu-command/tests/commands/table/display.rs
@@ -184,6 +184,28 @@ fn table_colors() -> Result {
             ╰───┴───╯"})
 }
 
+/// Primitive custom values (e.g. semver) keep their type-specific color when listed.
+/// Structured custom values are still expanded for table layout.
+#[test]
+fn table_semver_list_colors() -> Result {
+    let mut tester = test();
+    // cyan_bold = bold cyan (1;36)
+    let colored = indoc! {"
+        \u{1b}[39m╭───┬───────╮\u{1b}[0m
+        \u{1b}[39m│\u{1b}[0m \u{1b}[1;32m0\u{1b}[0m \u{1b}[39m│\u{1b}[0m \u{1b}[1;36m1.0.0\u{1b}[0m \u{1b}[39m│\u{1b}[0m
+        \u{1b}[39m│\u{1b}[0m \u{1b}[1;32m1\u{1b}[0m \u{1b}[39m│\u{1b}[0m \u{1b}[1;36m2.0.0\u{1b}[0m \u{1b}[39m│\u{1b}[0m
+        \u{1b}[39m╰───┴───────╯\u{1b}[0m
+    "};
+    tester
+        .run(
+            "
+                $env.config.use_ansi_coloring = true
+                ['1.0.0' '2.0.0'] | into semver | table
+            ",
+        )
+        .expect_value_eq(colored)
+}
+
 #[test]
 fn table_empty_colors() -> Result {
     let mut tester = test();

--- a/crates/nu-command/tests/commands/table/display.rs
+++ b/crates/nu-command/tests/commands/table/display.rs
@@ -206,6 +206,24 @@ fn table_semver_list_colors() -> Result {
         .expect_value_eq(colored)
 }
 
+/// A bare single semver also keeps type-specific coloring (rendered as a one-row list).
+#[test]
+fn table_semver_single_colors() -> Result {
+    let colored = indoc! {"
+        \u{1b}[39m╭───┬───────╮\u{1b}[0m
+        \u{1b}[39m│\u{1b}[0m \u{1b}[1;32m0\u{1b}[0m \u{1b}[39m│\u{1b}[0m \u{1b}[1;36m1.0.0\u{1b}[0m \u{1b}[39m│\u{1b}[0m
+        \u{1b}[39m╰───┴───────╯\u{1b}[0m
+    "};
+    test()
+        .run(
+            "
+                $env.config.use_ansi_coloring = true
+                '1.0.0' | into semver | table
+            ",
+        )
+        .expect_value_eq(colored)
+}
+
 #[test]
 fn table_empty_colors() -> Result {
     let mut tester = test();


### PR DESCRIPTION
## Description

There are 2 tweaks in this PR.
1. semver types should show up as cyan_bold in tables. there was a bug that prevented this before.
2. `into semver` and `into semver-range` now support a `--loose` flag to indicate that it's not strictly checking for semver versions because it allows a variety of `v` prefixes: `v1.2.3`, `v.1.2.3`, `v:1.2.3`, `v-1.2.3`, `v_1.2.3`

## User-facing changes (Release notes)

### Added loose `semver` parsing and `semver` table coloring

- semver types should show up as cyan_bold in tables
- `into semver` and `into semver-range` add the `--loose` command to support a variety of `v` prefixes: `v1.2.3`, `v.1.2.3`, `v:1.2.3`, `v-1.2.3`, `v_1.2.3`


## Additional notes
closes https://github.com/nushell/nushell/issues/18818
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->