### PR TITLE
fix(config): match unnamed keybindings by the key they bind

### DIFF
--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -593,9 +593,10 @@ $env.config.hooks.command_not_found = null
 # etc.). Inspect with `$env.config.keybindings`. Reedline's base emacs/vi maps are
 # still applied underneath and are listed by `keybindings default`.
 #
-# Full list replacement (`=`) clears Nushell menu bindings. Prefer `++=` to add,
-# or set `event: null` on a matching binding to unbind a key.
-# $env.config.keybindings = []
+# Assigning this list merges into the defaults rather than replacing them, so
+# `=` never clears the Nushell menu bindings. Entries are matched by `name`,
+# or by modifier/keycode/mode when unnamed; a match is overwritten, anything
+# else appended. Set `event: null` on a matching binding to unbind a key.
 
 # Example: Add Alt+. keybinding to insert the last token from previous command:
 # $env.config.keybindings ++= [
@@ -655,9 +656,8 @@ $env.config.abbreviations = {}
 # after its value. Unset keeps reedline's default.
 #
 # Default: completion_menu, ide_completion_menu, history_menu, help_menu.
-# Inspect with `$env.config.menus`. Full list replacement (`=`) clears defaults;
-# prefer `++=` to add custom menus.
-# $env.config.menus = []
+# Inspect with `$env.config.menus`. Assigning this list merges into the
+# defaults by `name` rather than replacing them, so `=` never clears them.
 
 # Example: Custom completion menu configuration:
 # $env.config.menus ++= [{

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -267,23 +267,25 @@ impl UpdateFromValue for Config {
                 "keybindings" => match Vec::<ParsedKeybinding>::from_value(val.clone()) {
                     Ok(keybindings) => {
                         for keybinding in keybindings {
-                            let target_name = keybinding
-                                .name
-                                .as_ref()
-                                .map(|name| name.to_expanded_string("", self));
-
-                            let found_index = target_name.as_ref().and_then(|name_to_match| {
+                            // An unnamed binding has no name to merge on, so match it on
+                            // the key it binds. Otherwise it matches nothing and is
+                            // appended again on every assignment, growing the list each
+                            // time a config is re-sourced.
+                            let found_index =
                                 self.keybindings.iter().position(|existing_keybinding| {
-                                    existing_keybinding
-                                        .name
-                                        .as_ref()
-                                        .map(|existing_name| {
-                                            existing_name.to_expanded_string("", self)
-                                        })
-                                        .as_ref()
-                                        == Some(name_to_match)
-                                })
-                            });
+                                    match (&keybinding.name, &existing_keybinding.name) {
+                                        (Some(name), Some(existing_name)) => {
+                                            name.to_expanded_string("", self)
+                                                == existing_name.to_expanded_string("", self)
+                                        }
+                                        (None, None) => {
+                                            keybinding.modifier == existing_keybinding.modifier
+                                                && keybinding.keycode == existing_keybinding.keycode
+                                                && keybinding.mode == existing_keybinding.mode
+                                        }
+                                        _ => false,
+                                    }
+                                });
 
                             if let Some(index) = found_index {
                                 self.keybindings[index] = keybinding;
@@ -416,5 +418,42 @@ mod tests {
                 "default keybinding {name:?} was lost after reassigning `keybindings`"
             );
         }
+    }
+
+    /// Guards the unnamed case: with no `name` to merge on, every reassignment
+    /// used to append another copy.
+    #[test]
+    fn reassigning_an_unnamed_keybinding_does_not_duplicate_it() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        let mut unnamed = old.keybindings[0].clone();
+        unnamed.name = None;
+        unnamed.modifier = Value::test_string("alt");
+        unnamed.keycode = Value::test_string("char_j");
+        new.keybindings.push(unnamed);
+
+        let expected = new.keybindings.len();
+
+        // Feed the list back through `update_from_value` the way re-sourcing a
+        // config (or any `$env.config.keybindings = ...`) does.
+        for _ in 0..2 {
+            let value = Value::test_record(record! {
+                "keybindings" => Value::test_list(
+                    new.keybindings
+                        .iter()
+                        .map(|keybinding| keybinding.clone().into_value(Span::test_data()))
+                        .collect(),
+                ),
+            });
+            new.update_from_value(&old, &value)
+                .expect("update should succeed");
+        }
+
+        assert_eq!(
+            new.keybindings.len(),
+            expected,
+            "reassigning `keybindings` duplicated the unnamed binding"
+        );
     }
 }


### PR DESCRIPTION
## Description

#18761 swapped the wholesale `self.keybindings = keybindings` assignment for a loop that merges each incoming binding into the existing list, matching on `name`.
`name` is `Option<Value>` on `ParsedKeybinding`, so an unnamed binding matches nothing and falls through to the `push`, every time.
Re-sourcing a config therefore grows the list by one entry per unnamed binding on each pass.

The fix matches on the identity reedline already keys a binding by: named bindings compare on the expanded `name`, unnamed ones on `modifier`, `keycode` and `mode`, and a named/unnamed pair never matches.

Also fixes `doc_config.nu`, which still claimed a full list replacement (`=`) clears the defaults for `keybindings` and `menus`.
That was true when #18747 wrote it, but #18761 made both assignments no-ops without updating the text, so I dropped the two commented examples.

Worth landing before 0.115, since neither PR has shipped yet (last tag is 0.114.1).

## User-facing changes (Release notes)

### Fixed config reloads duplicating unnamed keybindings

Assigning `$env.config.keybindings` or `$env.config.menus` now merges into the defaults rather than replacing them, so `$env.config.keybindings = []` and `$env.config.menus = []` no longer clear anything.
Set `event: null` on a matching binding to unbind a key.

## Additional notes

The merge change rode in on #18761 alongside a large amount of unrelated completer work, which is probably why the doc drift went unnoticed.

Out of scope: the merge still has no way to drop a binding outright.