### PR TITLE
bug: make `$ans` work better with TUIs

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -539,8 +539,10 @@ fn store_byte_stream_prefix(
     // decoded to string, matching [`ByteStream::into_value`].
     let trim_trailing_newline = stream.source().is_external();
 
-    // No capturable bytes (e.g. stdout was null or still inherited). Do not replace
-    // a prior `$ans.last` with empty binary; leave the stream for print/wait.
+    // No capturable bytes (e.g. stdout was null or still inherited/TTY). Do not
+    // replace a prior `$ans.last` with empty binary; leave the stream for print/wait.
+    // Bare interactive externals keep inherited stdout so TUI tools (`nvim`, `btm`)
+    // still attach to the real terminal — capturing them would require a pipe and hang.
     let has_stdout = match stream.source() {
         ByteStreamSource::Read(_) | ByteStreamSource::File(_) => true,
         ByteStreamSource::Child(child) => child.stdout.is_some(),

--- a/crates/nu-cli/tests/last_result.rs
+++ b/crates/nu-cli/tests/last_result.rs
@@ -497,14 +497,32 @@ fn engine_stats_reports_last_result_sizes() -> Result {
 
 #[test]
 #[deps(TESTBIN_NONU)]
-fn external_command_stdout_is_stored_as_string() -> Result {
-    // Bare external UTF-8 stdout is decoded for `$ans.last` (no decode step).
+fn bare_external_with_inherited_stdout_does_not_capture() -> Result {
+    // Bare externals keep stdout on the TTY (Print/Inherit). Forcing a pipe for
+    // `$ans` would hang interactive tools (nvim, btm). Prior `.last` is left alone.
+    let mut session = Interactive::new();
+    session.run("42");
+    assert_eq!(session.last_payload()?, Value::test_int(42));
+
+    session.run("^nonu should_not_overwrite_last");
+    assert_eq!(
+        session.last_payload()?,
+        Value::test_int(42),
+        "bare external must not steal TTY stdout or clobber $ans.last"
+    );
+    Ok(())
+}
+
+#[test]
+#[deps(TESTBIN_NONU)]
+fn external_command_stdout_is_stored_when_piped() -> Result {
+    // External UTF-8 bytes enter `$ans.last` only when already in the pipeline.
     // Structured internal results still take the Value/ListStream paths unchanged.
     // Testbins live in `crates/testbins` and are built via `#[deps(TESTBIN_*)]`.
     let marker = "last_external_marker_xyz";
     let mut session = Interactive::new();
-    // `nonu` prints args with no trailing newline.
-    session.run(&format!("^nonu {marker}"));
+    // `nonu` prints args with no trailing newline; `| collect` pipes stdout.
+    session.run(&format!("^nonu {marker} | collect"));
 
     assert_eq!(session.last_payload()?, Value::test_string(marker));
     Ok(())
@@ -514,9 +532,9 @@ fn external_command_stdout_is_stored_as_string() -> Result {
 #[deps(TESTBIN_COCOCO)]
 fn external_command_trailing_newline_is_trimmed_in_last() -> Result {
     // Match ByteStream::into_value / complete: one trailing newline is stripped.
-    // `cococo` uses println! (trailing `\n`).
+    // `cococo` uses println! (trailing `\n`). Pipe so bytes are capturable.
     let mut session = Interactive::new();
-    session.run("^cococo trim_me");
+    session.run("^cococo trim_me | collect");
 
     let stored = session.last_payload()?;
     match stored {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -205,28 +205,16 @@ If you create a custom command with this name, that will be used instead."
 
         // Configure stdout and stderr. If both are set to `OutDest::Pipe`,
         // we'll set up a pipe that merges two streams into one.
+        //
+        // Do **not** force-pipe bare external stdout for interactive `$ans` capture.
+        // Replacing `Print`/`Inherit` with a pipe steals the TTY from full-screen /
+        // interactive tools (`nvim`, `btm`, etc.): they hang or misbehave because
+        // `isatty(stdout)` is false and `store_byte_stream_prefix` blocks reading the
+        // pipe. Bare externals keep the terminal; `$ans.last` only receives external
+        // bytes when stdout is already redirected into the pipeline (e.g. `^cmd | collect`).
         let stdout = stack.stdout();
         let stderr = stack.stderr();
-
-        // Interactive `$ans` capture needs a readable stdout. `Print`/`Inherit` would
-        // write straight to the terminal with no bytes for `maybe_store_last_result`,
-        // which previously stored empty binary. Pipe instead so the REPL can tee a
-        // prefix into `$ans.last` and still print the stream (TTY-aware tools may change
-        // formatting when not on a real TTY — same tradeoff as `| complete`).
-        let pipe_stdout = OutDest::Pipe;
-        let capture_stdout_for_last = engine_state.is_interactive
-            && engine_state.capture_repl_last_result
-            && matches!(stdout, OutDest::Print | OutDest::Inherit)
-            && stack.get_config(engine_state).last_result_size_bytes() > 0;
-        let effective_stdout = if capture_stdout_for_last {
-            &pipe_stdout
-        } else {
-            stdout
-        };
-
-        let merged_stream = if matches!(effective_stdout, OutDest::Pipe)
-            && matches!(stderr, OutDest::Pipe)
-        {
+        let merged_stream = if matches!(stdout, OutDest::Pipe) && matches!(stderr, OutDest::Pipe) {
             let (reader, writer) =
                 os_pipe::pipe().map_err(|err| IoError::new(err, call.head, None))?;
             command.stdout(
@@ -238,13 +226,12 @@ If you create a custom command with this name, that will be used instead."
             Some(reader)
         } else {
             if engine_state.is_background_job()
-                && matches!(effective_stdout, OutDest::Inherit | OutDest::Print)
+                && matches!(stdout, OutDest::Inherit | OutDest::Print)
             {
                 command.stdout(Stdio::null());
             } else {
                 command.stdout(
-                    Stdio::try_from(effective_stdout)
-                        .map_err(|err| IoError::new(err, call.head, None))?,
+                    Stdio::try_from(stdout).map_err(|err| IoError::new(err, call.head, None))?,
                 );
             }
 

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -127,8 +127,10 @@ $env.config.recursion_limit = 50
 # its memory is freed. `$ans.exit_code` and `$ans.duration` are still updated.
 # When a result exceeds the limit, it is truncated to fit and a warning is shown
 # the next time you access `$ans`. Bare `$ans` / `$ans.*` cell-paths do not
-# overwrite `$ans.last`. External command output is stored as a string when UTF-8,
-# or as binary otherwise. The name `ans` is reserved and cannot be rebound with `let`.
+# overwrite `$ans.last`. External command output is stored only when it is already
+# in the pipeline (e.g. `^cmd | collect`); bare externals keep the real TTY so
+# interactive tools like nvim/btm work. Piped external bytes become a string when
+# UTF-8, or binary otherwise. The name `ans` is reserved and cannot be rebound with `let`.
 # Default: 0b
 $env.config.last_result_size = 0b
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR tries to address this problem that was reported on Discord by @woosaaahh 

On both linux and windows, if I set $env.config.last_result_size to something else than 0B, some tools doesn't work properly or "hang".
You can see in the video with btm (bottom).
If I try to open nvim, it hangs but with fzf no problems.
Tried and reproduced on both Linux and Windows.
On Windows, I tried to run nushell:
- directly by double-click on the *.exe
- from cmd.exe with or without zellij
- from Windows Terminal
- from alacritty with or without zellij
and every time the bug happen.
On Linux I only tried via alacritty with or without zellij and it also have this issue.


## User-facing changes (Release notes)
`$ans` works with TUIs better

<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->