### PR TITLE
fix(env): normalize PATH when refreshing ENV_CONVERSIONS

### DIFF
--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_engine::env::convert_env_var;
 
 #[derive(Clone)]
 pub struct LoadEnv;
@@ -11,6 +10,10 @@ impl Command for LoadEnv {
 
     fn description(&self) -> &str {
         "Loads an environment update from a record."
+    }
+
+    fn extra_description(&self) -> &str {
+        "Environment conversions are not applied automatically. To apply the conversions configured in $env.ENV_CONVERSIONS after loading an update, assign $env.ENV_CONVERSIONS to itself."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -28,11 +31,6 @@ impl Command for LoadEnv {
                 SyntaxShape::record(),
                 "The record to use for updates.",
             )
-            .switch(
-                "convert",
-                "Apply environment conversions to imported string values.",
-                None,
-            )
             .category(Category::FileSystem)
     }
 
@@ -44,7 +42,6 @@ impl Command for LoadEnv {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let arg: Option<Record> = call.opt(engine_state, stack, 0)?;
-        let convert = call.has_flag(engine_state, stack, "convert")?;
         let span = call.head;
 
         let record = match arg {
@@ -71,16 +68,8 @@ impl Command for LoadEnv {
             }
         }
 
-        let mut strings_to_convert = Vec::new();
         for (env_var, rhs) in record {
-            if convert && matches!(rhs, Value::String { .. }) {
-                strings_to_convert.push(env_var.clone());
-            }
             stack.add_env_var(env_var, rhs);
-        }
-
-        for env_var in strings_to_convert {
-            convert_env_var(stack, engine_state, &env_var)?;
         }
         Ok(PipelineData::empty())
     }
@@ -98,8 +87,8 @@ impl Command for LoadEnv {
                 result: Some(Value::test_string("ABE")),
             },
             Example {
-                description: "Load a variable and apply its environment conversion.",
-                example: "$env.ENV_CONVERSIONS = {MY_ENV_VAR: {from_string: { split row ':' }}}; load-env --convert {MY_ENV_VAR: 'foo:bar'}; $env.MY_ENV_VAR",
+                description: "Load a variable, then apply its environment conversion.",
+                example: "$env.ENV_CONVERSIONS = {MY_ENV_VAR: {from_string: { split row ':' }}}; load-env {MY_ENV_VAR: 'foo:bar'}; $env.ENV_CONVERSIONS = $env.ENV_CONVERSIONS; $env.MY_ENV_VAR",
                 result: Some(Value::test_list(vec![
                     Value::test_string("foo"),
                     Value::test_string("bar"),

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_engine::env::convert_env_var;
 
 #[derive(Clone)]
 pub struct LoadEnv;
@@ -27,6 +28,11 @@ impl Command for LoadEnv {
                 SyntaxShape::record(),
                 "The record to use for updates.",
             )
+            .switch(
+                "convert",
+                "Apply environment conversions to imported string values.",
+                None,
+            )
             .category(Category::FileSystem)
     }
 
@@ -38,6 +44,7 @@ impl Command for LoadEnv {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let arg: Option<Record> = call.opt(engine_state, stack, 0)?;
+        let convert = call.has_flag(engine_state, stack, "convert")?;
         let span = call.head;
 
         let record = match arg {
@@ -64,8 +71,16 @@ impl Command for LoadEnv {
             }
         }
 
+        let mut strings_to_convert = Vec::new();
         for (env_var, rhs) in record {
+            if convert && matches!(rhs, Value::String { .. }) {
+                strings_to_convert.push(env_var.clone());
+            }
             stack.add_env_var(env_var, rhs);
+        }
+
+        for env_var in strings_to_convert {
+            convert_env_var(stack, engine_state, &env_var)?;
         }
         Ok(PipelineData::empty())
     }
@@ -81,6 +96,14 @@ impl Command for LoadEnv {
                 description: "Load variables from an argument.",
                 example: "load-env {NAME: ABE, AGE: UNKNOWN}; $env.NAME",
                 result: Some(Value::test_string("ABE")),
+            },
+            Example {
+                description: "Load a variable and apply its environment conversion.",
+                example: "$env.ENV_CONVERSIONS = {MY_ENV_VAR: {from_string: { split row ':' }}}; load-env --convert {MY_ENV_VAR: 'foo:bar'}; $env.MY_ENV_VAR",
+                result: Some(Value::test_list(vec![
+                    Value::test_string("foo"),
+                    Value::test_string("bar"),
+                ])),
             },
         ]
     }

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -333,11 +333,17 @@ fn get_converted_value(
     orig_val: &Value,
     direction: &str,
 ) -> Result<Value, ConversionError> {
-    let conversion = stack
+    let conversions = stack
         .get_env_var(engine_state, ENV_CONVERSIONS)
         .ok_or(ConversionError::CellPathError)?
-        .as_record()?
+        .as_record()?;
+    let conversion = conversions
         .get(name)
+        .or_else(|| {
+            conversions
+                .iter()
+                .find_map(|(key, value)| key.eq_ignore_ascii_case(name).then_some(value))
+        })
         .ok_or(ConversionError::CellPathError)?
         .as_record()?
         .get(direction)

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -63,6 +63,38 @@ pub fn convert_env_vars(
     Ok(())
 }
 
+/// Convert a string environment variable with its configured `from_string` closure.
+///
+/// `PATH` receives the same built-in normalization used during Nushell startup when no custom
+/// conversion turns it into a valid list.
+pub fn convert_env_var(
+    stack: &mut Stack,
+    engine_state: &EngineState,
+    name: &str,
+) -> Result<(), ShellError> {
+    let Some(value) = stack.get_env_var(engine_state, name) else {
+        return Ok(());
+    };
+
+    if !matches!(value, Value::String { .. }) {
+        return Ok(());
+    }
+
+    match get_converted_value(engine_state, stack, name, value, "from_string") {
+        Ok(value) => stack.add_env_var(name.to_string(), value),
+        Err(ConversionError::ShellError(error)) => return Err(error),
+        Err(ConversionError::CellPathError) => {}
+    }
+
+    if name.eq_ignore_ascii_case("path")
+        && let Some(error) = ensure_path(engine_state, stack)
+    {
+        return Err(error);
+    }
+
+    Ok(())
+}
+
 /// Translate environment variables from Strings to Values. Requires config to be already set up in
 /// case the user defined custom env conversions in config.nu.
 ///

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -60,39 +60,8 @@ pub fn convert_env_vars(
             stack.add_env_var(key.to_string(), new_val);
         }
     }
-    Ok(())
-}
 
-/// Convert a string environment variable with its configured `from_string` closure.
-///
-/// `PATH` receives the same built-in normalization used during Nushell startup when no custom
-/// conversion turns it into a valid list.
-pub fn convert_env_var(
-    stack: &mut Stack,
-    engine_state: &EngineState,
-    name: &str,
-) -> Result<(), ShellError> {
-    let Some(value) = stack.get_env_var(engine_state, name) else {
-        return Ok(());
-    };
-
-    if !matches!(value, Value::String { .. }) {
-        return Ok(());
-    }
-
-    match get_converted_value(engine_state, stack, name, value, "from_string") {
-        Ok(value) => stack.add_env_var(name.to_string(), value),
-        Err(ConversionError::ShellError(error)) => return Err(error),
-        Err(ConversionError::CellPathError) => {}
-    }
-
-    if name.eq_ignore_ascii_case("path")
-        && let Some(error) = ensure_path(engine_state, stack)
-    {
-        return Err(error);
-    }
-
-    Ok(())
+    ensure_path(engine_state, stack).map_or(Ok(()), Err)
 }
 
 /// Translate environment variables from Strings to Values. Requires config to be already set up in
@@ -333,17 +302,11 @@ fn get_converted_value(
     orig_val: &Value,
     direction: &str,
 ) -> Result<Value, ConversionError> {
-    let conversions = stack
+    let conversion = stack
         .get_env_var(engine_state, ENV_CONVERSIONS)
         .ok_or(ConversionError::CellPathError)?
-        .as_record()?;
-    let conversion = conversions
+        .as_record()?
         .get(name)
-        .or_else(|| {
-            conversions
-                .iter()
-                .find_map(|(key, value)| key.eq_ignore_ascii_case(name).then_some(value))
-        })
         .ok_or(ConversionError::CellPathError)?
         .as_record()?
         .get(direction)

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -356,6 +356,95 @@ fn load_env_variable_arg() -> Result {
 }
 
 #[test]
+fn load_env_converts_string_variables() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: { split row ":" } } }
+        load-env --convert { TESTENVVAR: "hello:world", UNCONVERTED: "plain" }
+        [$env.TESTENVVAR, $env.UNCONVERTED]
+    "#;
+
+    test().run(code).expect_value_eq(Value::test_list(vec![
+        Value::test_list(vec![
+            Value::test_string("hello"),
+            Value::test_string("world"),
+        ]),
+        Value::test_string("plain"),
+    ]))
+}
+
+#[test]
+fn load_env_convert_normalizes_path() -> Result {
+    let separator = if cfg!(windows) { ";" } else { ":" };
+    let code = format!("load-env --convert {{ pAtH: 'first{separator}second' }}; $env.PATH");
+
+    test().run(code).expect_value_eq(["first", "second"])
+}
+
+#[test]
+fn load_env_convert_pipeline_preserves_non_strings_and_null() -> Result {
+    let code = "
+        { NUMBER: 42, FLAG: true, NULL_VALUE: null } | load-env --convert
+        [($env.NUMBER == 42), ($env.FLAG == true), ($env.NULL_VALUE | describe)]
+    ";
+
+    test().run(code).expect_value_eq(Value::test_list(vec![
+        Value::test_bool(true),
+        Value::test_bool(true),
+        Value::test_string("nothing"),
+    ]))
+}
+
+#[test]
+fn load_env_convert_rejects_invalid_conversion() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: "not a closure" } }
+        load-env --convert { TESTENVVAR: "hello" }
+    "#;
+
+    test()
+        .run(code)
+        .expect_error_code_eq("nu::shell::cant_convert")
+}
+
+#[test]
+fn load_env_convert_propagates_conversion_closure_errors() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = {
+            TESTENVVAR: { from_string: { error make { msg: "conversion failed" } } }
+        }
+        load-env --convert { TESTENVVAR: "hello" }
+    "#;
+
+    let error = test().run(code).expect_error()?;
+    assert_contains("conversion failed", error.to_string());
+    Ok(())
+}
+
+#[test]
+fn load_env_conversions_can_read_other_imported_variables() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = {
+            TESTENVVAR: { from_string: { $"($env.PREFIX):($in)" } }
+        }
+        load-env --convert { TESTENVVAR: "value", PREFIX: "prefix" }
+        $env.TESTENVVAR
+    "#;
+
+    test().run(code).expect_value_eq("prefix:value")
+}
+
+#[test]
+fn load_env_without_convert_leaves_strings_unchanged() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: { split row ":" } } }
+        load-env { TESTENVVAR: "hello:world" }
+        $env.TESTENVVAR
+    "#;
+
+    test().run(code).expect_value_eq("hello:world")
+}
+
+#[test]
 fn load_env_doesnt_leak() -> Result {
     let err = test()
         .run(r#"do { echo { name: xyz, value: "my message" } | load-env }; $env.xyz"#)

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -356,103 +356,32 @@ fn load_env_variable_arg() -> Result {
 }
 
 #[test]
-fn load_env_converts_string_variables() -> Result {
+fn refreshing_env_conversions_converts_loaded_variables() -> Result {
     let code = r#"
         $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: { split row ":" } } }
-        load-env --convert { TESTENVVAR: "hello:world", UNCONVERTED: "plain" }
-        [$env.TESTENVVAR, $env.UNCONVERTED]
+        load-env { TESTENVVAR: "hello:world" }
+        let before = $env.TESTENVVAR
+        $env.ENV_CONVERSIONS = $env.ENV_CONVERSIONS
+        [$before, $env.TESTENVVAR]
     "#;
 
     test().run(code).expect_value_eq(Value::test_list(vec![
+        Value::test_string("hello:world"),
         Value::test_list(vec![
             Value::test_string("hello"),
             Value::test_string("world"),
         ]),
-        Value::test_string("plain"),
     ]))
 }
 
 #[test]
-fn load_env_conversion_names_are_case_insensitive() -> Result {
-    let code = r#"
-        $env.ENV_CONVERSIONS = { FOO: { from_string: { into int } } }
-        load-env --convert { foo: "42" }
-        $env.FOO
-    "#;
-
-    test().run(code).expect_value_eq(42)
-}
-
-#[test]
-fn load_env_convert_normalizes_path() -> Result {
+fn refreshing_env_conversions_normalizes_loaded_path() -> Result {
     let separator = if cfg!(windows) { ";" } else { ":" };
-    let code = format!("load-env --convert {{ pAtH: 'first{separator}second' }}; $env.PATH");
+    let code = format!(
+        "$env.ENV_CONVERSIONS = {{}}; load-env {{ pAtH: 'first{separator}second' }}; $env.ENV_CONVERSIONS = $env.ENV_CONVERSIONS; $env.PATH"
+    );
 
     test().run(code).expect_value_eq(["first", "second"])
-}
-
-#[test]
-fn load_env_convert_pipeline_preserves_non_strings_and_null() -> Result {
-    let code = "
-        { NUMBER: 42, FLAG: true, NULL_VALUE: null } | load-env --convert
-        [($env.NUMBER == 42), ($env.FLAG == true), ($env.NULL_VALUE | describe)]
-    ";
-
-    test().run(code).expect_value_eq(Value::test_list(vec![
-        Value::test_bool(true),
-        Value::test_bool(true),
-        Value::test_string("nothing"),
-    ]))
-}
-
-#[test]
-fn load_env_convert_rejects_invalid_conversion() -> Result {
-    let code = r#"
-        $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: "not a closure" } }
-        load-env --convert { TESTENVVAR: "hello" }
-    "#;
-
-    test()
-        .run(code)
-        .expect_error_code_eq("nu::shell::cant_convert")
-}
-
-#[test]
-fn load_env_convert_propagates_conversion_closure_errors() -> Result {
-    let code = r#"
-        $env.ENV_CONVERSIONS = {
-            TESTENVVAR: { from_string: { error make { msg: "conversion failed" } } }
-        }
-        load-env --convert { TESTENVVAR: "hello" }
-    "#;
-
-    let error = test().run(code).expect_error()?;
-    assert_contains("conversion failed", error.to_string());
-    Ok(())
-}
-
-#[test]
-fn load_env_conversions_can_read_other_imported_variables() -> Result {
-    let code = r#"
-        $env.ENV_CONVERSIONS = {
-            TESTENVVAR: { from_string: { $"($env.PREFIX):($in)" } }
-        }
-        load-env --convert { TESTENVVAR: "value", PREFIX: "prefix" }
-        $env.TESTENVVAR
-    "#;
-
-    test().run(code).expect_value_eq("prefix:value")
-}
-
-#[test]
-fn load_env_without_convert_leaves_strings_unchanged() -> Result {
-    let code = r#"
-        $env.ENV_CONVERSIONS = { TESTENVVAR: { from_string: { split row ":" } } }
-        load-env { TESTENVVAR: "hello:world" }
-        $env.TESTENVVAR
-    "#;
-
-    test().run(code).expect_value_eq("hello:world")
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -373,6 +373,17 @@ fn load_env_converts_string_variables() -> Result {
 }
 
 #[test]
+fn load_env_conversion_names_are_case_insensitive() -> Result {
+    let code = r#"
+        $env.ENV_CONVERSIONS = { FOO: { from_string: { into int } } }
+        load-env --convert { foo: "42" }
+        $env.FOO
+    "#;
+
+    test().run(code).expect_value_eq(42)
+}
+
+#[test]
 fn load_env_convert_normalizes_path() -> Result {
     let separator = if cfg!(windows) { ";" } else { ":" };
     let code = format!("load-env --convert {{ pAtH: 'first{separator}second' }}; $env.PATH");


### PR DESCRIPTION
## Description
Refreshing `$env.ENV_CONVERSIONS` already reapplies configured `from_string` conversions to string environment variables. However, the built-in `PATH` normalization was only performed during startup, so an importer such as `load-env` could leave `PATH` as a string after the refresh.

This change makes the existing `ENV_CONVERSIONS` refresh path also perform the built-in `PATH` normalization. It also documents the refresh pattern on `load-env`:

  ```nushell
  direnv export json | from json | default {} | load-env
  $env.ENV_CONVERSIONS = $env.ENV_CONVERSIONS
  ```

Regression tests cover configured conversions on imported values and platform-specific `PATH` normalization.

## User-facing changes (Release notes)

Refreshing `$env.ENV_CONVERSIONS` now also normalizes `PATH` into its usual list form. The `load-env` help documents how to refresh environment conversions after importing string values.

## Additional notes

Closes #18766