### PR TITLE
fix(completion): stop stat-ing all of PATH once the external cap is hit

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -216,52 +216,48 @@ impl CommandCompletion {
             .max_results as usize;
         let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
 
-        let mut external_commands = HashSet::new();
-        let mut collisions = HashSet::new();
+        let mut external_commands: HashSet<String> = HashSet::new();
+        let mut collisions: HashSet<String> = HashSet::new();
 
-        let executables: Vec<_> = self
-            .get_executable_files(working_set)
-            .filter_map(|(file_name, file_path)| {
-                let matches_prefix = matcher.check_match(&file_name).is_some();
-                let is_collision = internal_names.contains(&file_name);
+        for (file_name, file_path) in self.get_executable_files(working_set) {
+            let is_collision =
+                internal_names.contains(&file_name) && !collisions.contains(&file_name);
+            let wants_suggestion = external_commands.len() < maximum_results
+                && matcher.check_match(&file_name).is_some();
 
-                ((matches_prefix || is_collision) && Self::is_executable_command(&file_path))
-                    .then_some((file_name, file_path, matches_prefix, is_collision))
-            })
-            .collect();
+            // `is_executable_command` stats the file, which dominates the scan on slow
+            // filesystems (e.g. WSL's 9P mounts to Windows `PATH` directories), so only
+            // pay for entries that can still contribute a suggestion or a collision.
+            if !(wants_suggestion || is_collision) || !Self::is_executable_command(&file_path) {
+                continue;
+            }
 
-        executables
-            .into_iter()
-            .for_each(|(file_name, _, matches_prefix, is_collision)| {
-                if is_collision {
-                    collisions.insert(file_name.clone());
-                }
+            if is_collision {
+                collisions.insert(file_name.clone());
+            }
 
-                if matches_prefix && external_commands.len() < maximum_results {
-                    let (command_value, tracking_name) = match is_collision {
-                        true => {
-                            let prefixed = format!("^{file_name}");
-                            (prefixed.clone(), prefixed)
-                        }
-                        false => (file_name.clone(), file_name.clone()),
-                    };
+            if wants_suggestion {
+                let command_value = match internal_names.contains(&file_name) {
+                    true => format!("^{file_name}"),
+                    false => file_name.clone(),
+                };
 
-                    if external_commands.insert(tracking_name) {
-                        matcher.add(
-                            file_name,
-                            SemanticSuggestion {
-                                suggestion: Suggestion {
-                                    value: command_value,
-                                    span: suggestion_span,
-                                    append_whitespace: true,
-                                    ..Suggestion::default()
-                                },
-                                kind: Some(SuggestionKind::Command(CommandType::External, None)),
+                if external_commands.insert(command_value.clone()) {
+                    matcher.add(
+                        file_name,
+                        SemanticSuggestion {
+                            suggestion: Suggestion {
+                                value: command_value,
+                                span: suggestion_span,
+                                append_whitespace: true,
+                                ..Suggestion::default()
                             },
-                        );
-                    }
+                            kind: Some(SuggestionKind::Command(CommandType::External, None)),
+                        },
+                    );
                 }
-            });
+            }
+        }
 
         // Add `%`-prefixed copies of collided internal suggestions.
         let percent_prefixed_suggestions: Vec<SemanticSuggestion> = internal_suggestions


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

Since #18761 the external command scan called `is_executable` on every `PATH` entry whose name matched the prefix, applying `completions.external.max_results` only when building suggestions afterwards. On an empty prefix that stats every file on `PATH`; over WSL's 9P mounts each stat is a round-trip, which is the multi-second tab delay reported in #18799.

Gate the stat on the cap again, as 0.114.1 did, while still walking the full `PATH` for collision detection, which only stats names that shadow internal commands.


## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
n/a

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

Had Claude suggest low hanging fruit for solving #18799. This was the suggestion.
If it solves it nice, if not drop it.
@NotTheDr01ds would be amazing if you could check it out.