### PR TITLE
Fix module item completion

### DIFF
--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -199,14 +199,11 @@ impl<'a> ArgValueCompletion<'a> {
     ) -> Fetched {
         let cursor_position = self.cursor;
 
-        let Some(item) = items
+        let item_span = items
             .iter()
-            .find(|item| touches(item.expr().span, cursor_position))
-        else {
-            return Fetched::pure(vec![]);
-        };
-
-        let item_span = item.expr().span;
+            .map(|item| item.expr().span)
+            .find(|item_span| touches(*item_span, cursor_position))
+            .unwrap_or(Span::point(cursor_position));
 
         // The member's typed text is the tail of `completion_context.prefix`, from
         // the member's start onward; the cursor-sliced buffer already ends it.

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -199,39 +199,38 @@ impl<'a> ArgValueCompletion<'a> {
     ) -> Fetched {
         let cursor_position = self.cursor;
 
-        for item in items {
-            let item_span = item.expr().span;
+        let Some(item) = items
+            .iter()
+            .find(|item| touches(item.expr().span, cursor_position))
+        else {
+            return Fetched::pure(vec![]);
+        };
 
-            if !touches(item_span, cursor_position) {
-                continue;
-            }
+        let item_span = item.expr().span;
 
-            // The member's typed text is the tail of `completion_context.prefix`, from
-            // the member's start onward; the cursor-sliced buffer already ends it.
-            let relative_offset = item_span
-                .start
-                .saturating_sub(completion_context.span.start);
-            let sliced_prefix = completion_context
-                .prefix
-                .get(relative_offset..)
-                .unwrap_or_default();
+        // The member's typed text is the tail of `completion_context.prefix`, from
+        // the member's start onward; the cursor-sliced buffer already ends it.
+        let relative_offset = item_span
+            .start
+            .saturating_sub(completion_context.span.start);
+        let sliced_prefix = completion_context
+            .prefix
+            .get(relative_offset..)
+            .unwrap_or_default();
 
-            let new_span = Span::new(
-                item_span.start,
-                completion_context.span.end.min(item_span.end),
-            );
+        let new_span = Span::new(
+            item_span.start,
+            completion_context.span.end.min(item_span.end),
+        );
 
-            let item_context = self.completer.context(
-                completion_context.working_set,
-                new_span,
-                sliced_prefix,
-                completion_context.offset,
-            );
+        let item_context = self.completer.context(
+            completion_context.working_set,
+            new_span,
+            sliced_prefix,
+            completion_context.offset,
+        );
 
-            return exportable_completion.fetch(&item_context);
-        }
-
-        Fetched::pure(vec![])
+        exportable_completion.fetch(&item_context)
     }
 
     fn fetch_fallback_completion(

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -145,10 +145,8 @@ impl<'a> ArgValueCompletion<'a> {
                 ),
                 _ => Fetched::pure(vec![]),
             },
-            // No expression at all (e.g. a missing/undefined argument).
-            None => Fetched::pure(vec![]),
-            // Any other scalar shape (`Expr::String`, plus `Expr::Nothing` for the
-            // `null` keyword): search exports by the raw prefix text.
+            // No expression at all or any other scalar shape (`Expr::String`, plus `Expr::Nothing`
+            // for the `null` keyword): search exports by the raw prefix text.
             _ => exportable_completion.fetch(completion_context),
         };
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1134,6 +1134,16 @@ fn exportable_completions() {
     let suggestions = completer.complete_blocking(completion_str, completion_str.len());
     match_suggestions(&vec!["TAU"], &suggestions);
 
+    // without providing any prefix to match items against
+    let completion_str = "use std/math ";
+    let suggestions = completer.complete_blocking(completion_str, completion_str.len());
+    match_suggestions(&vec!["GAMMA", "E", "PI", "TAU", "PHI"], &suggestions);
+
+    // without a prefix within the list style importy
+    let completion_str = "use std/math [";
+    let suggestions = completer.complete_blocking(completion_str, completion_str.len());
+    match_suggestions(&vec!["GAMMA", "E", "PI", "TAU", "PHI"], &suggestions);
+
     let completion_str = "use 🤔🐘 'foo";
     let suggestions = completer.complete_blocking(completion_str, completion_str.len());
     match_suggestions(&vec!["foo"], &suggestions);


### PR DESCRIPTION
## Description

```nushell
# _ represents cursor position
# no completions
use std/iter _

# completions
use std/iter "_
# => find
# => find-index
# => intersperse
# => ...

"# similarly with the list syntax
# no completions
use std/iter [_

]# completions
use std/iter ["_
# => find
# => find-index
# => intersperse
# => ...
```

Marking as `notes:mention` rather than `notes:fix` because this regression happened after the last release and so wasn't exposed in any releases.

## User-facing changes (Release notes)
Fixed module item completion for `use` commands to work without a string for possible items to match against.