### PR TITLE
`group-by --to-table` keep original types

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -3,6 +3,7 @@ use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     FromValue, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
 };
+use std::hash::{Hash, Hasher};
 
 #[derive(Clone)]
 pub struct GroupBy;
@@ -42,12 +43,14 @@ impl Command for GroupBy {
     }
 
     fn extra_description(&self) -> &str {
-        r#"the group-by command makes some assumptions:
-    - if the input data is not a string, the grouper will convert the key to string but the values will remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
+        r#"The default record output uses display-string keys because record keys must be strings:
+    - if the input data is not a string, the grouper converts the key to a string but the values remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
     - datetime is formatted based on your configuration setting. use `format date` to change the format.
     - filesize is formatted based on your configuration setting. use `format filesize` to change the format.
     - some nushell values are not supported, such as closures.
-    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null."#
+    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+
+With --to-table, group keys keep their original types and grouping uses typed value identity (same type and payload). Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups. null group keys are included as null values."#
     }
 
     fn run(
@@ -99,6 +102,25 @@ impl Command for GroupBy {
                     ]),
                     "2" => Value::test_list(vec![Value::test_string("2")]),
                 })),
+            },
+            Example {
+                description: "Group by a non-string column and keep the original key type.",
+                example: "[{n: 1} {n: 2} {n: 1}] | group-by n --to-table",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "n" => Value::test_int(1),
+                        "items" => Value::test_list(vec![
+                            Value::test_record(record! { "n" => Value::test_int(1) }),
+                            Value::test_record(record! { "n" => Value::test_int(1) }),
+                        ]),
+                    }),
+                    Value::test_record(record! {
+                        "n" => Value::test_int(2),
+                        "items" => Value::test_list(vec![
+                            Value::test_record(record! { "n" => Value::test_int(2) }),
+                        ]),
+                    }),
+                ])),
             },
             Example {
                 description: "You can also output a table instead of a record.",
@@ -281,14 +303,28 @@ pub fn group_by(
 
     let grouped = match &groupers[..] {
         [first, rest @ ..] => {
-            let mut grouped =
-                Grouped::new(first.as_ref(), prune, values, config, engine_state, stack)?;
+            let mut grouped = Grouped::new(
+                first.as_ref(),
+                prune,
+                values,
+                config,
+                to_table,
+                engine_state,
+                stack,
+            )?;
             for grouper in rest {
-                grouped.subgroup(grouper.as_ref(), prune, config, engine_state, stack)?;
+                grouped.subgroup(
+                    grouper.as_ref(),
+                    prune,
+                    config,
+                    to_table,
+                    engine_state,
+                    stack,
+                )?;
             }
             grouped
         }
-        [] => Grouped::empty(values, config),
+        [] => Grouped::empty(values, config, to_table),
     };
 
     let value = if to_table {
@@ -363,26 +399,177 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
 /// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+///
+/// Default record output groups by display string (`Display`). `--to-table` keeps the
+/// original value and groups by typed identity (`Preserved`).
+#[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
-    String(String),
+    Display(String),
+    Preserved(Value),
 }
 
 impl GroupKey {
-    fn from_value(value: &Value, config: &nu_protocol::Config) -> Self {
+    fn from_value(value: &Value, config: &nu_protocol::Config, preserve_values: bool) -> Self {
         if value.is_nothing() {
             Self::Nothing
+        } else if preserve_values {
+            Self::Preserved(value.clone())
         } else {
-            Self::String(value.to_expanded_string(", ", config))
+            Self::Display(value.to_expanded_string(", ", config))
         }
     }
 
     fn into_value(self, span: Span) -> Value {
         match self {
             Self::Nothing => Value::nothing(span),
-            Self::String(s) => Value::string(s, span),
+            Self::Display(s) => Value::string(s, span),
+            Self::Preserved(v) => v,
         }
+    }
+}
+
+impl PartialEq for GroupKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Nothing, Self::Nothing) => true,
+            (Self::Display(a), Self::Display(b)) => a == b,
+            (Self::Preserved(a), Self::Preserved(b)) => group_values_eq(a, b),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for GroupKey {}
+
+impl Hash for GroupKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Nothing => {}
+            Self::Display(s) => s.hash(state),
+            Self::Preserved(v) => hash_group_value(v, state),
+        }
+    }
+}
+
+fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
+    std::mem::discriminant(value).hash(state);
+    match value {
+        Value::Bool { val, .. } => val.hash(state),
+        Value::Int { val, .. } => val.hash(state),
+        Value::Float { val, .. } => val.to_bits().hash(state),
+        Value::String { val, .. } => val.hash(state),
+        Value::Glob { val, no_expand, .. } => {
+            val.hash(state);
+            no_expand.hash(state);
+        }
+        Value::Filesize { val, .. } => val.hash(state),
+        Value::Duration { val, .. } => val.hash(state),
+        Value::Date { val, .. } => val.hash(state),
+        Value::Range { val, .. } => val.to_string().hash(state),
+        Value::Record { val, .. } => {
+            let mut pairs: Vec<_> = val.iter().collect();
+            pairs.sort_unstable_by_key(|(a, _)| *a);
+            pairs.len().hash(state);
+            for (key, child) in pairs {
+                key.hash(state);
+                hash_group_value(child, state);
+            }
+        }
+        Value::List { vals, .. } => {
+            vals.len().hash(state);
+            for child in vals.iter() {
+                hash_group_value(child, state);
+            }
+        }
+        Value::Closure { val, .. } => val.block_id.hash(state),
+        Value::Error { .. } => {}
+        Value::Binary { val, .. } => val.hash(state),
+        Value::CellPath { val, .. } => {
+            val.members.len().hash(state);
+            for member in &val.members {
+                match member {
+                    PathMember::String { val, optional, .. } => {
+                        0u8.hash(state);
+                        val.hash(state);
+                        optional.hash(state);
+                    }
+                    PathMember::Int { val, optional, .. } => {
+                        1u8.hash(state);
+                        val.hash(state);
+                        optional.hash(state);
+                    }
+                }
+            }
+        }
+        Value::Custom { val, .. } => {
+            val.type_name().hash(state);
+            if let Ok(base) = val.to_base_value(value.span()) {
+                hash_group_value(&base, state);
+            }
+        }
+        Value::Nothing { .. } => {}
+    }
+}
+
+fn group_values_eq(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::Bool { val: a, .. }, Value::Bool { val: b, .. }) => a == b,
+        (Value::Int { val: a, .. }, Value::Int { val: b, .. }) => a == b,
+        (Value::Float { val: a, .. }, Value::Float { val: b, .. }) => a.to_bits() == b.to_bits(),
+        (Value::String { val: a, .. }, Value::String { val: b, .. }) => a == b,
+        (
+            Value::Glob {
+                val: a,
+                no_expand: a_no_expand,
+                ..
+            },
+            Value::Glob {
+                val: b,
+                no_expand: b_no_expand,
+                ..
+            },
+        ) => a == b && a_no_expand == b_no_expand,
+        (Value::Filesize { val: a, .. }, Value::Filesize { val: b, .. }) => a == b,
+        (Value::Duration { val: a, .. }, Value::Duration { val: b, .. }) => a == b,
+        (Value::Date { val: a, .. }, Value::Date { val: b, .. }) => a == b,
+        // Typed identity: do not use Range::eq, which treats int and float ranges as equal.
+        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => {
+            a.to_string() == b.to_string()
+        }
+        (Value::Record { val: a, .. }, Value::Record { val: b, .. }) => {
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut left_pairs: Vec<_> = a.iter().collect();
+            let mut right_pairs: Vec<_> = b.iter().collect();
+            left_pairs.sort_unstable_by_key(|(x, _)| *x);
+            right_pairs.sort_unstable_by_key(|(x, _)| *x);
+            left_pairs
+                .iter()
+                .zip(right_pairs)
+                .all(|((ak, av), (bk, bv))| *ak == bk && group_values_eq(av, bv))
+        }
+        (Value::List { vals: a, .. }, Value::List { vals: b, .. }) => {
+            a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| group_values_eq(x, y))
+        }
+        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => a.block_id == b.block_id,
+        (Value::Error { .. }, Value::Error { .. }) => true,
+        (Value::Binary { val: a, .. }, Value::Binary { val: b, .. }) => a == b,
+        (Value::CellPath { val: a, .. }, Value::CellPath { val: b, .. }) => a == b,
+        (Value::Custom { val: a, .. }, Value::Custom { val: b, .. }) => {
+            if a.type_name() != b.type_name() {
+                return false;
+            }
+            match (a.to_base_value(left.span()), b.to_base_value(right.span())) {
+                (Ok(a_base), Ok(b_base)) => group_values_eq(&a_base, &b_base),
+                (Err(_), Err(_)) => true,
+                _ => false,
+            }
+        }
+        (Value::Nothing { .. }, Value::Nothing { .. }) => true,
+        _ => false,
     }
 }
 
@@ -398,6 +585,7 @@ fn group_cell_path(
     prune: bool,
     values: Vec<Value>,
     config: &nu_protocol::Config,
+    preserve_values: bool,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let optional_path = path_has_optional_member(column_name);
@@ -411,7 +599,7 @@ fn group_cell_path(
             continue;
         }
 
-        let key = GroupKey::from_value(key_val.as_ref(), config);
+        let key = GroupKey::from_value(key_val.as_ref(), config, preserve_values);
 
         if prune {
             // it's okay if this fails since pruning is best-effort
@@ -438,6 +626,7 @@ fn group_closure(
     values: Vec<Value>,
     span: Span,
     closure: Closure,
+    preserve_values: bool,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
@@ -447,7 +636,7 @@ fn group_closure(
 
     for value in values {
         let key_val = closure.run_with_value(value.clone())?.into_value(span)?;
-        let key = GroupKey::from_value(&key_val, config);
+        let key = GroupKey::from_value(&key_val, config, preserve_values);
 
         groups.entry(key).or_default().push(value);
     }
@@ -483,11 +672,11 @@ enum Tree {
 }
 
 impl Grouped {
-    fn empty(values: Vec<Value>, config: &nu_protocol::Config) -> Self {
+    fn empty(values: Vec<Value>, config: &nu_protocol::Config, preserve_values: bool) -> Self {
         let mut groups = IndexMap::<_, Vec<_>>::new();
 
         for value in values.into_iter() {
-            let key = GroupKey::from_value(&value, config);
+            let key = GroupKey::from_value(&value, config, preserve_values);
             groups.entry(key).or_default().push(value);
         }
 
@@ -501,15 +690,19 @@ impl Grouped {
         prune: bool,
         values: Vec<Value>,
         config: &nu_protocol::Config,
+        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
         let groups = match grouper.item {
-            Grouper::CellPath { val } => group_cell_path(val, prune, values, config)?,
+            Grouper::CellPath { val } => {
+                group_cell_path(val, prune, values, config, preserve_values)?
+            }
             Grouper::Closure { val } => group_closure(
                 values,
                 grouper.span,
                 Closure::clone(val),
+                preserve_values,
                 engine_state,
                 stack,
             )?,
@@ -524,6 +717,7 @@ impl Grouped {
         grouper: Spanned<&Grouper>,
         prune: bool,
         config: &nu_protocol::Config,
+        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<(), ShellError> {
@@ -531,14 +725,22 @@ impl Grouped {
             Tree::Leaf(groups) => std::mem::take(groups)
                 .into_iter()
                 .map(|(key, values)| -> Result<_, ShellError> {
-                    let leaf = Self::new(grouper, prune, values, config, engine_state, stack)?;
+                    let leaf = Self::new(
+                        grouper,
+                        prune,
+                        values,
+                        config,
+                        preserve_values,
+                        engine_state,
+                        stack,
+                    )?;
                     Ok((key, leaf))
                 })
                 .collect::<Result<IndexMap<_, _>, ShellError>>()?,
             Tree::Branch(nested_groups) => {
                 let mut nested_groups = std::mem::take(nested_groups);
                 for v in nested_groups.values_mut() {
-                    v.subgroup(grouper, prune, config, engine_state, stack)?;
+                    v.subgroup(grouper, prune, config, preserve_values, engine_state, stack)?;
                 }
                 nested_groups
             }
@@ -589,8 +791,8 @@ impl Grouped {
                     // Records cannot use null as a key; omit null groups rather than
                     // mapping them to the empty string (which collides with "").
                     .filter_map(|(k, v)| match k {
-                        GroupKey::String(key) => Some((key, v.into_value(head))),
-                        GroupKey::Nothing => None,
+                        GroupKey::Display(key) => Some((key, v.into_value(head))),
+                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
                     })
                     .collect(),
                 head,
@@ -599,8 +801,8 @@ impl Grouped {
                 let values = branch
                     .into_iter()
                     .filter_map(|(k, v)| match k {
-                        GroupKey::String(key) => Some((key, v.into_record(head))),
-                        GroupKey::Nothing => None,
+                        GroupKey::Display(key) => Some((key, v.into_record(head))),
+                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
                     })
                     .collect();
                 Value::record(values, head)

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -21,7 +21,7 @@ impl Command for GroupBy {
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Any)])
             .switch(
                 "to-table",
-                "Return a table with \"groups\" and \"items\" columns.",
+                "Always return a table. Key columns keep their original types (column name \"group\" when no grouper is given).",
                 None,
             )
             .switch(
@@ -50,9 +50,9 @@ impl Command for GroupBy {
 
 The default output is a record when every group key is a string. Those record keys are the original strings; they are not reformatted. null group keys are omitted (records cannot use null as a key). Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
 
-If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table.
+If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table. Table output uses the same column-name rules as --to-table: a grouper named `items` is rejected (use `{ get items }` or rename the column), and duplicate grouper names are rejected.
 
---to-table always returns a table. Group columns keep their original types. null group keys are included as null values."#
+--to-table always returns a table. The group column is named `group` when no grouper is given; otherwise the grouper names. Group columns keep their original types. null group keys are included as null values."#
     }
 
     fn run(
@@ -481,8 +481,15 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
                 hash_group_value(child, state);
             }
         }
-        Value::Closure { val, .. } => val.block_id.hash(state),
-        Value::Error { .. } => {}
+        Value::Closure { val, .. } => {
+            val.block_id.hash(state);
+            val.captures.len().hash(state);
+            for (var_id, captured) in &val.captures {
+                var_id.hash(state);
+                hash_group_value(captured, state);
+            }
+        }
+        Value::Error { error, .. } => format!("{error:?}").hash(state),
         Value::Binary { val, .. } => val.hash(state),
         Value::CellPath { val, .. } => {
             val.members.len().hash(state);
@@ -593,8 +600,17 @@ fn group_values_eq(left: &Value, right: &Value) -> bool {
         (Value::List { vals: a, .. }, Value::List { vals: b, .. }) => {
             a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| group_values_eq(x, y))
         }
-        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => a.block_id == b.block_id,
-        (Value::Error { .. }, Value::Error { .. }) => true,
+        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => {
+            a.block_id == b.block_id
+                && a.captures.len() == b.captures.len()
+                && a.captures
+                    .iter()
+                    .zip(&b.captures)
+                    .all(|((id_a, val_a), (id_b, val_b))| {
+                        *id_a == *id_b && group_values_eq(val_a, val_b)
+                    })
+        }
+        (Value::Error { error: a, .. }, Value::Error { error: b, .. }) => a == b,
         (Value::Binary { val: a, .. }, Value::Binary { val: b, .. }) => a == b,
         (Value::CellPath { val: a, .. }, Value::CellPath { val: b, .. }) => a == b,
         (Value::Custom { val: a, .. }, Value::Custom { val: b, .. }) => {
@@ -844,9 +860,54 @@ impl Grouped {
 #[cfg(test)]
 mod test {
     use super::*;
+    use nu_protocol::{BlockId, ShellError, Span, VarId};
+    use std::hash::Hasher;
 
     #[test]
     fn test_examples() -> nu_test_support::Result {
         nu_test_support::test().examples(GroupBy)
+    }
+
+    fn hash_of(value: &Value) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hash_group_value(value, &mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn group_identity_includes_error_payload_and_closure_captures() {
+        let block = BlockId::new(1);
+        let var = VarId::new(0);
+        let c1 = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(1))],
+        });
+        let c1_again = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(1))],
+        });
+        let c2 = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(2))],
+        });
+        assert!(group_values_eq(&c1, &c1_again));
+        assert_eq!(hash_of(&c1), hash_of(&c1_again));
+        assert!(!group_values_eq(&c1, &c2));
+
+        let e1 = Value::error(
+            ShellError::Generic(GenericError::new("a", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        let e1_again = Value::error(
+            ShellError::Generic(GenericError::new("a", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        let e2 = Value::error(
+            ShellError::Generic(GenericError::new("b", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        assert!(group_values_eq(&e1, &e1_again));
+        assert_eq!(hash_of(&e1), hash_of(&e1_again));
+        assert!(!group_values_eq(&e1, &e2));
     }
 }

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -42,18 +42,17 @@ impl Command for GroupBy {
     }
 
     fn description(&self) -> &str {
-        "Splits a list or table into groups, and returns a record containing those groups."
+        "Splits a list or table into groups. Returns a record when the group keys are strings, otherwise a table."
     }
 
     fn extra_description(&self) -> &str {
-        r#"The default record output uses display-string keys because record keys must be strings:
-    - if the input data is not a string, the grouper converts the key to a string but the values remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
-    - datetime is formatted based on your configuration setting. use `format date` to change the format.
-    - filesize is formatted based on your configuration setting. use `format filesize` to change the format.
-    - some nushell values are not supported, such as closures.
-    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+        r#"Grouping uses typed value identity (same type and payload), not display strings. Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups.
 
-With --to-table, group keys keep their original types and grouping uses typed value identity (same type and payload). Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups. null group keys are included as null values."#
+The default output is a record when every group key is a string. Those record keys are the original strings; they are not reformatted. null group keys are omitted (records cannot use null as a key). Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+
+If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table.
+
+--to-table always returns a table. Group columns keep their original types. null group keys are included as null values."#
     }
 
     fn run(
@@ -107,8 +106,8 @@ With --to-table, group keys keep their original types and grouping uses typed va
                 })),
             },
             Example {
-                description: "Group by a non-string column and keep the original key type.",
-                example: "[{n: 1} {n: 2} {n: 1}] | group-by n --to-table",
+                description: "Group by a non-string column. The result is a table so the keys keep their original type.",
+                example: "[{n: 1} {n: 2} {n: 1}] | group-by n",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "n" => Value::test_int(1),
@@ -152,18 +151,26 @@ With --to-table, group keys keep their original types and grouping uses typed va
                 ])),
             },
             Example {
-                description: "Group bools, whether they are strings or actual bools.",
+                description: "Bools and strings are different keys, so the result is a table.",
                 example: r#"[true "true" false "false"] | group-by"#,
-                result: Some(Value::test_record(record! {
-                    "true" => Value::test_list(vec![
-                        Value::test_bool(true),
-                        Value::test_string("true"),
-                    ]),
-                    "false" => Value::test_list(vec![
-                        Value::test_bool(false),
-                        Value::test_string("false"),
-                    ]),
-                })),
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "group" => Value::test_bool(true),
+                        "items" => Value::test_list(vec![Value::test_bool(true)]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_string("true"),
+                        "items" => Value::test_list(vec![Value::test_string("true")]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_bool(false),
+                        "items" => Value::test_list(vec![Value::test_bool(false)]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_string("false"),
+                        "items" => Value::test_list(vec![Value::test_string("false")]),
+                    }),
+                ])),
             },
             Example {
                 description: "Group items by multiple columns' values.",
@@ -292,7 +299,6 @@ pub fn group_by(
     let groupers: Vec<Spanned<Grouper>> = call.rest(engine_state, stack, 0)?;
     let to_table = call.has_flag(engine_state, stack, "to-table")?;
     let prune = call.has_flag(engine_state, stack, "prune")?;
-    let config = &stack.get_config(engine_state);
 
     let values: Vec<Value> = input.into_iter().collect();
     if values.is_empty() {
@@ -306,31 +312,18 @@ pub fn group_by(
 
     let grouped = match &groupers[..] {
         [first, rest @ ..] => {
-            let mut grouped = Grouped::new(
-                first.as_ref(),
-                prune,
-                values,
-                config,
-                to_table,
-                engine_state,
-                stack,
-            )?;
+            let mut grouped = Grouped::new(first.as_ref(), prune, values, engine_state, stack)?;
             for grouper in rest {
-                grouped.subgroup(
-                    grouper.as_ref(),
-                    prune,
-                    config,
-                    to_table,
-                    engine_state,
-                    stack,
-                )?;
+                grouped.subgroup(grouper.as_ref(), prune, engine_state, stack)?;
             }
             grouped
         }
-        [] => Grouped::empty(values, config, to_table),
+        [] => Grouped::empty(values),
     };
 
-    let value = if to_table {
+    // Records can only use string keys. Non-string group keys keep their type
+    // by emitting the same table --to-table would.
+    let value = if to_table || grouped.has_non_string_key() {
         let column_names = groupers_to_column_names(&groupers)?;
         grouped.into_table(&column_names, head)
     } else {
@@ -401,31 +394,38 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 }
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
-/// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
+/// do not collapse. Record output omits `Nothing` keys; table output emits them as null.
 #[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
-    Display(String),
     Preserved(Value),
 }
 
 impl GroupKey {
-    fn from_value(value: &Value, config: &nu_protocol::Config, preserve_values: bool) -> Self {
+    fn from_value(value: &Value) -> Self {
         if value.is_nothing() {
             Self::Nothing
-        } else if preserve_values {
-            Self::Preserved(value.clone())
         } else {
-            Self::Display(value.to_expanded_string(", ", config))
+            Self::Preserved(value.clone())
         }
     }
 
     fn into_value(self, span: Span) -> Value {
         match self {
             Self::Nothing => Value::nothing(span),
-            Self::Display(s) => Value::string(s, span),
             Self::Preserved(v) => v,
         }
+    }
+
+    fn as_record_key(&self) -> Option<&str> {
+        match self {
+            Self::Preserved(Value::String { val, .. }) => Some(val.as_str()),
+            Self::Nothing | Self::Preserved(_) => None,
+        }
+    }
+
+    fn is_non_string(&self) -> bool {
+        !matches!(self, Self::Nothing | Self::Preserved(Value::String { .. }))
     }
 }
 
@@ -433,7 +433,6 @@ impl PartialEq for GroupKey {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Nothing, Self::Nothing) => true,
-            (Self::Display(a), Self::Display(b)) => a == b,
             (Self::Preserved(a), Self::Preserved(b)) => group_values_eq(a, b),
             _ => false,
         }
@@ -447,7 +446,6 @@ impl Hash for GroupKey {
         std::mem::discriminant(self).hash(state);
         match self {
             Self::Nothing => {}
-            Self::Display(s) => s.hash(state),
             Self::Preserved(v) => hash_group_value(v, state),
         }
     }
@@ -625,8 +623,6 @@ fn group_cell_path(
     column_name: &CellPath,
     prune: bool,
     values: Vec<Value>,
-    config: &nu_protocol::Config,
-    preserve_values: bool,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let optional_path = path_has_optional_member(column_name);
@@ -640,7 +636,7 @@ fn group_cell_path(
             continue;
         }
 
-        let key = GroupKey::from_value(key_val.as_ref(), config, preserve_values);
+        let key = GroupKey::from_value(key_val.as_ref());
 
         if prune {
             // it's okay if this fails since pruning is best-effort
@@ -667,17 +663,15 @@ fn group_closure(
     values: Vec<Value>,
     span: Span,
     closure: Closure,
-    preserve_values: bool,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let mut closure = ClosureEval::new(engine_state, stack, closure);
-    let config = &stack.get_config(engine_state);
 
     for value in values {
         let key_val = closure.run_with_value(value.clone())?.into_value(span)?;
-        let key = GroupKey::from_value(&key_val, config, preserve_values);
+        let key = GroupKey::from_value(&key_val);
 
         groups.entry(key).or_default().push(value);
     }
@@ -713,11 +707,11 @@ enum Tree {
 }
 
 impl Grouped {
-    fn empty(values: Vec<Value>, config: &nu_protocol::Config, preserve_values: bool) -> Self {
+    fn empty(values: Vec<Value>) -> Self {
         let mut groups = IndexMap::<_, Vec<_>>::new();
 
         for value in values.into_iter() {
-            let key = GroupKey::from_value(&value, config, preserve_values);
+            let key = GroupKey::from_value(&value);
             groups.entry(key).or_default().push(value);
         }
 
@@ -730,20 +724,15 @@ impl Grouped {
         grouper: Spanned<&Grouper>,
         prune: bool,
         values: Vec<Value>,
-        config: &nu_protocol::Config,
-        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
         let groups = match grouper.item {
-            Grouper::CellPath { val } => {
-                group_cell_path(val, prune, values, config, preserve_values)?
-            }
+            Grouper::CellPath { val } => group_cell_path(val, prune, values)?,
             Grouper::Closure { val } => group_closure(
                 values,
                 grouper.span,
                 Closure::clone(val),
-                preserve_values,
                 engine_state,
                 stack,
             )?,
@@ -757,8 +746,6 @@ impl Grouped {
         &mut self,
         grouper: Spanned<&Grouper>,
         prune: bool,
-        config: &nu_protocol::Config,
-        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<(), ShellError> {
@@ -766,28 +753,30 @@ impl Grouped {
             Tree::Leaf(groups) => std::mem::take(groups)
                 .into_iter()
                 .map(|(key, values)| -> Result<_, ShellError> {
-                    let leaf = Self::new(
-                        grouper,
-                        prune,
-                        values,
-                        config,
-                        preserve_values,
-                        engine_state,
-                        stack,
-                    )?;
+                    let leaf = Self::new(grouper, prune, values, engine_state, stack)?;
                     Ok((key, leaf))
                 })
                 .collect::<Result<IndexMap<_, _>, ShellError>>()?,
             Tree::Branch(nested_groups) => {
                 let mut nested_groups = std::mem::take(nested_groups);
                 for v in nested_groups.values_mut() {
-                    v.subgroup(grouper, prune, config, preserve_values, engine_state, stack)?;
+                    v.subgroup(grouper, prune, engine_state, stack)?;
                 }
                 nested_groups
             }
         };
         self.groups = Tree::Branch(groups);
         Ok(())
+    }
+
+    fn has_non_string_key(&self) -> bool {
+        match &self.groups {
+            Tree::Leaf(leaf) => leaf.keys().any(GroupKey::is_non_string),
+            Tree::Branch(branch) => {
+                branch.keys().any(GroupKey::is_non_string)
+                    || branch.values().any(Self::has_non_string_key)
+            }
+        }
     }
 
     fn into_table(self, column_names: &[String], head: Span) -> Value {
@@ -831,9 +820,9 @@ impl Grouped {
                 leaf.into_iter()
                     // Records cannot use null as a key; omit null groups rather than
                     // mapping them to the empty string (which collides with "").
-                    .filter_map(|(k, v)| match k {
-                        GroupKey::Display(key) => Some((key, v.into_value(head))),
-                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
+                    .filter_map(|(k, v)| {
+                        k.as_record_key()
+                            .map(|key| (key.to_string(), v.into_value(head)))
                     })
                     .collect(),
                 head,
@@ -841,9 +830,9 @@ impl Grouped {
             Tree::Branch(branch) => {
                 let values = branch
                     .into_iter()
-                    .filter_map(|(k, v)| match k {
-                        GroupKey::Display(key) => Some((key, v.into_record(head))),
-                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
+                    .filter_map(|(k, v)| {
+                        k.as_record_key()
+                            .map(|key| (key.to_string(), v.into_record(head)))
                     })
                     .collect();
                 Value::record(values, head)

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -1,9 +1,12 @@
 use indexmap::IndexMap;
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
-    FromValue, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
+    FromValue, Range, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
 };
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Bound,
+};
 
 #[derive(Clone)]
 pub struct GroupBy;
@@ -399,9 +402,6 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
 /// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
-///
-/// Default record output groups by display string (`Display`). `--to-table` keeps the
-/// original value and groups by typed identity (`Preserved`).
 #[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
@@ -467,7 +467,7 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
         Value::Filesize { val, .. } => val.hash(state),
         Value::Duration { val, .. } => val.hash(state),
         Value::Date { val, .. } => val.hash(state),
-        Value::Range { val, .. } => val.to_string().hash(state),
+        Value::Range { val, .. } => hash_range(val, state),
         Value::Record { val, .. } => {
             let mut pairs: Vec<_> = val.iter().collect();
             pairs.sort_unstable_by_key(|(a, _)| *a);
@@ -513,6 +513,50 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
     }
 }
 
+fn hash_range<H: Hasher>(range: &Range, state: &mut H) {
+    match range {
+        Range::IntRange(r) => {
+            0u8.hash(state);
+            r.start().hash(state);
+            r.step().hash(state);
+            r.end().hash(state);
+        }
+        Range::FloatRange(r) => {
+            1u8.hash(state);
+            r.start().to_bits().hash(state);
+            r.step().to_bits().hash(state);
+            match r.end() {
+                Bound::Unbounded => 0u8.hash(state),
+                Bound::Included(v) => {
+                    1u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+                Bound::Excluded(v) => {
+                    2u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+            }
+        }
+    }
+}
+
+fn ranges_eq(left: &Range, right: &Range) -> bool {
+    match (left, right) {
+        (Range::IntRange(a), Range::IntRange(b)) => a == b,
+        (Range::FloatRange(a), Range::FloatRange(b)) => {
+            a.start().to_bits() == b.start().to_bits()
+                && a.step().to_bits() == b.step().to_bits()
+                && match (a.end(), b.end()) {
+                    (Bound::Unbounded, Bound::Unbounded) => true,
+                    (Bound::Included(x), Bound::Included(y))
+                    | (Bound::Excluded(x), Bound::Excluded(y)) => x.to_bits() == y.to_bits(),
+                    _ => false,
+                }
+        }
+        _ => false,
+    }
+}
+
 fn group_values_eq(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::Bool { val: a, .. }, Value::Bool { val: b, .. }) => a == b,
@@ -534,10 +578,7 @@ fn group_values_eq(left: &Value, right: &Value) -> bool {
         (Value::Filesize { val: a, .. }, Value::Filesize { val: b, .. }) => a == b,
         (Value::Duration { val: a, .. }, Value::Duration { val: b, .. }) => a == b,
         (Value::Date { val: a, .. }, Value::Date { val: b, .. }) => a == b,
-        // Typed identity: do not use Range::eq, which treats int and float ranges as equal.
-        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => {
-            a.to_string() == b.to_string()
-        }
+        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => ranges_eq(a, b),
         (Value::Record { val: a, .. }, Value::Record { val: b, .. }) => {
             if a.len() != b.len() {
                 return false;

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -91,34 +91,26 @@ fn group_by_to_table_on_empty_list_returns_empty_list() -> Result {
 
 #[test]
 fn optional_cell_path_works() -> Result {
+    // Int keys are not strings, so the default output is a table.
     test()
         .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
-        .expect_value_eq(test_value!({
-            "123": [{foo: 123}],
-            "234": [{foo: 234}],
-        }))
+        .expect_value_eq(test_value!([
+            {foo: 123, items: [{foo: 123}]},
+            {foo: 234, items: [{foo: 234}]},
+        ]))
 }
 
 #[test]
 fn group_by_compound_values_are_grouped_distinctly() -> Result {
-    // Regression test for grouping by list values.
-    let code = "
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
-        $data | group-by v | columns | length
-    ";
-    test().run(code).expect_value_eq(4)?;
-
-    // Every distinct list value should produce a separate group with exactly 1 row.
-    let code = "
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
-        $data
-        | group-by v
-        | values
-        | each {|items| $items | length }
-        | uniq
-        | first
-    ";
-    test().run(code).expect_value_eq(1)
+    // List keys force table output. Distinct lists stay distinct.
+    test()
+        .run("[[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]] | group-by v")
+        .expect_value_eq(test_value!([
+            {v: [2, 1], items: [{k: "a", v: [2, 1]}]},
+            {v: [1, 2], items: [{k: "b", v: [1, 2]}]},
+            {v: [3], items: [{k: "c", v: [3]}]},
+            {v: [2], items: [{k: "d", v: [2]}]},
+        ]))
 }
 
 // --- null key consistency (#18707) ---
@@ -193,10 +185,10 @@ fn optional_cell_path_still_skips_nothing() -> Result {
     // Missing optional column is still ignored (historical #9020 behavior).
     test()
         .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
-        .expect_value_eq(test_value!({
-            "123": [{foo: 123}],
-            "234": [{foo: 234}],
-        }))?;
+        .expect_value_eq(test_value!([
+            {foo: 123, items: [{foo: 123}]},
+            {foo: 234, items: [{foo: 234}]},
+        ]))?;
 
     // Optional path with explicit null is also skipped (cannot distinguish from missing).
     test()
@@ -225,14 +217,13 @@ fn multi_grouper_null_key_in_to_table() -> Result {
             {a: 2, b: 1, items: [{a: 2, b: 1}]},
         ]))?;
 
-    // Record mode drops the null branch entirely.
+    // Non-string keys (and null) force table output; null is kept as nothing.
     test()
         .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b")
-        .expect_value_eq(test_value!({
-            "2": {
-                "1": [{a: 2, b: 1}],
-            },
-        }))
+        .expect_value_eq(test_value!([
+            {a: (), b: 1, items: [{a: (), b: 1}]},
+            {a: 2, b: 1, items: [{a: 2, b: 1}]},
+        ]))
 }
 
 #[test]
@@ -277,10 +268,52 @@ fn to_table_keeps_int_keys() -> Result {
 }
 
 #[test]
-fn record_mode_still_groups_filesizes_by_display_string() -> Result {
+fn non_string_keys_emit_a_table_without_to_table_flag() -> Result {
     test()
-        .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
-        .expect_value_eq(1)
+        .run("[[size]; [1MB] [1.001MB]] | group-by size | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[[size]; [1MB]] | group-by size | get 0.size | describe")
+        .expect_value_eq("filesize")?;
+
+    test()
+        .run("[{n: 1} {n: 1} {n: 2}] | group-by n")
+        .expect_value_eq(test_value!([
+            {n: 1, items: [{n: 1}, {n: 1}]},
+            {n: 2, items: [{n: 2}]},
+        ]))?;
+
+    test()
+        .run("[1 2 1] | group-by")
+        .expect_value_eq(test_value!([
+            {group: 1, items: [1, 1]},
+            {group: 2, items: [2]},
+        ]))?;
+
+    test()
+        .run(r#"[true "true"] | group-by"#)
+        .expect_value_eq(test_value!([
+            {group: true, items: [true]},
+            {group: "true", items: ["true"]},
+        ]))?;
+
+    test()
+        .run(r#"["a" 1] | group-by"#)
+        .expect_value_eq(test_value!([
+            {group: "a", items: ["a"]},
+            {group: 1, items: [1]},
+        ]))
+}
+
+#[test]
+fn string_keys_still_emit_a_record() -> Result {
+    test()
+        .run("['a' 'b' 'a'] | group-by")
+        .expect_value_eq(test_value!({
+            a: ["a", "a"],
+            b: ["b"],
+        }))
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -317,6 +317,37 @@ fn string_keys_still_emit_a_record() -> Result {
 }
 
 #[test]
+fn items_grouper_errors_when_output_is_a_table() -> Result {
+    // String keys still emit a record, so a column named `items` is fine.
+    test()
+        .run(r#"[{items: "a"} {items: "a"}] | group-by items"#)
+        .expect_value_eq(test_value!({
+            a: [{items: "a"}, {items: "a"}],
+        }))?;
+
+    // Non-string keys emit a table, which cannot have two `items` columns.
+    let err = test()
+        .run("[{items: 1} {items: 2}] | group-by items")
+        .expect_shell_error()?;
+    match err {
+        ShellError::Generic(generic) => {
+            assert_contains("items", generic.error.as_ref());
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
+}
+
+#[test]
+fn closures_with_different_captures_are_distinct_groups() -> Result {
+    let code = "
+        let make = {|n| {|| $n }}
+        [(do $make 1) (do $make 1) (do $make 2)] | group-by --to-table | length
+    ";
+    test().run(code).expect_value_eq(2)
+}
+
+#[test]
 fn to_table_does_not_merge_int_and_float_ranges() -> Result {
     // `1..3 == 1.0..3.0` is true, but --to-table groups by typed identity.
     test()

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -217,12 +217,12 @@ fn all_nulls_record_is_empty_table_has_null_group() -> Result {
 
 #[test]
 fn multi_grouper_null_key_in_to_table() -> Result {
-    // Non-null keys are still stringified for grouping; null is preserved as nothing.
+    // --to-table keeps original key types; null is preserved as nothing.
     test()
         .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b --to-table")
         .expect_value_eq(test_value!([
-            {a: (), b: "1", items: [{a: (), b: 1}]},
-            {a: "2", b: "1", items: [{a: 2, b: 1}]},
+            {a: (), b: 1, items: [{a: (), b: 1}]},
+            {a: 2, b: 1, items: [{a: 2, b: 1}]},
         ]))?;
 
     // Record mode drops the null branch entirely.
@@ -233,4 +233,52 @@ fn multi_grouper_null_key_in_to_table() -> Result {
                 "1": [{a: 2, b: 1}],
             },
         }))
+}
+
+#[test]
+fn to_table_preserves_filesize_keys_and_does_not_collapse_display_collisions() -> Result {
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size --to-table | length")
+        .expect_value_eq(2)?;
+
+    let code = "
+        let data = [[size]; [1MB] [1.001MB]]
+        let grouped = $data | group-by size --to-table
+        $grouped.size == $data.size
+    ";
+    test().run(code).expect_value_eq(true)?;
+
+    test()
+        .run("[[size]; [1MB]] | group-by size --to-table | get 0.size | describe")
+        .expect_value_eq("filesize")?;
+
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size --to-table | get 0.size | into filesize")
+        .expect_value_eq(nu_protocol::Filesize::new(1_000_000))
+}
+
+#[test]
+fn to_table_groups_equal_lists_and_keeps_list_keys() -> Result {
+    test()
+        .run("[[k v]; [a [1]] [b [1]]] | group-by v --to-table")
+        .expect_value_eq(test_value!([
+            {v: [1], items: [{k: "a", v: [1]}, {k: "b", v: [1]}]},
+        ]))
+}
+
+#[test]
+fn to_table_keeps_int_keys() -> Result {
+    test()
+        .run("[{n: 1} {n: 1} {n: 2}] | group-by n --to-table")
+        .expect_value_eq(test_value!([
+            {n: 1, items: [{n: 1}, {n: 1}]},
+            {n: 2, items: [{n: 2}]},
+        ]))
+}
+
+#[test]
+fn record_mode_still_groups_filesizes_by_display_string() -> Result {
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
+        .expect_value_eq(1)
 }

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -282,3 +282,33 @@ fn record_mode_still_groups_filesizes_by_display_string() -> Result {
         .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
         .expect_value_eq(1)
 }
+
+#[test]
+fn to_table_does_not_merge_int_and_float_ranges() -> Result {
+    // `1..3 == 1.0..3.0` is true, but --to-table groups by typed identity.
+    test()
+        .run("[1..3, 1..3, 1.0..3.0] | group-by --to-table | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[1..3, 1..3] | group-by --to-table | length")
+        .expect_value_eq(1)?;
+
+    test()
+        .run("[1.0..3.0, 1.0..3.0] | group-by --to-table | length")
+        .expect_value_eq(1)?;
+
+    test()
+        .run("[1..3, 1..4] | group-by --to-table | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[1..3] | group-by --to-table | get 0.group | describe")
+        .expect_value_eq("range")?;
+
+    let code = "
+        let grouped = [1..3, 1..3, 1.0..3.0] | group-by --to-table
+        ($grouped.items.0 | length) == 2 and ($grouped.items.1 | length) == 1
+    ";
+    test().run(code).expect_value_eq(true)
+}

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -212,7 +212,7 @@ fn sqlite_database_operations(#[case] operation: &str, #[case] expected: impl In
 #[case::wrap("wrap wrapped | columns | first", "wrapped")]
 #[case::interleave("interleave { [{z: 999}] } | length", 6)]
 #[case::rotate("rotate --ccw | columns | first", "column0")]
-#[case::group_by("group-by z | columns | length", 4)]
+#[case::group_by("group-by z | length", 5)]
 #[case::get("get z.0", 1)]
 #[case::length("length", 5)]
 #[case::merge("first | merge {n: 1} | get n", 1)]


### PR DESCRIPTION
## Description

`group-by` always grouped by `Value::to_expanded_string`. That is required for the default record output, because record keys are strings. `--to-table` has no such constraint, but it used the same string keys anyway.

That caused three user-visible bugs:

1. **Type is lost.** Group columns become `string` even when the source column is `filesize`, `int`, `datetime`, `list`, etc.

   ```nu
   ls | group-by size --to-table | describe
   # table<size: string, items: table<... size: filesize ...>>
   ```

2. **Distinct values collapse** when they share a display string. Default filesize formatting uses one decimal place, so `1MB` and `1.001MB` both render as `1.0 MB` / `1,0 MB` and land in one group, even though they compare as different.

   ```nu
   [[size]; [1MB] [1.001MB]]
   | tee { if $in.0 == $in.1 { print same } else { print different } }
   | group-by size --to-table
   # different
   # one group, both rows under the same string key
   ```

3. **Round-trip is locale-broken.** The key is a localized display string, so `into filesize` fails unless the user first does `str replace , .`.

   ```nu
   [[size]; [1MB] [1.001MB]] | group-by size --to-table
   # Error: can't convert string to filesize
   ```

## User-facing changes (Release notes)

### `group-by --to-table` keeps original key types

`group-by --to-table` no longer converts group keys to display strings. The group columns keep the original type, and rows are grouped by typed value identity (same type and payload), not by how the value would print.

```nu
[{n: 1} {n: 2} {n: 1}] | group-by n --to-table
# n is int, not string
```

```nu
[[k v]; [a [1]] [b [1]]] | group-by v --to-table
# one group, v is list<int> [1]
```

```nu
[[size]; [1MB] [1.001MB]] | group-by size --to-table | describe
# table<size: filesize, items: table<size: filesize>>
```

Distinct filesizes that used to share a formatted string (`1MB` and `1.001MB` both display as `1.0 MB`) are now separate groups. The group key can be used as a filesize again without `str replace` / `into filesize` workarounds:

```nu
[[size]; [1MB] [1.001MB]] | group-by size --to-table
```

Default `group-by` (record output) is unchanged: keys are still display strings, `"true"` and `true` still share a group, and filesize/datetime still follow config. Use `--to-table` when you need the original type.

This is a breaking change for scripts that assumed `--to-table` keys were strings (`str replace`, `into filesize` after stringify, string compares). `"true"` and `true` are now separate `--to-table` groups.


## Additional notes
closes https://github.com/nushell/nushell/issues/12226