### PR TITLE
perf - stop parse-time-loading modules and extra cwd walks while typing `use std/`

### DIFF
--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -55,12 +55,14 @@ impl Completer for DotNuCompletion {
         }
 
         // Add std virtual paths first
+        let mut resolved_virtual_dir = false;
         if self.std_virtual_path {
             // Where we have '/' in the prefix, e.g. use std/l
             if let Some((base_dir, _)) = prefix.as_ref().rsplit_once("/") {
                 let base_dir = surround_remove(base_dir);
                 if let Some(VirtualPath::Dir(sub_paths)) = working_set.find_virtual_path(&base_dir)
                 {
+                    resolved_virtual_dir = true;
                     for sub_vp_id in sub_paths {
                         let (path, sub_vp) = working_set.get_virtual_path(*sub_vp_id);
                         matcher.add_semantic_suggestion(SemanticSuggestion {
@@ -110,7 +112,11 @@ impl Completer for DotNuCompletion {
             })
             .collect::<HashSet<_>>();
 
-        if let Ok(cwd) = working_set.permanent_state.cwd(None) {
+        // A virtual dir (`use std/`) already supplied its children. Walking cwd
+        // is the `/` hitch in large trees and cannot complete extra files under
+        // virtual `std` (find_in_dirs prefers the VFS). Still search NU_LIB_DIRS
+        // so a real `std/` overlay in lib dirs can appear.
+        if !resolved_virtual_dir && let Ok(cwd) = working_set.permanent_state.cwd(None) {
             search_dirs.insert(cwd.into_std_path_buf());
         }
 

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -4,12 +4,16 @@ use nu_color_config::{get_matching_brackets_style, get_shape_color};
 use nu_engine::env;
 use nu_parser::{FlatShape, flatten_block, parse};
 use nu_protocol::{
-    Span,
+    BlockId, Span,
     ast::{Block, Expr, Expression, PipelineRedirection, RecordItem},
     engine::{EngineState, Stack, StateWorkingSet},
 };
 use reedline::{AbbrExpandContext, Highlighter, StyledText};
-use std::sync::{Arc, Mutex};
+use std::{
+    borrow::Cow,
+    ffi::OsStr,
+    sync::{Arc, Mutex},
+};
 
 /// A highlighter that does nothing
 ///
@@ -24,10 +28,38 @@ impl Highlighter for NoOpHighlighter {
     }
 }
 
+/// Engine bits that change span / block IDs. Overlay or file loads must miss the cache.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct HighlightEngineKey {
+    span_start: usize,
+    num_blocks: usize,
+    num_decls: usize,
+}
+
+impl HighlightEngineKey {
+    fn of(engine_state: &EngineState) -> Self {
+        Self {
+            span_start: engine_state.next_span_start(),
+            num_blocks: engine_state.num_blocks(),
+            num_decls: engine_state.num_decls(),
+        }
+    }
+}
+
+/// Parse/flatten result reused across paints of the same line.
+#[derive(Clone)]
+struct ParsedHighlight {
+    block: Arc<Block>,
+    /// Blocks added by this parse (`StateWorkingSet::delta.blocks`), in id order.
+    delta_blocks: Vec<Arc<Block>>,
+    shapes: Arc<Vec<(Span, FlatShape)>>,
+    global_span_offset: usize,
+}
+
 struct HighlightCache {
     line: String,
-    global_span_offset: usize,
-    shapes: Arc<Vec<(Span, FlatShape)>>,
+    engine: HighlightEngineKey,
+    parsed: ParsedHighlight,
 }
 
 pub struct NuHighlighter {
@@ -48,38 +80,14 @@ impl NuHighlighter {
 
 impl Highlighter for NuHighlighter {
     fn highlight(&self, line: &str, cursor: usize) -> StyledText {
-        let result = highlight_syntax(&self.engine_state, &self.stack, line, cursor);
-        *self.cache.lock().unwrap_or_else(|e| e.into_inner()) = Some(HighlightCache {
-            line: line.to_string(),
-            global_span_offset: result.global_span_offset,
-            shapes: Arc::new(result.shapes),
-        });
-        result.text
+        let parsed = self.parsed_line(line);
+        style_parsed(&self.engine_state, &self.stack, line, cursor, &parsed).text
     }
 
     fn should_expand_abbr(&self, line: &str, cursor: usize, context: AbbrExpandContext) -> bool {
-        let (global_span_offset, shapes) = match self
-            .cache
-            .lock()
-            .ok()
-            .as_deref()
-            .and_then(|c| c.as_ref())
-            .filter(|c| c.line == line)
-        {
-            Some(c) => (c.global_span_offset, Arc::clone(&c.shapes)),
-            None => {
-                let mut working_set = StateWorkingSet::new(&self.engine_state);
-                working_set.skip_module_load = true;
-                let block = parse(&mut working_set, None, line.as_bytes(), false);
-                (
-                    self.engine_state.next_span_start(),
-                    Arc::new(flatten_block(&working_set, &block)),
-                )
-            }
-        };
-
-        let global_cursor = cursor + global_span_offset;
-        !shapes.iter().any(|(span, shape)| {
+        let parsed = self.parsed_line(line);
+        let global_cursor = cursor + parsed.global_span_offset;
+        !parsed.shapes.iter().any(|(span, shape)| {
             span.contains(global_cursor)
                 && match context {
                     AbbrExpandContext::WordAbbreviation => matches!(
@@ -95,13 +103,34 @@ impl Highlighter for NuHighlighter {
     }
 }
 
+impl NuHighlighter {
+    fn parsed_line(&self, line: &str) -> ParsedHighlight {
+        let engine = HighlightEngineKey::of(&self.engine_state);
+        {
+            let guard = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(cache) = guard.as_ref()
+                && cache.line == line
+                && cache.engine == engine
+            {
+                return cache.parsed.clone();
+            }
+        }
+
+        let parsed = parse_highlight_line(&self.engine_state, line);
+        *self.cache.lock().unwrap_or_else(|e| e.into_inner()) = Some(HighlightCache {
+            line: line.to_string(),
+            engine,
+            parsed: parsed.clone(),
+        });
+        parsed
+    }
+}
+
 /// Result of a syntax highlight operation
 #[derive(Default)]
 pub(crate) struct HighlightResult {
     pub(crate) text: StyledText,
     pub(crate) found_garbage: Option<Span>,
-    pub(crate) global_span_offset: usize,
-    pub(crate) shapes: Vec<(Span, FlatShape)>,
 }
 
 pub(crate) fn highlight_syntax(
@@ -110,33 +139,53 @@ pub(crate) fn highlight_syntax(
     line: &str,
     cursor: usize,
 ) -> HighlightResult {
+    let parsed = parse_highlight_line(engine_state, line);
+    style_parsed(engine_state, stack, line, cursor, &parsed)
+}
+
+fn parse_highlight_line(engine_state: &EngineState, line: &str) -> ParsedHighlight {
     trace!("highlighting: {line}");
 
-    let config = stack.get_config(engine_state);
-    let highlight_resolved_externals = config.highlight_resolved_externals;
     let mut working_set = StateWorkingSet::new(engine_state);
     // Color `use` without parse-time-loading modules (the `d` hitch on `use std`).
     working_set.skip_module_load = true;
     let block = parse(&mut working_set, None, line.as_bytes(), false);
     // TODO: Traverse::flat_map based highlighting?
     let shapes = flatten_block(&working_set, &block);
-    let global_span_offset = engine_state.next_span_start();
-    let mut result = HighlightResult {
-        global_span_offset,
-        ..Default::default()
-    };
+    ParsedHighlight {
+        block,
+        delta_blocks: working_set.delta.blocks,
+        shapes: Arc::new(shapes),
+        global_span_offset: engine_state.next_span_start(),
+    }
+}
+
+fn style_parsed(
+    engine_state: &EngineState,
+    stack: &Stack,
+    line: &str,
+    cursor: usize,
+    parsed: &ParsedHighlight,
+) -> HighlightResult {
+    let config = stack.get_config(engine_state);
+    let highlight_resolved_externals = config.highlight_resolved_externals;
+    let global_span_offset = parsed.global_span_offset;
+    let shapes = parsed.shapes.as_ref();
+    let mut result = HighlightResult::default();
+    result.text.buffer.reserve(shapes.len().saturating_mul(2));
     let mut last_seen_span_end = global_span_offset;
 
+    let get_block = |id: BlockId| get_highlight_block(engine_state, &parsed.delta_blocks, id);
     let global_cursor_offset = cursor + global_span_offset;
     let matching_brackets_pos = find_matching_brackets(
         line,
-        &working_set,
-        &block,
+        &get_block,
+        &parsed.block,
         global_span_offset,
         global_cursor_offset,
     );
 
-    for (raw_span, flat_shape) in &shapes {
+    for (raw_span, flat_shape) in shapes {
         // NOTE: Currently we expand aliases while flattening for tasks such as completion
         // https://github.com/nushell/nushell/issues/16944
         let span = if let FlatShape::External(alias_span) = flat_shape {
@@ -154,19 +203,17 @@ pub(crate) fn highlight_syntax(
             continue;
         }
         if span.start > last_seen_span_end {
-            let gap = line
-                [(last_seen_span_end - global_span_offset)..(span.start - global_span_offset)]
-                .to_string();
-            result.text.push((Style::new(), gap));
+            push_line_slice(
+                &mut result.text,
+                Style::new(),
+                line,
+                last_seen_span_end - global_span_offset,
+                span.start - global_span_offset,
+            );
         }
-        let next_token =
-            line[(span.start - global_span_offset)..(span.end - global_span_offset)].to_string();
 
-        let mut add_colored_token = |shape: &FlatShape, text: String| {
-            result
-                .text
-                .push((get_shape_color(shape.as_str(), &config), text));
-        };
+        let token_start = span.start - global_span_offset;
+        let token_end = span.end - global_span_offset;
 
         match flat_shape {
             FlatShape::Garbage => {
@@ -176,29 +223,39 @@ pub(crate) fn highlight_syntax(
                         span.end - global_span_offset,
                     )
                 });
-                add_colored_token(flat_shape, next_token)
+                push_shaped_slice(
+                    &mut result.text,
+                    flat_shape,
+                    &config,
+                    line,
+                    token_start,
+                    token_end,
+                );
             }
             FlatShape::External(_) => {
-                let mut true_shape = flat_shape.clone();
                 // Highlighting externals has a config point because of concerns that using which to resolve
                 // externals may slow down things too much.
-                if highlight_resolved_externals {
-                    // use `raw_span` here for aliased external calls
-                    let str_contents = working_set.get_span_contents(*raw_span);
-                    let str_word = String::from_utf8_lossy(str_contents).to_string();
-                    let paths = env::path_str(engine_state, stack, *raw_span).ok();
-                    let res = if let Ok(cwd) = engine_state.cwd(Some(stack)) {
-                        which::which_in(str_word, paths.as_ref(), cwd).ok()
-                    } else {
-                        which::which_in_global(str_word, paths.as_ref())
-                            .ok()
-                            .and_then(|mut i| i.next())
-                    };
-                    if res.is_some() {
-                        true_shape = FlatShape::ExternalResolved;
-                    }
-                }
-                add_colored_token(&true_shape, next_token);
+                let resolved = highlight_resolved_externals
+                    && external_is_resolved(
+                        engine_state,
+                        stack,
+                        line,
+                        global_span_offset,
+                        *raw_span,
+                    );
+                let shape = if resolved {
+                    &FlatShape::ExternalResolved
+                } else {
+                    flat_shape
+                };
+                push_shaped_slice(
+                    &mut result.text,
+                    shape,
+                    &config,
+                    line,
+                    token_start,
+                    token_end,
+                );
             }
             FlatShape::List
             | FlatShape::Table
@@ -212,28 +269,117 @@ pub(crate) fn highlight_syntax(
                     global_span_offset,
                 );
                 for (part, highlight) in spans {
-                    let start = part.start - span.start;
-                    let end = part.end - span.start;
-                    let text = next_token[start..end].to_string();
                     let mut style = get_shape_color(flat_shape.as_str(), &config);
                     if highlight {
                         style = get_matching_brackets_style(style, &config);
                     }
-                    result.text.push((style, text));
+                    push_line_slice(
+                        &mut result.text,
+                        style,
+                        line,
+                        part.start - global_span_offset,
+                        part.end - global_span_offset,
+                    );
                 }
             }
-            _ => add_colored_token(flat_shape, next_token),
+            _ => push_shaped_slice(
+                &mut result.text,
+                flat_shape,
+                &config,
+                line,
+                token_start,
+                token_end,
+            ),
         }
         last_seen_span_end = span.end;
     }
 
-    let remainder = line[(last_seen_span_end - global_span_offset)..].to_string();
-    if !remainder.is_empty() {
-        result.text.push((Style::new(), remainder));
-    }
+    push_line_slice(
+        &mut result.text,
+        Style::new(),
+        line,
+        last_seen_span_end - global_span_offset,
+        line.len(),
+    );
 
-    result.shapes = shapes;
     result
+}
+
+fn push_line_slice(out: &mut StyledText, style: Style, line: &str, start: usize, end: usize) {
+    if start < end && end <= line.len() {
+        out.push((style, line[start..end].to_string()));
+    }
+}
+
+fn push_shaped_slice(
+    out: &mut StyledText,
+    shape: &FlatShape,
+    config: &nu_protocol::Config,
+    line: &str,
+    start: usize,
+    end: usize,
+) {
+    push_line_slice(
+        out,
+        get_shape_color(shape.as_str(), config),
+        line,
+        start,
+        end,
+    );
+}
+
+fn get_highlight_block<'a>(
+    engine_state: &'a EngineState,
+    delta_blocks: &'a [Arc<Block>],
+    id: BlockId,
+) -> &'a Block {
+    let n = engine_state.num_blocks();
+    if id.get() < n {
+        engine_state.get_block(id).as_ref()
+    } else {
+        delta_blocks
+            .get(id.get() - n)
+            .expect("internal error: missing highlight block")
+            .as_ref()
+    }
+}
+
+/// Contents of `span` for `which`: the current line when the span is on it,
+/// otherwise engine-state text (aliased externals).
+fn span_text<'a>(
+    line: &'a str,
+    global_span_offset: usize,
+    engine_state: &'a EngineState,
+    span: Span,
+) -> Cow<'a, str> {
+    let start = span.start.saturating_sub(global_span_offset);
+    let end = span.end.saturating_sub(global_span_offset);
+    if span.start >= global_span_offset && end <= line.len() && start <= end {
+        Cow::Borrowed(&line[start..end])
+    } else {
+        String::from_utf8_lossy(engine_state.get_span_contents(span))
+    }
+}
+
+fn external_is_resolved(
+    engine_state: &EngineState,
+    stack: &Stack,
+    line: &str,
+    global_span_offset: usize,
+    raw_span: Span,
+) -> bool {
+    let word = span_text(line, global_span_offset, engine_state, raw_span);
+    let paths = env::path_str(engine_state, stack, raw_span).ok();
+    let word_os = OsStr::new(word.as_ref());
+    let paths_os = paths.as_deref().map(OsStr::new);
+    if let Ok(cwd) = engine_state.cwd(Some(stack)) {
+        which::which_in(word_os, paths_os, cwd).is_ok()
+    } else {
+        which::which_in_global(word_os, paths_os)
+            .ok()
+            .and_then(|mut i| i.next())
+            .is_some()
+    }
 }
 
 fn split_span_by_highlight_positions(
@@ -265,9 +411,9 @@ fn split_span_by_highlight_positions(
     result
 }
 
-fn find_matching_brackets(
+fn find_matching_brackets<'a>(
     line: &str,
-    working_set: &StateWorkingSet,
+    get_block: &dyn Fn(BlockId) -> &'a Block,
     block: &Block,
     global_span_offset: usize,
     global_cursor_offset: usize,
@@ -300,7 +446,7 @@ fn find_matching_brackets(
     // find matching bracket by finding matching block end
     let matching_block_end = find_matching_block_end_in_block(
         line,
-        working_set,
+        get_block,
         block,
         global_span_offset,
         global_bracket_pos,
@@ -318,9 +464,9 @@ fn find_matching_brackets(
     Vec::new()
 }
 
-fn find_matching_block_end_in_block(
+fn find_matching_block_end_in_block<'a>(
     line: &str,
-    working_set: &StateWorkingSet,
+    get_block: &dyn Fn(BlockId) -> &'a Block,
     block: &Block,
     global_span_offset: usize,
     global_cursor_offset: usize,
@@ -330,7 +476,7 @@ fn find_matching_block_end_in_block(
             if e.expr.span.contains(global_cursor_offset)
                 && let Some(pos) = find_matching_block_end_in_expr(
                     line,
-                    working_set,
+                    get_block,
                     &e.expr,
                     global_span_offset,
                     global_cursor_offset,
@@ -349,7 +495,7 @@ fn find_matching_block_end_in_block(
                         if let Some(pos) = target.expr().and_then(|expr| {
                             find_matching_block_end_in_expr(
                                 line,
-                                working_set,
+                                get_block,
                                 expr,
                                 global_span_offset,
                                 global_cursor_offset,
@@ -366,9 +512,9 @@ fn find_matching_block_end_in_block(
     None
 }
 
-fn find_matching_block_end_in_expr(
+fn find_matching_block_end_in_expr<'a>(
     line: &str,
-    working_set: &StateWorkingSet,
+    get_block: &dyn Fn(BlockId) -> &'a Block,
     expression: &Expression,
     global_span_offset: usize,
     global_cursor_offset: usize,
@@ -418,7 +564,7 @@ fn find_matching_block_end_in_expr(
                 .find_map(|attr| {
                     find_matching_block_end_in_expr(
                         line,
-                        working_set,
+                        get_block,
                         &attr.expr,
                         global_span_offset,
                         global_cursor_offset,
@@ -427,7 +573,7 @@ fn find_matching_block_end_in_expr(
                 .or_else(|| {
                     find_matching_block_end_in_expr(
                         line,
-                        working_set,
+                        get_block,
                         &ab.item,
                         global_span_offset,
                         global_cursor_offset,
@@ -450,7 +596,7 @@ fn find_matching_block_end_in_expr(
                         .find_map(|expr| {
                             find_matching_block_end_in_expr(
                                 line,
-                                working_set,
+                                get_block,
                                 expr,
                                 global_span_offset,
                                 global_cursor_offset,
@@ -471,7 +617,7 @@ fn find_matching_block_end_in_expr(
                     exprs.iter().find_map(|expr| match expr {
                         RecordItem::Pair(k, v) => find_matching_block_end_in_expr(
                             line,
-                            working_set,
+                            get_block,
                             k,
                             global_span_offset,
                             global_cursor_offset,
@@ -479,7 +625,7 @@ fn find_matching_block_end_in_expr(
                         .or_else(|| {
                             find_matching_block_end_in_expr(
                                 line,
-                                working_set,
+                                get_block,
                                 v,
                                 global_span_offset,
                                 global_cursor_offset,
@@ -487,7 +633,7 @@ fn find_matching_block_end_in_expr(
                         }),
                         RecordItem::Spread(_, record) => find_matching_block_end_in_expr(
                             line,
-                            working_set,
+                            get_block,
                             record,
                             global_span_offset,
                             global_cursor_offset,
@@ -500,7 +646,7 @@ fn find_matching_block_end_in_expr(
                 arg.expr().and_then(|expr| {
                     find_matching_block_end_in_expr(
                         line,
-                        working_set,
+                        get_block,
                         expr,
                         global_span_offset,
                         global_cursor_offset,
@@ -510,7 +656,7 @@ fn find_matching_block_end_in_expr(
 
             Expr::FullCellPath(b) => find_matching_block_end_in_expr(
                 line,
-                working_set,
+                get_block,
                 &b.head,
                 global_span_offset,
                 global_cursor_offset,
@@ -519,7 +665,7 @@ fn find_matching_block_end_in_expr(
             Expr::BinaryOp(lhs, op, rhs) => [lhs, op, rhs].into_iter().find_map(|expr| {
                 find_matching_block_end_in_expr(
                     line,
-                    working_set,
+                    get_block,
                     expr,
                     global_span_offset,
                     global_cursor_offset,
@@ -528,7 +674,7 @@ fn find_matching_block_end_in_expr(
 
             Expr::Collect(_, expr) => find_matching_block_end_in_expr(
                 line,
-                working_set,
+                get_block,
                 expr,
                 global_span_offset,
                 global_cursor_offset,
@@ -546,10 +692,10 @@ fn find_matching_block_end_in_expr(
                     Some(expr_last)
                 } else {
                     // cursor is inside block
-                    let nested_block = working_set.get_block(*block_id);
+                    let nested_block = get_block(*block_id);
                     find_matching_block_end_in_block(
                         line,
-                        working_set,
+                        get_block,
                         nested_block,
                         global_span_offset,
                         global_cursor_offset,
@@ -561,7 +707,7 @@ fn find_matching_block_end_in_expr(
                 exprs.iter().find_map(|expr| {
                     find_matching_block_end_in_expr(
                         line,
-                        working_set,
+                        get_block,
                         expr,
                         global_span_offset,
                         global_cursor_offset,
@@ -580,7 +726,7 @@ fn find_matching_block_end_in_expr(
                     list.iter().find_map(|item| {
                         find_matching_block_end_in_expr(
                             line,
-                            working_set,
+                            get_block,
                             item.expr(),
                             global_span_offset,
                             global_cursor_offset,
@@ -598,7 +744,7 @@ fn get_char_at_index(s: &str, index: usize) -> Option<char> {
 }
 
 fn get_char_length(c: char) -> usize {
-    c.to_string().len()
+    c.len_utf8()
 }
 
 #[cfg(test)]
@@ -611,6 +757,42 @@ mod tests {
 
     fn make_highlighter() -> NuHighlighter {
         NuHighlighter::new(Arc::new(EngineState::new()), Arc::new(Stack::new()))
+    }
+
+    #[test]
+    fn highlight_reuses_parse_cache_for_the_same_line() {
+        let h = make_highlighter();
+        let line = "let x = [1, 2]";
+        let first = h.highlight(line, 0);
+        let second = h.highlight(line, 0);
+        assert_eq!(first.render_simple(), second.render_simple());
+        assert_eq!(first.raw_string(), line);
+
+        // Cursor-only change must restyle matching brackets without re-parsing.
+        let on_open = h.highlight(line, 8);
+        let on_open_again = h.highlight(line, 8);
+        assert_eq!(on_open.render_simple(), on_open_again.render_simple());
+        assert_eq!(on_open.raw_string(), line);
+    }
+
+    #[test]
+    fn highlight_slices_cover_the_whole_line() {
+        let h = make_highlighter();
+        for line in [
+            "",
+            "ls",
+            "use std/iter",
+            "1 + 2",
+            "{a: 1}",
+            "def f [] { 1 }",
+        ] {
+            let styled = h.highlight(line, line.len());
+            assert_eq!(
+                styled.raw_string(),
+                line,
+                "lost text while styling {line:?}"
+            );
+        }
     }
 
     #[rstest]

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -69,6 +69,7 @@ impl Highlighter for NuHighlighter {
             Some(c) => (c.global_span_offset, Arc::clone(&c.shapes)),
             None => {
                 let mut working_set = StateWorkingSet::new(&self.engine_state);
+                working_set.skip_module_load = true;
                 let block = parse(&mut working_set, None, line.as_bytes(), false);
                 (
                     self.engine_state.next_span_start(),
@@ -114,6 +115,8 @@ pub(crate) fn highlight_syntax(
     let config = stack.get_config(engine_state);
     let highlight_resolved_externals = config.highlight_resolved_externals;
     let mut working_set = StateWorkingSet::new(engine_state);
+    // Color `use` without parse-time-loading modules (the `d` hitch on `use std`).
+    working_set.skip_module_load = true;
     let block = parse(&mut working_set, None, line.as_bytes(), false);
     // TODO: Traverse::flat_map based highlighting?
     let shapes = flatten_block(&working_set, &block);

--- a/crates/nu-cli/tests/commands/nu_highlight.rs
+++ b/crates/nu-cli/tests/commands/nu_highlight.rs
@@ -32,6 +32,16 @@ fn nu_highlight_color_detection(#[case] cmd: &str, #[case] shape: &str) -> Resul
 }
 
 #[test]
+fn nu_highlight_use_std_is_not_garbage() -> Result {
+    let mut tester = test();
+    let () = tester.run_with_data("let color = $in", "#112233")?;
+    let () = tester.run("$env.config.color_config.shape_garbage = $color")?;
+    tester
+        .run("'use std' | nu-highlight | $in has (ansi $color)")
+        .expect_value_eq(false)
+}
+
+#[test]
 fn nu_highlight_not_expr() -> Result {
     test()
         .run("'not false' | nu-highlight | ansi strip")

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1100,6 +1100,15 @@ fn dotnu_stdlib_completions() {
     let completion_str = "use \"std";
     let suggestions = completer.complete_blocking(completion_str, completion_str.len());
     match_suggestions(&vec!["std", "std-rfc"], &suggestions);
+
+    // Trailing `/` lists virtual children without walking cwd (the `/` hitch).
+    let completion_str = "use std/";
+    let suggestions = completer.complete_blocking(completion_str, completion_str.len());
+    let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
+    assert!(
+        values.contains(&"std/iter") && values.contains(&"std/assert"),
+        "expected virtual std/ children, got {values:?}"
+    );
 }
 
 #[test]

--- a/crates/nu-cli/tests/highlight_use.rs
+++ b/crates/nu-cli/tests/highlight_use.rs
@@ -1,0 +1,38 @@
+use nu_parser::parse;
+use nu_protocol::engine::StateWorkingSet;
+use nu_std::load_standard_library;
+
+/// The highlighter sets `skip_module_load` so typing `use std` does not
+/// parse-time-load the standard library. Execution still loads it.
+#[test]
+fn skip_module_load_does_not_parse_std() {
+    let mut engine = nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+    assert!(load_standard_library(&mut engine).is_ok());
+    let modules_before = engine.num_modules();
+
+    let mut skip = StateWorkingSet::new(&engine);
+    skip.skip_module_load = true;
+    parse(&mut skip, None, b"use std/iter", false);
+    assert!(
+        skip.parse_errors.is_empty(),
+        "highlight parse should not report ModuleNotFound: {:?}",
+        skip.parse_errors
+    );
+    assert_eq!(
+        skip.num_modules(),
+        modules_before,
+        "skip_module_load must not add modules"
+    );
+
+    let mut load = StateWorkingSet::new(&engine);
+    parse(&mut load, None, b"use std/iter", false);
+    assert!(
+        load.parse_errors.is_empty(),
+        "execute parse of `use std/iter` should succeed: {:?}",
+        load.parse_errors
+    );
+    assert!(
+        load.num_modules() > modules_before,
+        "execute parse of `use std/iter` must load the module"
+    );
+}

--- a/crates/nu-cli/tests/main.rs
+++ b/crates/nu-cli/tests/main.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod completions;
+mod highlight_use;
 mod last_result;
 
 #[macro_use]

--- a/crates/nu-parser/src/parse_module.rs
+++ b/crates/nu-parser/src/parse_module.rs
@@ -780,6 +780,10 @@ pub fn parse_module_file_or_dir(
         return None;
     }
 
+    if working_set.skip_module_load {
+        return None;
+    }
+
     #[allow(deprecated)]
     let cwd = working_set.get_cwd();
 
@@ -963,6 +967,10 @@ pub fn parse_module(
             call_span,
             Type::Any,
         )]);
+
+        if working_set.skip_module_load {
+            return (pipeline, None);
+        }
 
         if let Some(module_id) = parse_module_file_or_dir(
             working_set,
@@ -1201,6 +1209,16 @@ pub fn parse_use(
             module,
             module_id,
         )
+    } else if working_set.skip_module_load {
+        return (
+            Pipeline::from_vec(vec![Expression::new(
+                working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]),
+            vec![],
+        );
     } else if let Some(module_id) = parse_module_file_or_dir(
         working_set,
         &import_pattern.head.name,
@@ -1690,6 +1708,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
                     module_id,
                     true,
                 )
+            } else if working_set.skip_module_load {
+                return pipeline;
             } else if let Some(module_id) = parse_module_file_or_dir(
                 working_set,
                 overlay_name.as_bytes(),

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -29,6 +29,11 @@ pub struct StateWorkingSet<'a> {
     pub files: FileStack,
     /// Whether or not predeclarations are searched when looking up a command (used with aliases)
     pub search_predecls: bool,
+    /// When true, `use` / `export use` / `overlay use` / `module <file>` parse as
+    /// syntax only and do not load modules from disk or the virtual filesystem.
+    /// The REPL highlighter sets this so typing `use std` does not parse-time-load
+    /// the standard library on every keystroke.
+    pub skip_module_load: bool,
     pub parse_errors: Vec<ParseError>,
     pub parse_warnings: Vec<ParseWarning>,
     pub compile_errors: Vec<CompileError>,
@@ -48,6 +53,7 @@ impl<'a> StateWorkingSet<'a> {
             permanent_state,
             files,
             search_predecls: true,
+            skip_module_load: false,
             parse_errors: vec![],
             parse_warnings: vec![],
             compile_errors: vec![],


### PR DESCRIPTION
## Description

This PR is intended to be a performance speed-up to help with user experience. When you think about it, the repl is the user interface and so it should be as buttery smooth as possible. This addresses one problem I've seen recently.

Typing `use std/iter` in a debug REPL hitches twice: at the `d` of `std`, and again at `/`. Release builds do the same work; debug just makes it more obvious. The work is on the **paint path**: reedline fully repaints on each key (should fix later), Nushell re-parses the whole line for syntax highlighting, and an open or implicit completion can parse again and walk disk.

This PR removes those two hitches and two related per-keystroke costs. Execute, `nu-highlight`, and completion of real filesystem modules are unchanged.

## User-facing changes (Release notes)

### Faster typing of `use` in the REPL

The REPL no longer parse-time-loads a module just to syntax-highlight it. Typing `use std` or `use std/iter` no longer stalls on the first exact match of `std` (most noticeable in debug builds). Execution is unchanged: the module still loads when you run the line.

Completing `use std/` (and `export use` / `overlay use`) lists virtual standard-library children without walking the current directory. `$NU_LIB_DIRS` is still searched. Completing a real path such as `use ./foo/` is unchanged.

Syntax highlighting also does less work per keystroke: it reuses the last parse of the same line (for example when only the cursor moves) and copies less text while painting.

```nushell
# These should feel instant to type in the REPL, including debug `cargo run`
use std
use std/iter
use std/assert
```

## Additional notes
