### PR TITLE
let more commands use row conditions

### DIFF
--- a/crates/nu-command/src/filters/chunk_by.rs
+++ b/crates/nu-command/src/filters/chunk_by.rs
@@ -20,11 +20,7 @@ impl Command for ChunkBy {
                 ),
                 (Type::Range, Type::list(Type::list(Type::Any))),
             ])
-            .required(
-                "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                "The closure to run.",
-            )
+            .required("closure", SyntaxShape::RowCondition, "The closure to run.")
             .category(Category::Filters)
     }
 
@@ -51,7 +47,7 @@ consecutive elements that share the same closure result value into lists."
         vec![
             Example {
                 description: "Chunk data into runs of larger than zero or not.",
-                example: "[1, 3, -2, -2, 0, 1, 2] | chunk-by {|it| $it >= 0 }",
+                example: "[1, 3, -2, -2, 0, 1, 2] | chunk-by $it >= 0",
                 result: Some(Value::test_list(vec![
                     Value::test_list(vec![Value::test_int(1), Value::test_int(3)]),
                     Value::test_list(vec![Value::test_int(-2), Value::test_int(-2)]),
@@ -64,7 +60,7 @@ consecutive elements that share the same closure result value into lists."
             },
             Example {
                 description: "Identify repetitions in a string",
-                example: "[a b b c c c] | chunk-by { |it| $it }",
+                example: "[a b b c c c] | chunk-by $it",
                 result: Some(Value::test_list(vec![
                     Value::test_list(vec![Value::test_string("a")]),
                     Value::test_list(vec![Value::test_string("b"), Value::test_string("b")]),

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -20,7 +20,7 @@ impl Command for SkipUntil {
             ])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::RowCondition,
                 "The predicate that skipped element must not match.",
             )
             .category(Category::Filters)
@@ -38,7 +38,7 @@ impl Command for SkipUntil {
         vec![
             Example {
                 description: "Skip until the element is positive.",
-                example: "[-2 0 2 -1] | skip until {|x| $x > 0 }",
+                example: "[-2 0 2 -1] | skip until $it > 0",
                 result: Some(Value::test_list(vec![
                     Value::test_int(2),
                     Value::test_int(-1),
@@ -54,7 +54,7 @@ impl Command for SkipUntil {
             },
             Example {
                 description: "Skip until the field value is positive.",
-                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip until {|x| $x.a > 0 }",
+                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip until a > 0",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "a" => Value::test_int(2),

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -20,7 +20,7 @@ impl Command for SkipWhile {
             ])
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::RowCondition,
                 "The predicate that skipped element must match.",
             )
             .category(Category::Filters)
@@ -38,7 +38,7 @@ impl Command for SkipWhile {
         vec![
             Example {
                 description: "Skip while the element is negative.",
-                example: "[-2 0 2 -1] | skip while {|x| $x < 0 }",
+                example: "[-2 0 2 -1] | skip while $it < 0",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(2),
@@ -56,7 +56,7 @@ impl Command for SkipWhile {
             },
             Example {
                 description: "Skip while the field value is negative.",
-                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip while {|x| $x.a < 0 }",
+                example: "[{a: -2} {a: 0} {a: 2} {a: -1}] | skip while a < 0",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "a" => Value::test_int(0),

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -26,7 +26,7 @@ impl Command for TakeUntil {
             )
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::RowCondition,
                 "The predicate that element(s) must not match.",
             )
             .category(Category::Filters)
@@ -40,7 +40,7 @@ impl Command for TakeUntil {
         vec![
             Example {
                 description: "Take until the element is positive.",
-                example: "[-1 -2 9 1] | take until {|x| $x > 0 }",
+                example: "[-1 -2 9 1] | take until $it > 0",
                 result: Some(test_value!([-1, -2])),
             },
             Example {
@@ -50,7 +50,7 @@ impl Command for TakeUntil {
             },
             Example {
                 description: "Take until the field value is positive.",
-                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until {|x| $x.a > 0 }",
+                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take until a > 0",
                 result: Some(test_value!([{a: (-1)}, {a: (-2)}])),
             },
             Example {

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -26,7 +26,7 @@ impl Command for TakeWhile {
             )
             .required(
                 "predicate",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                SyntaxShape::RowCondition,
                 "The predicate that element(s) must match.",
             )
             .category(Category::Filters)
@@ -40,7 +40,7 @@ impl Command for TakeWhile {
         vec![
             Example {
                 description: "Take while the element is negative.",
-                example: "[-1 -2 9 1] | take while {|x| $x < 0 }",
+                example: "[-1 -2 9 1] | take while $it < 0",
                 result: Some(test_value!([-1, -2])),
             },
             Example {
@@ -50,7 +50,7 @@ impl Command for TakeWhile {
             },
             Example {
                 description: "Take while the field value is negative.",
-                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while {|x| $x.a < 0 }",
+                example: "[{a: -1} {a: -2} {a: 9} {a: 1}] | take while a < 0",
                 result: Some(test_value!([{a: (-1)}, {a: (-2)}])),
             },
             Example {


### PR DESCRIPTION
## Description

Based on fdncred's comment in #18353, adds row conditions to every other command using a predicate-like closure.

## User-facing changes (Release notes)

Allow `take until`, `take while`, `skip until`, `skip while`, and `chunk-by` to use row condition syntax alongside closures.

## Additional notes

Updated examples cover most test cases, but waiting on writing tests depending on if there are any more additions / removals.

It looks like the `-i` flag of `take until` and `take while` must be proved to the command before the predicate even it it's given as a closure.
