### PR TITLE
chore(reedline): bump reedline to 61715da including helix-mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.49.0"
-source = "git+https://github.com/nushell/reedline?branch=main#6b9115d6dc03940c3856c62cd40ec42400716ee1"
+source = "git+https://github.com/nushell/reedline?branch=main#61715da7b99b3d38dbd26f00dfaa2a5ef6316b3c"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,6 +451,14 @@ system-clipboard = [
   "nu-cli/system-clipboard",
 ]
 
+# Experimental Helix/Kakoune-style edit mode from `reedline` (`$env.config.edit_mode = "helix"`).
+# Opt-in while the implementation stabilizes.
+helix = [
+  "nu-cli/helix",
+  "nu-command/helix",
+  "reedline/helix",
+]
+
 # Stable (Default)
 trash-support = ["nu-command/trash-support"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,10 @@ ratatui = { version = "0.30", default-features = false, features = [
   #"underline-color" # leave out so we don't bring in termwiz
 ] }
 rayon = "1.12.0"
-reedline = "0.49.0"
+# default-features = false keeps reedline's default-on `helix` feature keyed to
+# the workspace `helix` feature chain, so nu-cli's cfg-gated glue and reedline's
+# helix types stay in lockstep even when a crate is built standalone.
+reedline = { version = "0.49.0", default-features = false }
 regex = "1.13.1"
 rmp = "0.8.15"
 rmp-serde = "1.3.1"
@@ -392,6 +395,7 @@ tempfile = { workspace = true }
 # Enable all features while still avoiding mutually exclusive features.
 # Use this if `--all-features` fails.
 full = [
+  "helix",
   "lsp",
   "mcp",
   "network",
@@ -429,6 +433,7 @@ native-tls = ["nu-command/native-tls"]
 rustls-tls = ["nu-command/rustls-tls"]
 
 default = [
+  "helix",
   "lsp",
   "mcp",
   "network",
@@ -451,8 +456,8 @@ system-clipboard = [
   "nu-cli/system-clipboard",
 ]
 
-# Experimental Helix/Kakoune-style edit mode from `reedline` (`$env.config.edit_mode = "helix"`).
-# Opt-in while the implementation stabilizes.
+# Helix/Kakoune-style edit mode from `reedline` (`$env.config.edit_mode = "helix"`).
+# Enabled by default; opt out for a build without the mode.
 helix = [
   "nu-cli/helix",
   "nu-command/helix",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -61,6 +61,7 @@ which = { workspace = true }
 [features]
 plugin = ["nu-plugin-engine"]
 system-clipboard = ["reedline/system_clipboard"]
+helix = ["reedline/helix"]
 sqlite = ["reedline/sqlite", "nu-protocol/sqlite", "nu-command/sqlite"]
 
 [lints]

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,6 +1,8 @@
 use nu_protocol::engine::{PromptContents, PromptState};
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
+#[cfg(feature = "helix")]
+use reedline::PromptHelixMode;
 use reedline::{
     DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
     PromptViMode,
@@ -135,6 +137,16 @@ fn indicator_for(contents: &PromptContents, edit_mode: PromptEditMode) -> String
         }
         PromptEditMode::Vi(PromptViMode::Visual) => {
             contents.vi_normal.as_deref().unwrap_or("v ").to_string()
+        }
+        // Helix reuses the vi indicators; normal and select share one, as they
+        // share a keybinding table.
+        #[cfg(feature = "helix")]
+        PromptEditMode::Helix(PromptHelixMode::Normal | PromptHelixMode::Select) => {
+            contents.vi_normal.as_deref().unwrap_or("> ").to_string()
+        }
+        #[cfg(feature = "helix")]
+        PromptEditMode::Helix(PromptHelixMode::Insert) => {
+            contents.vi_insert.as_deref().unwrap_or(": ").to_string()
         }
         PromptEditMode::Custom(str) => format!("({str})"),
     }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -688,6 +688,17 @@ fn add_keybinding(
             Ok(PEMD::HelixNormal | PEMD::HelixSelect) => {
                 add_parsed_keybinding(&mut tables.helix_normal, keybinding, config)
             }
+            // The default keybindings name the helix tables unconditionally, so
+            // a build without the `helix` feature skips them rather than
+            // rejecting a mode it has no table to bind into.
+            #[cfg(not(feature = "helix"))]
+            _ if matches!(
+                val.as_str(),
+                "helix_normal" | "helix_insert" | "helix_select"
+            ) =>
+            {
+                Ok(())
+            }
             Ok(PEMD::Default | PEMD::Custom) | Err(_) => Err(ShellError::InvalidValue {
                 valid: VALID_KEYBINDING_MODES.into(),
                 actual: format!("'{val}'"),
@@ -2071,9 +2082,46 @@ mod test {
     #[test]
     fn default_config_keybindings_apply() {
         // Nushell menu keybindings on Config::default must parse as valid reedline events.
+        // Without the `helix` feature this also covers the helix modes the defaults
+        // name but this build has no table for.
         let config = Config::default();
         assert!(!config.keybindings.is_empty());
         assert!(!config.menus.is_empty());
         create_keybindings(&config).expect("default keybindings should apply cleanly");
+    }
+
+    #[test]
+    #[cfg(feature = "helix")]
+    fn default_config_binds_menu_keys_in_helix_mode() {
+        // The Nushell menu keybindings are mode-scoped; helix missing from that
+        // list left Tab and the other menu keys unbound in both helix tables.
+        let config = Config {
+            edit_mode: EditBindings::Helix,
+            ..Default::default()
+        };
+        let KeybindingsMode::Helix {
+            insert_keybindings,
+            normal_keybindings,
+        } = create_keybindings(&config).expect("default keybindings should apply cleanly")
+        else {
+            panic!("`edit_mode: helix` should produce helix keybindings");
+        };
+
+        for (table, keybindings) in [
+            ("insert", insert_keybindings),
+            ("normal", normal_keybindings),
+        ] {
+            for (name, modifier, keycode) in [
+                ("completion_menu", KeyModifiers::NONE, KeyCode::Tab),
+                ("completion_previous", KeyModifiers::SHIFT, KeyCode::BackTab),
+                ("history_menu", KeyModifiers::CONTROL, KeyCode::Char('r')),
+                ("help_menu", KeyModifiers::NONE, KeyCode::F(1)),
+            ] {
+                assert!(
+                    keybindings.find_binding(modifier, keycode).is_some(),
+                    "`{name}` should be bound in the helix {table} table"
+                );
+            }
+        }
     }
 }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -15,6 +15,8 @@ use reedline::{
     TraversalDirection, WordEdge, WordKind, default_emacs_keybindings,
     default_vi_insert_keybindings, default_vi_normal_keybindings,
 };
+#[cfg(feature = "helix")]
+use reedline::{default_helix_insert_keybindings, default_helix_normal_keybindings};
 use std::{str::FromStr, sync::Arc};
 
 // Adds all menus from `$env.config.menus` (defaults live on `Config::default()`).
@@ -597,6 +599,24 @@ pub enum KeybindingsMode {
         insert_keybindings: Keybindings,
         normal_keybindings: Keybindings,
     },
+    #[cfg(feature = "helix")]
+    Helix {
+        insert_keybindings: Keybindings,
+        normal_keybindings: Keybindings,
+    },
+}
+
+/// The per-mode keybinding tables a parsed `$env.config.keybindings` entry can
+/// target, seeded with reedline's defaults.
+struct KeybindingTables {
+    emacs: Keybindings,
+    vi_insert: Keybindings,
+    vi_normal: Keybindings,
+    #[cfg(feature = "helix")]
+    helix_insert: Keybindings,
+    /// Shared by helix normal and select mode; reedline keeps one table for both.
+    #[cfg(feature = "helix")]
+    helix_normal: Keybindings,
 }
 
 pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, ShellError> {
@@ -604,62 +624,79 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
 
     // Reedline base maps stay library-owned; Nushell menu bindings live on
     // `config.keybindings` (including defaults from `Config::default()`).
-    let mut emacs_keybindings = default_emacs_keybindings();
-    let mut insert_keybindings = default_vi_insert_keybindings();
-    let mut normal_keybindings = default_vi_normal_keybindings();
+    let mut tables = KeybindingTables {
+        emacs: default_emacs_keybindings(),
+        vi_insert: default_vi_insert_keybindings(),
+        vi_normal: default_vi_normal_keybindings(),
+        #[cfg(feature = "helix")]
+        helix_insert: default_helix_insert_keybindings(),
+        #[cfg(feature = "helix")]
+        helix_normal: default_helix_normal_keybindings(),
+    };
 
     for keybinding in parsed_keybindings {
-        add_keybinding(
-            &keybinding.mode,
-            keybinding,
-            config,
-            &mut emacs_keybindings,
-            &mut insert_keybindings,
-            &mut normal_keybindings,
-        )?
+        add_keybinding(&keybinding.mode, keybinding, config, &mut tables)?
     }
 
     match config.edit_mode {
-        EditBindings::Emacs => Ok(KeybindingsMode::Emacs(emacs_keybindings)),
+        EditBindings::Emacs => Ok(KeybindingsMode::Emacs(tables.emacs)),
         EditBindings::Vi => Ok(KeybindingsMode::Vi {
-            insert_keybindings,
-            normal_keybindings,
+            insert_keybindings: tables.vi_insert,
+            normal_keybindings: tables.vi_normal,
         }),
+        #[cfg(feature = "helix")]
+        EditBindings::Helix => Ok(KeybindingsMode::Helix {
+            insert_keybindings: tables.helix_insert,
+            normal_keybindings: tables.helix_normal,
+        }),
+        #[cfg(not(feature = "helix"))]
+        EditBindings::Helix => Err(ShellError::Generic(
+            nu_protocol::shell_error::generic::GenericError::new_internal(
+                "helix mode is not available in this build of nushell",
+                "`$env.config.edit_mode = \"helix\"` requires a build with the `helix` feature",
+            )
+            .with_help("rebuild nushell with `--features helix`"),
+        )),
     }
 }
+
+#[cfg(feature = "helix")]
+const VALID_KEYBINDING_MODES: &str =
+    "'emacs', 'vi_insert', 'vi_normal', 'helix_insert', 'helix_normal', or 'helix_select'";
+#[cfg(not(feature = "helix"))]
+const VALID_KEYBINDING_MODES: &str = "'emacs', 'vi_insert', or 'vi_normal'";
 
 fn add_keybinding(
     mode: &Value,
     keybinding: &ParsedKeybinding,
     config: &Config,
-    emacs_keybindings: &mut Keybindings,
-    insert_keybindings: &mut Keybindings,
-    normal_keybindings: &mut Keybindings,
+    tables: &mut KeybindingTables,
 ) -> Result<(), ShellError> {
     use PromptEditModeDiscriminants as PEMD;
     let span = mode.span();
     match &mode {
         // When updating this implementation, also update `display_edit_mode` function
         Value::String { val, .. } => match PEMD::from_str(val) {
-            Ok(PEMD::Emacs) => add_parsed_keybinding(emacs_keybindings, keybinding, config),
-            Ok(PEMD::ViInsert) => add_parsed_keybinding(insert_keybindings, keybinding, config),
-            Ok(PEMD::ViNormal) => add_parsed_keybinding(normal_keybindings, keybinding, config),
+            Ok(PEMD::Emacs) => add_parsed_keybinding(&mut tables.emacs, keybinding, config),
+            Ok(PEMD::ViInsert) => add_parsed_keybinding(&mut tables.vi_insert, keybinding, config),
+            Ok(PEMD::ViNormal) => add_parsed_keybinding(&mut tables.vi_normal, keybinding, config),
+            #[cfg(feature = "helix")]
+            Ok(PEMD::HelixInsert) => {
+                add_parsed_keybinding(&mut tables.helix_insert, keybinding, config)
+            }
+            #[cfg(feature = "helix")]
+            Ok(PEMD::HelixNormal | PEMD::HelixSelect) => {
+                add_parsed_keybinding(&mut tables.helix_normal, keybinding, config)
+            }
             Ok(PEMD::Default | PEMD::Custom) | Err(_) => Err(ShellError::InvalidValue {
-                valid: "'emacs', 'vi_insert', or 'vi_normal'".into(),
+                valid: VALID_KEYBINDING_MODES.into(),
                 actual: format!("'{val}'"),
                 span,
             }),
         },
         Value::List { vals, .. } => {
             for inner_mode in vals {
-                add_keybinding(
-                    inner_mode,
-                    keybinding,
-                    config,
-                    emacs_keybindings,
-                    insert_keybindings,
-                    normal_keybindings,
-                )?
+                add_keybinding(inner_mode, keybinding, config, tables)?
             }
 
             Ok(())
@@ -678,6 +715,12 @@ pub(crate) fn display_edit_mode(mode: PromptEditModeDiscriminants) -> Option<Str
         PromptEditModeDiscriminants::Emacs => Some("emacs".into()),
         PromptEditModeDiscriminants::ViNormal => Some("vi_normal".into()),
         PromptEditModeDiscriminants::ViInsert => Some("vi_insert".into()),
+        #[cfg(feature = "helix")]
+        PromptEditModeDiscriminants::HelixNormal => Some("helix_normal".into()),
+        #[cfg(feature = "helix")]
+        PromptEditModeDiscriminants::HelixInsert => Some("helix_insert".into()),
+        #[cfg(feature = "helix")]
+        PromptEditModeDiscriminants::HelixSelect => Some("helix_select".into()),
         PromptEditModeDiscriminants::Default | PromptEditModeDiscriminants::Custom => None,
     }
 }
@@ -1217,6 +1260,10 @@ fn edit_from_record(
             EditCommand::MoveLeftBefore { c: char, select }
         }
         Ok(ECD::SelectAll) => EditCommand::SelectAll,
+        #[cfg(feature = "helix")]
+        Ok(ECD::SelectLine) => EditCommand::SelectLine,
+        #[cfg(feature = "helix")]
+        Ok(ECD::EraseSelection) => EditCommand::EraseSelection,
         Ok(ECD::CutSelection) => EditCommand::CutSelection {
             granularity: parse_granularity(record, config, span)?,
         },
@@ -1306,6 +1353,7 @@ fn edit_from_record(
         // `Granularity`) parsed from the same record. See `parse_motion_target`.
         Ok(ECD::Move) => EditCommand::Move(parse_motion_target(record, config, span)?),
         Ok(ECD::Extend) => EditCommand::Extend(parse_motion_target(record, config, span)?),
+        Ok(ECD::Select) => EditCommand::Select(parse_motion_target(record, config, span)?),
         Ok(ECD::Erase) => EditCommand::Erase(parse_motion_target(record, config, span)?),
         Ok(ECD::Cut) => EditCommand::Cut {
             target: parse_motion_target(record, config, span)?,
@@ -1318,6 +1366,17 @@ fn edit_from_record(
         Ok(ECD::Change) => EditCommand::Change {
             target: parse_motion_target(record, config, span)?,
             granularity: parse_granularity(record, config, span)?,
+        },
+        Ok(ECD::CollapseSelection) => {
+            EditCommand::CollapseSelection(parse_direction(record, config, span)?)
+        }
+        Ok(ECD::PasteAtSelectionEdge) => EditCommand::PasteAtSelectionEdge {
+            direction: parse_direction(record, config, span)?,
+            count: extract_value("count", record, span)
+                .and_then(|value| value.as_int())
+                .ok()
+                .and_then(|count| usize::try_from(count).ok())
+                .unwrap_or(1),
         },
         // `EditCommand::ReplaceChars` - Internal hack not sanely implementable as a
         // standalone binding
@@ -1403,6 +1462,10 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::CutLeftUntil => "CutLeftUntil value: <char>",
         ECD::CutLeftBefore => "CutLeftBefore value: <char>",
         ECD::SelectAll => "SelectAll",
+        #[cfg(feature = "helix")]
+        ECD::SelectLine => "SelectLine",
+        #[cfg(feature = "helix")]
+        ECD::EraseSelection => "EraseSelection",
         ECD::CutSelection => "CutSelection granularity?: <string>",
         ECD::CopySelection => "CopySelection",
         ECD::LowercaseSelection => "LowercaseSelection",
@@ -1448,6 +1511,9 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::Extend => {
             "Extend motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
         }
+        ECD::Select => {
+            "Select motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
+        }
         ECD::Erase => {
             "Erase motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>"
         }
@@ -1460,6 +1526,8 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::Change => {
             "Change motion: <string>, direction: <string>, word_kind?: <string>, edge?: <string>, char?: <char>, stop?: <string>, granularity?: <string>"
         }
+        ECD::CollapseSelection => "CollapseSelection direction: <string>",
+        ECD::PasteAtSelectionEdge => "PasteAtSelectionEdge direction: <string>, count?: <int>",
         ECD::ReplaceChars => return None,
     })
 }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -35,6 +35,8 @@ use nu_utils::{
     filesystem::{PermissionResult, have_permission},
     perf, stderr_write_all_and_flush, stdout_write_all_and_flush,
 };
+#[cfg(feature = "helix")]
+use reedline::Helix;
 #[cfg(feature = "sqlite")]
 use reedline::SqliteBackedHistory;
 use reedline::{
@@ -605,6 +607,12 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         vi_insert: map_nucursorshape_to_cursorshape(config.cursor_shape.vi_insert),
         vi_normal: map_nucursorshape_to_cursorshape(config.cursor_shape.vi_normal),
         emacs: map_nucursorshape_to_cursorshape(config.cursor_shape.emacs),
+        #[cfg(feature = "helix")]
+        hx_insert: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_insert),
+        #[cfg(feature = "helix")]
+        hx_normal: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_normal),
+        #[cfg(feature = "helix")]
+        hx_select: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_select),
     };
     perf!("get config/cursor config", start_time, use_color);
 
@@ -1337,6 +1345,18 @@ fn setup_keybindings(engine_state: &EngineState, line_editor: Reedline) -> Reedl
                 normal_keybindings,
             } => {
                 let edit_mode = Box::new(Vi::new(insert_keybindings, normal_keybindings));
+                line_editor.with_edit_mode(edit_mode)
+            }
+            #[cfg(feature = "helix")]
+            KeybindingsMode::Helix {
+                insert_keybindings,
+                normal_keybindings,
+            } => {
+                let edit_mode = Box::new(
+                    Helix::default()
+                        .with_insert_keybindings(insert_keybindings)
+                        .with_normal_keybindings(normal_keybindings),
+                );
                 line_editor.with_edit_mode(edit_mode)
             }
         },

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -258,6 +258,8 @@ rustls-tls = [
 
 plugin = ["nu-parser/plugin", "nu-test-support/plugin", "os"]
 sqlite = ["rusqlite"]
+# Weak on `reedline` so the flag is inert without `os` (which pulls reedline in).
+helix = ["reedline?/helix"]
 trash-support = ["trash"]
 
 [dev-dependencies]

--- a/crates/nu-command/src/platform/input/reedline_prompt.rs
+++ b/crates/nu-command/src/platform/input/reedline_prompt.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "helix")]
+use reedline::PromptHelixMode;
 use reedline::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
 };
@@ -37,7 +39,20 @@ impl Prompt for ReedlinePrompt {
                 PromptViMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
                 PromptViMode::Visual => DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into(),
             },
+            #[cfg(feature = "helix")]
+            PromptEditMode::Helix(helix_mode) => match helix_mode {
+                PromptHelixMode::Normal | PromptHelixMode::Select => {
+                    DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into()
+                }
+                PromptHelixMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
+            },
             PromptEditMode::Custom(str) => format!("({str})").into(),
+            // Reedline's `helix` feature can be switched on by another crate in
+            // the build graph without this crate's `helix` feature following
+            // along; catch the then-uncovered variants instead of failing to
+            // compile.
+            #[allow(unreachable_patterns)]
+            _ => self.indicator.as_str().into(),
         }
     }
 

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -160,7 +160,7 @@ $env.config.clip.default_raw = false
 # "emacs": Use Emacs-style keybindings (default).
 # "vi": Use Vi-style keybindings with normal and insert modes.
 # "helix": Use Helix-style selection-first keybindings with normal, select, and
-#          insert modes. Only available in builds with the `helix` feature.
+#          insert modes. Requires the `helix` feature (enabled by default).
 # Default: "emacs"
 $env.config.edit_mode = "emacs"
 
@@ -191,7 +191,7 @@ $env.config.cursor_shape.vi_insert = "inherit"
 $env.config.cursor_shape.vi_normal = "inherit"
 
 # cursor_shape.helix_normal (string): Cursor shape when in helix normal mode.
-# Only takes effect in builds with the `helix` feature; likewise for
+# Requires the `helix` feature (enabled by default); likewise for
 # helix_select and helix_insert below.
 # One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
 # Default: "inherit"

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -159,6 +159,8 @@ $env.config.clip.default_raw = false
 # edit_mode (string): Sets the editing behavior of Reedline.
 # "emacs": Use Emacs-style keybindings (default).
 # "vi": Use Vi-style keybindings with normal and insert modes.
+# "helix": Use Helix-style selection-first keybindings with normal, select, and
+#          insert modes. Only available in builds with the `helix` feature.
 # Default: "emacs"
 $env.config.edit_mode = "emacs"
 
@@ -187,6 +189,23 @@ $env.config.cursor_shape.vi_insert = "inherit"
 # One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
 # Default: "inherit"
 $env.config.cursor_shape.vi_normal = "inherit"
+
+# cursor_shape.helix_normal (string): Cursor shape when in helix normal mode.
+# Only takes effect in builds with the `helix` feature; likewise for
+# helix_select and helix_insert below.
+# One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
+# Default: "inherit"
+$env.config.cursor_shape.helix_normal = "inherit"
+
+# cursor_shape.helix_select (string): Cursor shape when in helix select mode.
+# One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
+# Default: "inherit"
+$env.config.cursor_shape.helix_select = "inherit"
+
+# cursor_shape.helix_insert (string): Cursor shape when in helix insert mode.
+# One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
+# Default: "inherit"
+$env.config.cursor_shape.helix_insert = "inherit"
 
 # --------------------
 # Completions Behavior

--- a/crates/nu-protocol/src/config/defaults.rs
+++ b/crates/nu-protocol/src/config/defaults.rs
@@ -214,9 +214,22 @@ pub fn default_menus() -> Vec<ParsedMenu> {
     ]
 }
 
+/// Every edit mode the Nushell-owned keybindings below apply to.
+///
+/// The helix tables are named unconditionally, like `cursor_shape.helix_*`: a
+/// build without the `helix` feature has no table to bind them into and skips
+/// them when the keybindings are applied. `helix_select` is absent because
+/// reedline shares one table between helix normal and select mode, so
+/// `helix_normal` already covers both.
 fn all_modes() -> Value {
     Value::list(
-        vec![str("emacs"), str("vi_normal"), str("vi_insert")],
+        vec![
+            str("emacs"),
+            str("vi_normal"),
+            str("vi_insert"),
+            str("helix_normal"),
+            str("helix_insert"),
+        ],
         span(),
     )
 }

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -73,6 +73,10 @@ pub struct CursorShapeConfig {
     pub emacs: NuCursorShape,
     pub vi_insert: NuCursorShape,
     pub vi_normal: NuCursorShape,
+    /// Only takes effect in builds with the `helix` feature.
+    pub helix_normal: NuCursorShape,
+    pub helix_select: NuCursorShape,
+    pub helix_insert: NuCursorShape,
 }
 
 impl UpdateFromValue for CursorShapeConfig {
@@ -93,6 +97,9 @@ impl UpdateFromValue for CursorShapeConfig {
                 "vi_insert" => self.vi_insert.update(val, path, errors),
                 "vi_normal" => self.vi_normal.update(val, path, errors),
                 "emacs" => self.emacs.update(val, path, errors),
+                "helix_normal" => self.helix_normal.update(val, path, errors),
+                "helix_select" => self.helix_select.update(val, path, errors),
+                "helix_insert" => self.helix_insert.update(val, path, errors),
                 _ => errors.unknown_option(path, val),
             }
         }
@@ -104,6 +111,9 @@ pub enum EditBindings {
     Vi,
     #[default]
     Emacs,
+    /// Only usable in builds with the `helix` feature; selecting it elsewhere
+    /// reports an error when the keybindings are constructed.
+    Helix,
 }
 
 impl FromStr for EditBindings {
@@ -113,7 +123,8 @@ impl FromStr for EditBindings {
         match s.to_ascii_lowercase().as_str() {
             "vi" => Ok(Self::Vi),
             "emacs" => Ok(Self::Emacs),
-            _ => Err("'emacs' or 'vi'"),
+            "helix" => Ok(Self::Helix),
+            _ => Err("'emacs', 'vi' or 'helix'"),
         }
     }
 }


### PR DESCRIPTION
## Description

Wires up reedline's helix edit mode (nushell/reedline#1138) as `$env.config.edit_mode = helix`, and bumps the pinned reedline to 61715da.
The `helix` cargo feature (`default` and `full`), keybinding modes `helix_normal` / `helix_insert` / `helix_select`, the Nushell menu keybindings scoped to the helix tables, per-mode cursor shapes, prompt indicators, and config docs.

Quirks worth knowing:

- The workspace reedline dependency gains `default-features = false`: reedline ships helix in its default set, thus a standalone crate build (`cargo test -p nu-cli`) would see reedline's helix enum variants while the crate's cfg-gated match arms are compiled out. Keying reedline's feature to the workspace `helix` chain keeps the two in lockstep.
- `helix_select` is a valid keybinding mode but shares reedline's normal table, so the default keybindings only name `helix_normal` and `helix_insert`.
- Builds without the feature reject `edit_mode = helix` with an error, and *skip* the helix mode names on keybindings rather than erroring, since the defaults now carry them.

## User-facing changes (Release notes)

### Added Helix edit mode

Use `$env.config.edit_mode = helix` to enable a selection-first, Helix/Kakoune-style edit mode (normal, select, insert): motions carry the selection, verbs act on it.
Menu keybindings (Tab, Ctrl-r, F1) work as in the other modes, keybindings can target `helix_normal` / `helix_insert` / `helix_select` and cursor shapes can be customized via `cursor_shape.helix_*`.
On by default, opt-out via `--no-default-features`.