### PR TITLE
Allow raw `null`  as a value for `to yaml --non-roundtrip`

### DIFF
--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -21,7 +21,10 @@ impl Command for ToYamlLike {
             )
             .param(
                 Flag::new("non-roundtrip")
-                    .arg(SyntaxShape::String)
+                    .arg(SyntaxShape::OneOf(vec![
+                        SyntaxShape::String,
+                        SyntaxShape::Nothing,
+                    ]))
                     .desc("How to handle values that are non-roundtrippable.")
                     .completion(Completion::new_list(&["error", "null", "lossy"])),
             )
@@ -104,17 +107,19 @@ impl Command for ToYamlLike {
         let compact_list_indent = call.get_flag(engine_state, stack, "compact-list-indent")?;
         let quote_style = call.get_flag(engine_state, stack, "quote")?;
         let non_roundtrip =
-            call.get_flag::<Spanned<String>>(engine_state, stack, "non-roundtrip")?;
+            call.get_flag::<Spanned<Option<String>>>(engine_state, stack, "non-roundtrip")?;
         let non_roundtrip = match (
             call.has_flag(engine_state, stack, "serialize")?,
-            non_roundtrip.as_ref().map(|nr| nr.item.as_ref()),
+            non_roundtrip
+                .as_ref()
+                .map(|nr| nr.item.as_ref().map(|nr| nr.as_ref())),
         ) {
             // matching the spanned is way less comprehendible here, so we expect spans instead
-            (false, None | Some("error")) => NonRoundtrip::Error,
-            (true, None | Some("lossy")) => NonRoundtrip::Lossy {
+            (false, None | Some(Some("error"))) => NonRoundtrip::Error,
+            (true, None | Some(Some("lossy"))) => NonRoundtrip::Lossy {
                 engine_state: Box::new(engine_state.clone()),
             },
-            (false, Some("null")) => NonRoundtrip::Null,
+            (false, Some(Some("null") | None)) => NonRoundtrip::Null,
             (false, Some(_)) => {
                 return Err(ShellError::IncompatibleParametersSingle {
                     msg: "expected `error`, `null` or `lossy`".into(),

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -203,3 +203,13 @@ fn convert_keys_are_quoted_only_when_required(#[case] input: &str, #[case] quote
     };
     Ok(())
 }
+
+#[rstest]
+#[case::raw_null("null")]
+#[case::string_null("'null'")]
+#[nu_test_support::test]
+fn null_as_non_roundtrip_value(#[case] null: &str) -> Result {
+    test()
+        .run(format!("{{|| version}} | to yaml --non-roundtrip {null}"))
+        .expect_value_eq("null\n")
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

https://github.com/nushell/nushell.github.io/pull/2228 found that `to yaml --non-roundtrip null` is invalid in 0.115.0. I think that's a bit annoying, so I made it that a raw `null` is also a valid value here.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
`to yaml --non-roundtrip` now also accepts a raw `null` instead of only `"null"` for the null configuration.
