### PR TITLE
chore(reedline): bump to latest reedline commit 6b9115d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.49.0"
-source = "git+https://github.com/nushell/reedline?branch=main#e4fe8edfb28440614e58a8c9dba78d128783f70f"
+source = "git+https://github.com/nushell/reedline?branch=main#6b9115d6dc03940c3856c62cd40ec42400716ee1"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
## Description

Updates the pinned reedline commit from e4fe8ed to 6b9115d, pulling in three fixes
Moslty regressions introduced by the completer changes:

- nushell/reedline#1133: the prompt no longer redraws over output an external program scrolled onto the screen (fzf-style external completers, `$EDITOR`), and re-anchors to the cursor instead of jumping to the top.
- nushell/reedline#1144: menu completion decisions are made once an asynchronous completer answers: a lone suggestion arriving late is still accepted outright, a shared prefix is still spliced, an answer for a line the user has moved on from is dropped, and an opening menu stays off screen until it has something to show.
- nushell/reedline#1145: leaving the line editor (Ctrl+C, submit) erases menus and hints below the cursor, so host output like `pre_prompt` spacing starts on a clean row.

## User-facing changes (Release notes)

## Additional notes

After some more review and testing I decided to get this in before the release. These are geniune fixes and are well supported by tests.
Blast-radius should be quite low.

Helix-mode will be merged after this one lands.
