### PR TITLE
allow boolean comparison with semver

### DIFF
--- a/crates/nu-command/src/conversions/into/semver.rs
+++ b/crates/nu-command/src/conversions/into/semver.rs
@@ -522,6 +522,34 @@ mod tests {
             .run_with_data("into semver a c | values", value)
             .expect_value_eq(vec!["0.10.2", "will not error", "5.3.0"])
     }
+
+    #[test]
+    fn semver_comparison_can_be_or_ed_with_bool() -> Result {
+        test()
+            .run("true or (('1.0.0' | into semver) < ('2.0.0' | into semver))")
+            .expect_value_eq(true)
+    }
+
+    #[test]
+    fn semver_comparison_can_be_and_ed_with_bool() -> Result {
+        test()
+            .run("false and (('1.0.0' | into semver) < ('2.0.0' | into semver))")
+            .expect_value_eq(false)
+    }
+
+    #[test]
+    fn semver_comparison_can_be_bound_with_let() -> Result {
+        test()
+            .run("let x = ('1.0.0' | into semver) < ('2.0.0' | into semver); $x")
+            .expect_value_eq(true)
+    }
+
+    #[test]
+    fn semver_in_range_can_be_or_ed_with_bool() -> Result {
+        test()
+            .run("true or (('1.2.3' | into semver) in ('>=1.0.0' | into semver-range))")
+            .expect_value_eq(true)
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -261,6 +261,12 @@ mod math {
     }
 }
 
+/// Custom comparisons may return a bool (semver, matrix) or another custom
+/// value (polars expressions). Parse-time only has the type name, so allow both.
+fn custom_comparison_type(name: &str) -> Type {
+    Type::one_of([Type::Bool, Type::Custom(name.into())])
+}
+
 fn ord_cmp_op(lhs: &Type, rhs: &Type) -> Option<Type> {
     fn op(lhs: &Type, rhs: &Type) -> Option<Type> {
         Some(match (lhs, rhs) {
@@ -274,8 +280,8 @@ fn ord_cmp_op(lhs: &Type, rhs: &Type) -> Option<Type> {
             (Type::Filesize, Type::Filesize) => Type::Bool,
             (Type::Bool, Type::Bool) => Type::Bool,
 
-            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
-            (Type::Custom(a), _) => Type::Custom(a.clone()),
+            (Type::Custom(a), Type::Custom(b)) if a == b => custom_comparison_type(a),
+            (Type::Custom(a), _) => custom_comparison_type(a),
 
             (Type::Nothing, _) | (_, Type::Nothing) => Type::Nothing, // TODO: is this right
             // TODO: should this include:
@@ -296,8 +302,8 @@ fn str_cmp_op(lhs: &Type, rhs: &Type) -> Option<Type> {
         Some(match (lhs, rhs) {
             (Type::String | Type::Any, Type::String | Type::Any) => Type::Bool,
             // TODO: should this include glob?
-            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
-            (Type::Custom(a), _) => Type::Custom(a.clone()),
+            (Type::Custom(a), Type::Custom(b)) if a == b => custom_comparison_type(a),
+            (Type::Custom(a), _) => custom_comparison_type(a),
             _ => return None,
         })
     }
@@ -311,8 +317,8 @@ fn in_op(lhs: &Type, rhs: &Type) -> Option<Type> {
             (Type::Int | Type::Float | Type::Number, Type::Range) => Type::Bool,
             (Type::String, Type::String) => Type::Bool,
             (Type::String, Type::Record(_)) => Type::Bool,
-            (Type::Custom(a), Type::Custom(b)) if a == b => Type::Custom(a.clone()),
-            (Type::Custom(a), _) => Type::Custom(a.clone()),
+            (Type::Custom(a), Type::Custom(b)) if a == b => custom_comparison_type(a),
+            (Type::Custom(a), _) => custom_comparison_type(a),
             _ => return None,
         })
     }
@@ -323,7 +329,8 @@ fn has_op(lhs: &Type, rhs: &Type) -> Option<Type> {
     in_op(rhs, lhs)
 }
 
-// TODO: rework type checking for Custom values
+// Custom math/boolean ops still return the custom type. Comparison-class ops
+// use `custom_comparison_type` (`oneof<bool, custom>`).
 pub fn math_result_type(
     working_set: &mut StateWorkingSet,
     lhs: &mut Expression,
@@ -531,8 +538,8 @@ pub fn math_result_type(
         },
         Operator::Comparison(Comparison::Equal | Comparison::NotEqual) => {
             match (&lhs.ty, &rhs.ty) {
-                (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
-                (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
+                (Type::Custom(a), Type::Custom(b)) if a == b => (custom_comparison_type(a), None),
+                (Type::Custom(a), _) => (custom_comparison_type(a), None),
                 _ => (Type::Bool, None),
             }
         }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -2392,6 +2392,38 @@ mod range {
         ),);
     }
 
+    #[rstest]
+    #[case("true or ((to-custom) < (to-custom))")]
+    #[case("true and ((to-custom) == (to-custom))")]
+    #[case("true or ((to-custom) in (to-custom))")]
+    fn custom_comparison_is_usable_as_bool(#[case] code: &str) {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(ToCustom));
+
+        let _ = parse(&mut working_set, None, code.as_bytes(), true);
+
+        assert!(
+            working_set.parse_errors.is_empty(),
+            "Errors: {:?}",
+            working_set.parse_errors
+        );
+    }
+
+    #[test]
+    fn raw_custom_is_not_a_bool_for_or() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(ToCustom));
+
+        let _ = parse(&mut working_set, None, b"true or (to-custom)", true);
+
+        assert!(matches!(
+            &working_set.parse_errors[..],
+            [ParseError::OperatorIncompatibleTypes { .. }]
+        ));
+    }
+
     #[test]
     fn dont_mess_with_external_calls() {
         let engine_state = EngineState::new();


### PR DESCRIPTION
## Description

This PR fixes [#18852](https://github.com/nushell/nushell/issues/18852): the parser rejects boolean expressions that contain semver (and other custom-value) comparisons, even though those comparisons already evaluate to `bool` at runtime.

A script like “the tool is missing **or** its version is too old” fails to parse:

```nushell
true or (('1.0.0' | into semver) < ('2.0.0' | into semver))
# Error: Types 'bool' and 'semver' are not compatible for the 'or' operator.
```

The comparison itself is fine in isolation:

```nushell
('1.0.0' | into semver) < ('2.0.0' | into semver) | describe
# bool
```

## User-facing changes (Release notes)

### Semver (and other custom) comparisons work in boolean expressions

Comparing two semver values already returned a bool at runtime, but the parser treated that result as a `semver`. Combining it with `or` / `and`, binding it with `let`, or passing it to a `bool` parameter failed.

Those now work:

```nu
# missing or out of date
(which crush | is-empty) or ((crush --version | into semver) < ('1.0.0' | into semver))

let outdated = ('0.9.0' | into semver) < ('1.0.0' | into semver)
# $outdated is bool

true or (('1.2.3' | into semver) in ('>=1.0.0' | into semver-range))
```

The same applies to other custom values whose comparisons return a bool (for example matrix). Custom types that return another custom value from `<` / `==` (polars expressions) are unchanged.

A raw custom value is still not a bool: `true or ('1.0.0' | into semver)` remains a type error.
## Additional notes
close #18852