### PR TITLE
fix `keybindings listen` - ignore KeyEventState when checking for Esc

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -98,7 +98,14 @@ pub fn print_events(config: &Config, span: Span) -> Result<Value, ShellError> {
     loop {
         let event = crossterm::event::read()
             .map_err(|err| IoError::new_internal(err, "Could not read event"))?;
-        if event == Event::Key(KeyCode::Esc.into()) {
+        // match Esc with no modifiers, but ignoring KeyEventState (e.g. NumLock/CapsLock)
+        if let Event::Key(KeyEvent {
+            code: KeyCode::Esc,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+            kind: crossterm::event::KeyEventKind::Press,
+            ..
+        }) = event
+        {
             break;
         }
         // stdout.queue(crossterm::style::Print(format!("event: {:?}", &event)))?;


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
In some contexts (seemingly, when the Kitty keyboard protocol is enabled and supported by the terminal emulator), it's possible for `keybindings listen` to not quit when pressing `Esc` if NumLock (and maybe caps lock) are turned on.
The existing "check for Escape" logic checks that (among other things) `KeyEventState` is `NONE`. This change relaxes precisely the `KeyEventState` check, so e.g. Ctrl+Escape is still reported and doesn't quit `keybindings listen`, but Escape by itself exits, even when NumLock is reported.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Fixed an issue in `keybindings listen` where `Esc` wouldn't quit if a state (e.g. `NumLock` or `CapsLock`) was reported.

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
potentially fixes #14919