### PR TITLE
allow `$ans` to still work after invalid operation

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -14,7 +14,7 @@ use nu_protocol::{
     report_error::report_compile_error,
     report_parse_error, report_parse_warning, report_shell_error,
     shell_error::{generic::GenericError, io::IoError},
-    truncate_value_to_budget, value_from_bytes,
+    truncate_value_to_budget, value_from_bytes, value_is_error_only,
 };
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
@@ -445,7 +445,9 @@ fn maybe_store_last_result(
             PipelineData::Empty
         }
         PipelineData::Value(value, metadata) => {
-            stack.set_last_result(value.clone(), metadata.clone(), budget);
+            if !value_is_error_only(&value) {
+                stack.set_last_result(value.clone(), metadata.clone(), budget);
+            }
             PipelineData::Value(value, metadata)
         }
         PipelineData::ListStream(stream, metadata) => {
@@ -515,7 +517,9 @@ fn store_list_stream_prefix(
     } else {
         (stored, false)
     };
-    stack.store_last_result_raw(stored, metadata.clone(), truncated || more_trunc);
+    if !value_is_error_only(&stored) {
+        stack.store_last_result_raw(stored, metadata.clone(), truncated || more_trunc);
+    }
 
     // Print stream: under-budget full drain reuses `kept` without a second buffer of clones.
     let print_iter: Box<dyn Iterator<Item = Value> + Send> = match overflow_item {

--- a/crates/nu-cli/tests/last_result.rs
+++ b/crates/nu-cli/tests/last_result.rs
@@ -67,12 +67,12 @@ impl Interactive {
         self
     }
 
-    /// One interactive source unit (like one REPL entry).
-    fn run(&mut self, code: &str) {
+    /// One interactive source unit (like one REPL entry). Returns the eval exit code.
+    fn run(&mut self, code: &str) -> i32 {
         // Match REPL `do_run_cmd`: enable capture only for this user line.
         self.last_source = code.to_string();
         self.engine_state.capture_repl_last_result = true;
-        let _ = eval_source(
+        let code = eval_source(
             &mut self.engine_state,
             &mut self.stack,
             code.as_bytes(),
@@ -81,6 +81,7 @@ impl Interactive {
             false,
         );
         self.engine_state.capture_repl_last_result = false;
+        code
     }
 
     /// Full `$ans` value (record when present, `nothing` when never snapshotted/stored).
@@ -817,6 +818,91 @@ fn command_updates_on_bare_ans_without_clobbering_last() -> Result {
         ])
     );
     assert_eq!(session.last_command()?, last_var());
+    Ok(())
+}
+
+#[test]
+fn error_values_from_str_length_do_not_clobber_last() -> Result {
+    // https://github.com/nushell/nushell/issues/18861
+    // `str length` embeds type errors as values; `$ans.last` must stay the prior table.
+    let mut session = Interactive::new();
+    session.run("[{name: a}]");
+    let original = session.last_payload()?;
+    assert!(
+        matches!(original, Value::List { .. }),
+        "expected table payload, got {original:?}"
+    );
+
+    let failed = format!("{}.last | str length", last_var());
+    session.run(&failed);
+    session.snapshot_metadata(Duration::from_millis(1));
+    assert_eq!(session.last_payload()?, original);
+    assert_eq!(session.last_command()?, failed);
+
+    let ans_code = session.run(&last_var());
+    assert_eq!(
+        ans_code, 0,
+        "bare $ans must stay printable after error values"
+    );
+    assert_eq!(session.last_payload()?, original);
+    Ok(())
+}
+
+#[test]
+fn error_values_do_not_clobber_last_with_table_expand_hook() -> Result {
+    // Default display_output uses `table -e` on wide terminals; force it so CI reproduces.
+    let mut session = Interactive::new();
+    session.run("$env.config.hooks.display_output = 'table --expand'");
+    session.run("[{name: a}]");
+    let original = session.last_payload()?;
+
+    session.run(&format!("{}.last | str length", last_var()));
+    assert_eq!(session.last_payload()?, original);
+
+    let ans_code = session.run(&last_var());
+    assert_eq!(
+        ans_code, 0,
+        "bare $ans with table --expand must not rethrow stored type errors"
+    );
+    assert_eq!(session.last_payload()?, original);
+    Ok(())
+}
+
+#[test]
+fn error_only_list_stream_does_not_clobber_last() -> Result {
+    let mut session = Interactive::new();
+    session.run("[{name: a}]");
+    let original = session.last_payload()?;
+
+    // Range + each yields a list stream of records; str length maps it to error values.
+    session.run("1..2 | each {|i| {name: $i}} | str length");
+    assert_eq!(session.last_payload()?, original);
+    Ok(())
+}
+
+#[test]
+fn mixed_str_length_result_does_replace_last() -> Result {
+    // Cell-path `str length` keeps the table shape: one row becomes an int, one an error value.
+    // That mixed list must still replace `$ans.last` (not treated as error-only).
+    let mut session = Interactive::new();
+    session.run("[{name: 'ab'} {name: 1}]");
+    session.run(&format!("{}.last | str length name", last_var()));
+    let last = session.last_payload()?;
+    let Value::List { vals, .. } = last else {
+        panic!("expected list last payload, got {last:?}");
+    };
+    assert_eq!(vals.len(), 2);
+    let name0 = vals[0]
+        .as_record()
+        .expect("first row")
+        .get("name")
+        .expect("name");
+    assert_eq!(name0, &Value::test_int(2));
+    assert!(
+        vals[1].is_error(),
+        "row with a non-string cell should be an error value, got {:?}",
+        vals[1]
+    );
     Ok(())
 }
 

--- a/crates/nu-command/tests/commands/table/collapse_expand.rs
+++ b/crates/nu-command/tests/commands/table/collapse_expand.rs
@@ -640,6 +640,32 @@ fn table_expand_record_2() -> Result {
 }
 
 #[test]
+fn table_expand_nested_error_list_does_not_rethrow() -> Result {
+    // Nested `Value::Error` lists (e.g. `$ans.last` after `str length` on a table)
+    // must render under `--expand` instead of rethrowing. Construct the record in
+    // Rust: collecting `[{a: 1}] | str length` in a subexpression raises first.
+    use nu_protocol::shell_error::generic::GenericError;
+    use nu_protocol::{Span, record};
+
+    let err = Value::error(
+        ShellError::Generic(GenericError::new("boom", "test", Span::test_data())),
+        Span::test_data(),
+    );
+    let data = Value::test_record(record! {
+        "last" => Value::test_list(vec![err.clone(), err]),
+    });
+    let _: String = test().run_with_data("table --expand | ansi strip", data)?;
+    Ok(())
+}
+
+#[test]
+fn table_expand_top_level_error_list_still_throws() -> Result {
+    test()
+        .run("[{a: 1}] | str length | table --expand")
+        .expect_error_code_eq("nu::shell::only_supports_this_input_type")
+}
+
+#[test]
 #[deps(TESTBIN_MEOW)]
 fn external_with_too_much_stdout_should_not_hang_nu() -> Result {
     use nu_test_support::fs::Stub::FileWithContent;

--- a/crates/nu-protocol/src/last_result.rs
+++ b/crates/nu-protocol/src/last_result.rs
@@ -227,6 +227,20 @@ fn truncate_binary(val: Vec<u8>, budget: usize, span: Span) -> (Value, bool) {
     }
 }
 
+/// True when `value` is a [`Value::Error`] or a non-empty list of only errors.
+///
+/// Commands like `str length` embed type mismatches as values via `operate()`
+/// instead of failing the pipeline. Interactive last-result must not replace
+/// `$ans.last` with those payloads (same policy as a thrown runtime error).
+/// Mixed lists (some errors, some values) are real results and return false.
+pub fn value_is_error_only(value: &Value) -> bool {
+    match value {
+        Value::Error { .. } => true,
+        Value::List { vals, .. } => !vals.is_empty() && vals.iter().all(Value::is_error),
+        _ => false,
+    }
+}
+
 /// Returns true when `block` is only a reference to the last-result variable or a
 /// cell-path rooted at it (e.g. `$ans`, `$ans.last`, `$ans.exit_code`, `$ans.command`),
 /// optionally wrapped in parentheses / a single-element pipeline.
@@ -434,5 +448,36 @@ mod tests {
         let (out, truncated) = truncate_value_to_budget(rec, budget);
         assert!(truncated);
         assert!(out.memory_size() <= budget);
+    }
+
+    fn error_value() -> Value {
+        Value::error(
+            crate::ShellError::Generic(crate::shell_error::generic::GenericError::new(
+                "boom",
+                "",
+                Span::test_data(),
+            )),
+            Span::test_data(),
+        )
+    }
+
+    #[test]
+    fn error_only_detects_error_value() {
+        assert!(value_is_error_only(&error_value()));
+        assert!(!value_is_error_only(&Value::test_int(1)));
+        assert!(!value_is_error_only(&Value::test_nothing()));
+    }
+
+    #[test]
+    fn error_only_detects_nonempty_error_list() {
+        let list = Value::test_list(vec![error_value(), error_value()]);
+        assert!(value_is_error_only(&list));
+        assert!(!value_is_error_only(&Value::test_list(vec![])));
+    }
+
+    #[test]
+    fn error_only_rejects_mixed_list() {
+        let list = Value::test_list(vec![error_value(), Value::test_int(2)]);
+        assert!(!value_is_error_only(&list));
     }
 }

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -56,6 +56,7 @@ pub use example::*;
 pub use id::*;
 pub use last_result::{
     block_is_bare_last_result, block_is_bare_last_result_with, truncate_value_to_budget,
+    value_is_error_only,
 };
 pub use lev_distance::levenshtein_distance;
 pub use module::*;

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -33,18 +33,30 @@ impl ExpandedTable {
     }
 
     pub fn build_value(self, item: &Value, opts: TableOpts<'_>) -> NuText {
-        let cfg = Cfg { opts, format: self };
+        let cfg = Cfg {
+            opts,
+            format: self,
+            raise_row_errors: false,
+        };
         let cell = expand_entry(item, cfg);
         (cell.text, cell.style)
     }
 
     pub fn build_map(self, record: &Record, opts: TableOpts<'_>) -> StringResult {
-        let cfg = Cfg { opts, format: self };
+        let cfg = Cfg {
+            opts,
+            format: self,
+            raise_row_errors: false,
+        };
         expanded_table_kv(record, cfg).map(|cell| cell.map(|cell| cell.text))
     }
 
     pub fn build_list(self, vals: &[Value], opts: TableOpts<'_>) -> StringResult {
-        let cfg = Cfg { opts, format: self };
+        let cfg = Cfg {
+            opts,
+            format: self,
+            raise_row_errors: true,
+        };
         let output = expand_list(vals, cfg.clone())?;
         let mut output = match output {
             Some(out) => out,
@@ -66,6 +78,9 @@ impl ExpandedTable {
 struct Cfg<'a> {
     opts: TableOpts<'a>,
     format: ExpandedTable,
+    /// When true, a `Value::Error` row is re-raised (top-level `table --expand`).
+    /// Nested expansion leaves errors as cells so wrapping records (e.g. `$ans`) stay printable.
+    raise_row_errors: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -154,7 +169,7 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
         for (row, item) in input.iter().enumerate() {
             cfg.opts.signals.check(&cfg.opts.span)?;
-            check_value(item)?;
+            cfg.check_row(item)?;
 
             let inner_cfg = cfg_expand_reset_table(cfg.clone(), available_width);
             let cell = expand_entry(item, inner_cfg);
@@ -178,7 +193,7 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
         for (row, item) in input.iter().enumerate() {
             cfg.opts.signals.check(&cfg.opts.span)?;
-            check_value(item)?;
+            cfg.check_row(item)?;
 
             let index = row + row_offset;
             let index_value = item
@@ -203,7 +218,7 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
         for (row, item) in input.iter().enumerate() {
             cfg.opts.signals.check(&cfg.opts.span)?;
-            check_value(item)?;
+            cfg.check_row(item)?;
 
             let inner_cfg = cfg_expand_reset_table(cfg.clone(), available_width);
             let cell = expand_entry(item, inner_cfg);
@@ -234,7 +249,7 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
         for (row, item) in input.iter().enumerate() {
             cfg.opts.signals.check(&cfg.opts.span)?;
-            check_value(item)?;
+            cfg.check_row(item)?;
 
             let index = row + row_offset;
             let index_value = item
@@ -293,7 +308,7 @@ fn expand_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 
         for (row, item) in input.iter().enumerate() {
             cfg.opts.signals.check(&cfg.opts.span)?;
-            check_value(item)?;
+            cfg.check_row(item)?;
 
             let inner_cfg = cfg_expand_reset_table(cfg.clone(), available);
             let cell = expand_entry_with_header(item, &header, inner_cfg);
@@ -668,8 +683,18 @@ fn value_to_wrapped_string_clean(value: &Value, cfg: &Cfg<'_>, value_width: usiz
     wrap_text(&text, value_width, cfg.opts.config)
 }
 
+impl Cfg<'_> {
+    fn check_row(&self, item: &Value) -> Result<(), ShellError> {
+        if self.raise_row_errors {
+            check_value(item)?;
+        }
+        Ok(())
+    }
+}
+
 fn cfg_expand_next_level(mut cfg: Cfg<'_>, span: Span) -> Cfg<'_> {
     cfg.opts.span = span;
+    cfg.raise_row_errors = false;
     if let Some(deep) = cfg.format.expand_limit.as_mut() {
         *deep -= 1
     }


### PR DESCRIPTION
## Description

This PR fixes a bug with `$ans` after an invalid operation on `$ans.last` (for example `$ans.last | str length` on an `ls` table), bare `$ans` reprinted the same type error and stayed unusable.

The failure only shows up when `display_output` is `table --expand` (`table -e`) which I don't use.

The fix is to skip replacing `.last` when the payload is:

- `Value::Error`
- a non-empty list of only errors
- a list-stream tee of only errors

Leaving the previous `.last` (and its metadata) in place.

## User-facing changes (Release notes)

### Fix `$ans` after invalid operations on `$ans.last`

`$ans` stays usable after a type error on `$ans.last`

Invalid operations on `$ans.last` that embed type errors as values (for example `$ans.last | str length` on a table) no longer replace `$ans.last` or break later `$ans` display.

This mainly showed up with `table --expand` as the `display_output` hook.

```nu
$env.config.max_last_result_size = 1mb

ls
# table of files

$ans.last | str length
# Error: nu::shell::only_supports_this_input_type
# (still printed — the command is invalid)

$ans
# record with the original ls table in `.last` — no longer reprints the type error

$ans.last
# still the ls table
```

`$ans.exit_code`, `$ans.duration`, and `$ans.command` still update for the failed line. Results that mix real values and errors still replace `$ans.last`. Top-level `table --expand` on a list of errors still shows the original diagnostic.

## Additional notes
closes https://github.com/nushell/nushell/issues/18861