### PR TITLE
fix `update` to work better with custom values

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -251,8 +251,15 @@ fn update(
     let head = call.head;
     let cell_path: CellPath = call.req(engine_state, stack, 0)?;
     let replacement: Value = call.req(engine_state, stack, 1)?;
-    let is_custom = matches!(&input, PipelineData::Value(Value::Custom { .. }, _));
-    let input = if is_custom {
+    // Keep non-iterable custom values (e.g. matrix) so cell-path updates stay
+    // on the custom type. Iterable custom values such as SQLiteQueryBuilder
+    // must become a list stream so closure updates run per row.
+    #[expect(deprecated)]
+    let keep_as_custom = matches!(
+        &input,
+        PipelineData::Value(Value::Custom { val, .. }, _) if !val.is_iterable()
+    );
+    let input = if keep_as_custom {
         input
     } else {
         input.into_stream_or_original(engine_state)

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -359,3 +359,45 @@ fn update_nested_table_column_closure_with_in_place_transform() -> Result {
         )
         .expect_value_eq("datetime")
 }
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn update_closure_on_sqlite_query_builder() -> Result {
+    test()
+        .cwd("tests/fixtures/formats")
+        .run("open sample.db | get ints | update z { default 0 | $in + 1 } | get z.0")
+        .expect_value_eq(2)
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn update_literal_on_sqlite_query_builder() -> Result {
+    test()
+        .cwd("tests/fixtures/formats")
+        .run("open sample.db | get ints | update z 0 | get z.0")
+        .expect_value_eq(0)
+}
+
+#[cfg(feature = "sqlite")]
+#[test]
+fn update_into_datetime_on_sqlite_query_builder() -> Result {
+    Playground::setup("update_sqlite_datetime", |dirs, _| {
+        let code = "
+            [{ key: test, created: 1787132290545485211, expiry: 1787139010545500670, value: [7, 2, 128] }]
+            | into sqlite --table-name std_cache_store test.db
+            open test.db | get std_cache_store | update expiry { into datetime } | get expiry.0 | describe
+        ";
+
+        test()
+            .cwd(dirs.test())
+            .run(code)
+            .expect_value_eq("datetime")
+    })
+}
+
+#[test]
+fn update_matrix_row_preserves_matrix_type() -> Result {
+    test()
+        .run("[[1 2] [3 4]] | into matrix | update 0 [5 6] | describe")
+        .expect_value_eq("matrix")
+}


### PR DESCRIPTION
## Description

This PR fixes a problem reported in Discord where `update` with a closure on lazy SQLite tables didn't work.

```nushell
[{ key: test, created: 1787132290545485211, expiry: 1787139010545500670, value: [7, 2, 128, 164, 116, 101, 115, 116, 3] }]
| into sqlite --table-name std_cache_store test.db

open test.db | get std_cache_store | update expiry { into datetime }
# Error: nu::shell::column_not_found
#   x Cannot find column 'expiry'
```
The problem is that `open test.db | get std_cache_store` does **not** return a table. `open` yields a `SQLiteDatabase` custom value. `get <table>` returns a `SQLiteQueryBuilder` custom value: a lazy `SELECT * FROM [std_cache_store]`.

This happened with the `matrix` family of commands. So, it's a regression that wasn't previously tested.

## User-facing changes (Release notes)

### Fix `update` closures on lazy SQLite tables

`update` with a closure now works on a table taken from an opened SQLite database. `open foo.db | get my_table` is a lazy query; it already printed as a table, but `update col { ... }` reported a missing column instead of transforming each row.

```nushell
[{ key: test, created: 1787132290545485211, expiry: 1787139010545500670, value: [7, 2, 128] }]
| into sqlite --table-name std_cache_store test.db

open test.db | get std_cache_store | update expiry { into datetime }
# table with `expiry` as datetime
```

```nushell
open sample.db | get ints | update z { default 0 | $in + 1 }
# each `z` value is incremented
```

## Additional notes
closes https://github.com/nushell/nushell/issues/18864