### PR TITLE
feat(config): make the visual selection style configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.49.0"
-source = "git+https://github.com/nushell/reedline?branch=main#61715da7b99b3d38dbd26f00dfaa2a5ef6316b3c"
+source = "git+https://github.com/nushell/reedline?branch=main#464efb2ed5b8d294f81b787e70418006d48428f3"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -677,6 +677,14 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     line_editor = line_editor.with_visual_selection_style(
         style_computer.compute("selection", &Value::nothing(Span::unknown())),
     );
+    // Opt-in: unset means the cell under the cursor keeps the plain selection
+    // style, so presence has to be checked rather than computed, since
+    // `compute` folds a missing key into the default style.
+    if config.color_config.contains_key("selection_cursor") {
+        line_editor = line_editor.with_visual_selection_cursor_style(
+            style_computer.compute("selection_cursor", &Value::nothing(Span::unknown())),
+        );
+    }
     line_editor = if config.use_ansi_coloring.get(engine_state) && config.show_hints {
         // As of Nov 2022, "hints" color_config closures only get `null` passed in.
         // No meaningful span — this is a synthetic null value for style computation.

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -657,10 +657,6 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         ))
         .with_cursor_config(cursor_config)
         .with_abbreviations(config.abbreviations.clone())
-        .with_visual_selection_style(nu_ansi_term::Style {
-            is_reverse: true,
-            ..Default::default()
-        })
         .with_semantic_markers(semantic_markers_from_config(
             &config,
             term_program_is_vscode,
@@ -676,6 +672,11 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     let style_computer = StyleComputer::from_config(engine_state, &stack_arc);
 
     start_time = Instant::now();
+    // `color_config.selection` defaults to `{ attr: r }`, the reverse video
+    // this used to hardcode.
+    line_editor = line_editor.with_visual_selection_style(
+        style_computer.compute("selection", &Value::nothing(Span::unknown())),
+    );
     line_editor = if config.use_ansi_coloring.get(engine_state) && config.show_hints {
         // As of Nov 2022, "hints" color_config closures only get `null` passed in.
         // No meaningful span — this is a synthetic null value for style computation.

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -677,14 +677,9 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     line_editor = line_editor.with_visual_selection_style(
         style_computer.compute("selection", &Value::nothing(Span::unknown())),
     );
-    // Opt-in: unset means the cell under the cursor keeps the plain selection
-    // style, so presence has to be checked rather than computed, since
-    // `compute` folds a missing key into the default style.
-    if config.color_config.contains_key("selection_cursor") {
-        line_editor = line_editor.with_visual_selection_cursor_style(
-            style_computer.compute("selection_cursor", &Value::nothing(Span::unknown())),
-        );
-    }
+    line_editor = line_editor.with_visual_selection_cursor_style(
+        style_computer.compute("selection_cursor", &Value::nothing(Span::unknown())),
+    );
     line_editor = if config.use_ansi_coloring.get(engine_state) && config.show_hints {
         // As of Nov 2022, "hints" color_config closures only get `null` passed in.
         // No meaningful span — this is a synthetic null value for style computation.

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -1120,10 +1120,12 @@ $env.config.color_config.search_result = {bg: "red", fg: "default"}
 $env.config.color_config.selection = {attr: "r"}
 
 # color_config.selection_cursor: Style for the cell under the cursor inside a
-# visual selection, useful when the selection style would otherwise hide the
-# terminal cursor (e.g. a reverse selection under a reverse-rendering cursor).
-# Unset by default: the cell keeps the plain selection style.
-# $env.config.color_config.selection_cursor = {bg: "white", fg: "black"}
+# visual selection. The default { attr: n } (normal, no styling) leaves the
+# cell plain so the terminal cursor stays visible even when the selection
+# style would hide it; a block cursor that renders by reversing the cell turns
+# the plain cell back into the flat reverse-selection look.
+# Default: { attr: n }
+$env.config.color_config.selection_cursor = {attr: "n"}
 
 # color_config.header: Style for table column headers.
 # Default: green_bold

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -1114,6 +1114,11 @@ $env.config.color_config.hints = "dark_gray"
 # Default: { bg: red, fg: default }
 $env.config.color_config.search_result = {bg: "red", fg: "default"}
 
+# color_config.selection: Style for the line editor's visual selection,
+# including the helix-mode resting cursor cell.
+# Default: { attr: r } (reverse video)
+$env.config.color_config.selection = {attr: "r"}
+
 # color_config.header: Style for table column headers.
 # Default: green_bold
 $env.config.color_config.header = "green_bold"

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -1119,6 +1119,12 @@ $env.config.color_config.search_result = {bg: "red", fg: "default"}
 # Default: { attr: r } (reverse video)
 $env.config.color_config.selection = {attr: "r"}
 
+# color_config.selection_cursor: Style for the cell under the cursor inside a
+# visual selection, useful when the selection style would otherwise hide the
+# terminal cursor (e.g. a reverse selection under a reverse-rendering cursor).
+# Unset by default: the cell keeps the plain selection style.
+# $env.config.color_config.selection_cursor = {bg: "white", fg: "black"}
+
 # color_config.header: Style for table column headers.
 # Default: green_bold
 $env.config.color_config.header = "green_bold"

--- a/crates/nu-protocol/src/config/defaults.rs
+++ b/crates/nu-protocol/src/config/defaults.rs
@@ -73,6 +73,10 @@ pub fn default_color_config() -> HashMap<String, Value> {
             }),
         ),
         ("selection", rec(record! { "attr" => str("r") })),
+        // "n" (no styling) keeps the cursor cell plain inside a selection: a
+        // reversing block cursor reverses it back to the flat selection look,
+        // while thinner cursor shapes stay visible instead of drowning in it.
+        ("selection_cursor", rec(record! { "attr" => str("n") })),
         ("shape_binary", str("purple_bold")),
         ("shape_block", str("blue_bold")),
         ("shape_bool", str("light_cyan")),

--- a/crates/nu-protocol/src/config/defaults.rs
+++ b/crates/nu-protocol/src/config/defaults.rs
@@ -72,6 +72,7 @@ pub fn default_color_config() -> HashMap<String, Value> {
                 "fg" => str("default"),
             }),
         ),
+        ("selection", rec(record! { "attr" => str("r") })),
         ("shape_binary", str("purple_bold")),
         ("shape_block", str("blue_bold")),
         ("shape_bool", str("light_cyan")),


### PR DESCRIPTION
## Description

The visual selection style has been hardcoded to reverse video since #14052.
Helix mode turned that into a problem: its resting cursor cell is painted with the selection style, so a terminal that renders its cursor by reversing the cell loses the cursor inside any selection.

Two new `color_config` keys, computed through the existing `StyleComputer` like `hints`:

- `selection`: the selection style, default `{ attr: r }` (the hardcode it replaces).
- `selection_cursor`: the cell under the cursor inside a selection, backed by reedline's `with_visual_selection_cursor_style` (nushell/reedline#1149). Default `{ attr: n }`, leaving that one cell unstyled.

The defaults degrade gracefully: a reversing block cursor turns the plain cell back into the flat reverse look, so nothing changes visually for the common setup, while thinner cursor shapes (`underscore`, `line`) become visible inside selections.

## User-facing changes (Release notes)

### Added configurable visual selection styling

Added `color_config.selection` and `color_config.selection_cursor` to style the line editor's visual selection and the cursor cell inside it:

```nushell
$env.config.color_config.selection = { attr: r }         # default
$env.config.color_config.selection_cursor = { attr: n }  # default
```

With the defaults a block cursor looks as before; `underscore` and `line` cursor shapes are now visible inside selections.

## Additional notes

~~Merge this after #18833~~