### PR TITLE
fix: single semver output as table instead of value

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -481,23 +481,15 @@ fn handle_table_command(mut input: CmdInput<'_>) -> ShellResult<PipelineData> {
             // instead of stdout.
             Err(*error)
         }
-        PipelineData::Value(value @ Value::Custom { .. }, metadata) => {
-            // Expand structured custom values (records/lists) into native table
-            // shapes. Keep primitive customs (e.g. semver) as Custom so
-            // type-specific color_config keys still apply via style_primitive.
-            let base = value.as_custom_value()?.to_base_value(span)?;
-            match base {
-                Value::Record { .. } | Value::List { .. } => {
-                    let base_pipeline = base.into_pipeline_data_with_metadata(metadata);
-                    Table.run(input.engine_state, input.stack, input.call, base_pipeline)
-                }
-                _ => {
-                    let signals = input.engine_state.signals().clone();
-                    let stream = ListStream::new(std::iter::once(value), span, signals);
-                    input.data = PipelineData::empty();
-                    handle_row_stream(input, stream, metadata)
-                }
-            }
+        PipelineData::Value(Value::Custom { val, .. }, metadata) => {
+            // Always collapse a top-level custom so primitive customs (semver,
+            // etc.) print as scalars, matching filesize/duration. Structured
+            // customs become native records/lists. Cell coloring for customs
+            // inside lists/tables is handled in build_table_batch.
+            let base_pipeline = val
+                .to_base_value(span)?
+                .into_pipeline_data_with_metadata(metadata);
+            Table.run(input.engine_state, input.stack, input.call, base_pipeline)
         }
         PipelineData::Value(Value::Range { val, .. }, metadata) => {
             let signals = input.engine_state.signals().clone();

--- a/crates/nu-command/tests/commands/table/display.rs
+++ b/crates/nu-command/tests/commands/table/display.rs
@@ -206,22 +206,16 @@ fn table_semver_list_colors() -> Result {
         .expect_value_eq(colored)
 }
 
-/// A bare single semver also keeps type-specific coloring (rendered as a one-row list).
+/// A lone primitive custom (semver) prints as a scalar, not a one-row table.
 #[test]
-fn table_semver_single_colors() -> Result {
-    let colored = indoc! {"
-        \u{1b}[39m╭───┬───────╮\u{1b}[0m
-        \u{1b}[39m│\u{1b}[0m \u{1b}[1;32m0\u{1b}[0m \u{1b}[39m│\u{1b}[0m \u{1b}[1;36m1.0.0\u{1b}[0m \u{1b}[39m│\u{1b}[0m
-        \u{1b}[39m╰───┴───────╯\u{1b}[0m
-    "};
-    test()
-        .run(
-            "
-                $env.config.use_ansi_coloring = true
-                '1.0.0' | into semver | table
-            ",
-        )
-        .expect_value_eq(colored)
+fn table_semver_single_is_scalar() -> Result {
+    let mut tester = test();
+    tester
+        .run("'1.0.0' | into semver | table")
+        .expect_value_eq("1.0.0")?;
+    tester
+        .run("'1.0.0' | into semver | describe")
+        .expect_value_eq("semver")
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR fixes a bug where semver was outputting a single semver value as a table
### Before
```nushell
version | get version | into semver
┌───┬─────────┐
│ 0 │ 0.114.1 │
└───┴─────────┘
```
### After
```nushell
version | get version | into semver
0.114.1
```
## User-facing changes (Release notes)
Single semver values do not output as a table anymore
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->