### PR TITLE
Completor Fixes

### DIFF
--- a/crates/nu-cli/src/commands/commandline/complete.rs
+++ b/crates/nu-cli/src/commands/commandline/complete.rs
@@ -235,7 +235,9 @@ fn generate_typed_suggestions(
 
     // Explicit matching avoids boxing the source into a `dyn` trait object.
     match completion_type {
-        CompletionType::Directory => DirectoryCompletion.fetch(&context).suggestions,
-        CompletionType::Path | CompletionType::Glob => FileCompletion.fetch(&context).suggestions,
+        CompletionType::Directory => DirectoryCompletion.fetch(&context).into_suggestions(),
+        CompletionType::Path | CompletionType::Glob => {
+            FileCompletion.fetch(&context).into_suggestions()
+        }
     }
 }

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use nu_parser::parse_module_file_or_dir;
 use nu_protocol::{
-    DynamicCompletionCallRef, Span,
+    DynamicCompletionCallRef, Span, SyntaxShape,
     ast::{Argument, Call, Expr, Expression, ListItem},
     engine::{ArgType, StateWorkingSet},
 };
@@ -22,6 +22,10 @@ pub struct ArgValueCompletion<'a> {
     /// Index into `call.arguments`, or `call.arguments.len()` for a synthesized
     /// trailing slot the parser produced no argument for (e.g. `open <tab>`).
     pub arg_idx: usize,
+    /// The `SyntaxShape` this argument is declared with in the command's signature, if
+    /// known. Used to pick a type-specific fallback (e.g. directories for `cd <tab>`) when
+    /// the slot is still empty and so has no parsed expression to read the shape from.
+    pub declared_shape: Option<SyntaxShape>,
     /// Cursor, in absolute working-set (span) coordinates.
     pub cursor: usize,
 }
@@ -237,9 +241,21 @@ impl<'a> ArgValueCompletion<'a> {
     ) -> Fetched {
         let complete_file = || FileCompletion.fetch(completion_context);
 
-        match expression {
-            Some(Expr::Directory(_, _)) => DirectoryCompletion.fetch(completion_context),
-            Some(Expr::Filepath(_, _)) | Some(Expr::GlobPattern(_, _)) => complete_file(),
+        // Prefer the parsed argument's shape. When the slot is still empty (`cd <tab>`)
+        // there is no parsed expression, so fall back to the shape the signature declares
+        // for this argument; otherwise a typed positional/flag would lose its type-specific
+        // completion and dump every path instead (issue #18862).
+        let shape = match expression {
+            Some(Expr::Directory(_, _)) => Some(&SyntaxShape::Directory),
+            Some(Expr::Filepath(_, _)) => Some(&SyntaxShape::Filepath),
+            Some(Expr::GlobPattern(_, _)) => Some(&SyntaxShape::GlobPattern),
+            Some(_) => None,
+            None => self.declared_shape.as_ref(),
+        };
+
+        match shape {
+            Some(SyntaxShape::Directory) => DirectoryCompletion.fetch(completion_context),
+            Some(SyntaxShape::Filepath | SyntaxShape::GlobPattern) => complete_file(),
             // fallback to file completion if necessary
             _ if self.need_fallback => complete_file(),
             _ => Fetched::Pure(vec![]),

--- a/crates/nu-cli/src/completions/arg_value_completion.rs
+++ b/crates/nu-cli/src/completions/arg_value_completion.rs
@@ -90,7 +90,7 @@ impl<'a> ArgValueCompletion<'a> {
                     matcher.add_semantic_suggestion(suggestion);
                 }
 
-                Some(Fetched::cacheable(matcher.suggestion_results()))
+                Some(Fetched::Cacheable(matcher.suggestion_results()))
             }
             Ok(None) => None, // fallback to type based completion, file completion, etc.
             Err(error) => {
@@ -120,13 +120,13 @@ impl<'a> ArgValueCompletion<'a> {
     ) -> Fetched {
         let expression = self.arg_expr();
         let Some((module_name, span)) = self.find_module_name_and_span() else {
-            return Fetched::pure(vec![]);
+            return Fetched::Pure(vec![]);
         };
 
         let Some((module_id, temp_working_set)) =
             self.resolve_module(working_set, module_name, span)
         else {
-            return Fetched::pure(vec![]);
+            return Fetched::Pure(vec![]);
         };
 
         let mut exportable_completion = ExportableCompletion {
@@ -143,7 +143,7 @@ impl<'a> ArgValueCompletion<'a> {
                     completion_context,
                     &mut exportable_completion,
                 ),
-                _ => Fetched::pure(vec![]),
+                _ => Fetched::Pure(vec![]),
             },
             // No expression at all or any other scalar shape (`Expr::String`, plus `Expr::Nothing`
             // for the `null` keyword): search exports by the raw prefix text.
@@ -242,7 +242,7 @@ impl<'a> ArgValueCompletion<'a> {
             Some(Expr::Filepath(_, _)) | Some(Expr::GlobPattern(_, _)) => complete_file(),
             // fallback to file completion if necessary
             _ if self.need_fallback => complete_file(),
-            _ => Fetched::pure(vec![]),
+            _ => Fetched::Pure(vec![]),
         }
     }
 }

--- a/crates/nu-cli/src/completions/attribute_completions.rs
+++ b/crates/nu-cli/src/completions/attribute_completions.rs
@@ -30,7 +30,7 @@ impl Completer for AttributeCompletion {
             });
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }
 
@@ -62,6 +62,6 @@ impl Completer for AttributableCompletion {
             });
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -159,3 +159,16 @@ impl From<Suggestion> for SemanticSuggestion {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `complete_argument_value` relies on this to treat `need_fallback`-requesting
+    /// outcomes as always empty (a dead check was removed on that assumption).
+    #[test]
+    fn fallback_variants_carry_no_suggestions() {
+        assert!(Fetched::Declined.into_suggestions().is_empty());
+        assert!(Fetched::Absent.into_suggestions().is_empty());
+    }
+}

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -8,66 +8,53 @@ pub trait Completer {
     fn fetch(&mut self, ctx: &Context) -> Fetched;
 }
 
-/// The outcome of one source's [`Completer::fetch`], plus two flags the machinery cannot
-/// infer from the suggestions: `cacheable` (impure sources worth reusing between keystrokes)
-/// and `need_fallback` (try the next source). Fields are private, so a declining result can
-/// never also carry suggestions.
+/// The outcome of one source's [`Completer::fetch`]. Caching and fallback are encoded in
+/// the variant, so a declining result cannot carry suggestions.
 #[derive(Debug, Default)]
-pub struct Fetched {
-    pub(crate) suggestions: Vec<SemanticSuggestion>,
-    pub(crate) cacheable: bool,
-    pub(crate) need_fallback: bool,
+pub enum Fetched {
+    /// Cheap engine-state result: never cached, never falls back.
+    Pure(Vec<SemanticSuggestion>),
+    /// Impure source result (filesystem, `PATH`, user/plugin code); worth caching.
+    Cacheable(Vec<SemanticSuggestion>),
+    /// Impure source declined: fall back, but cache the attempt.
+    Declined,
+    /// No source ran: fall back cheaply.
+    #[default]
+    Absent,
 }
 
 impl Fetched {
-    /// A cheap engine-state result: never cached, never falls back.
-    pub(crate) fn pure(suggestions: Vec<SemanticSuggestion>) -> Self {
-        Self {
-            suggestions,
-            cacheable: false,
-            need_fallback: false,
+    /// The suggestions this outcome carries; declining outcomes carry none.
+    pub(crate) fn into_suggestions(self) -> Vec<SemanticSuggestion> {
+        match self {
+            Self::Pure(suggestions) | Self::Cacheable(suggestions) => suggestions,
+            Self::Declined | Self::Absent => Vec::new(),
         }
     }
 
-    /// An impure source's result (filesystem, `PATH`, user/plugin code); worth caching.
-    pub(crate) fn cacheable(suggestions: Vec<SemanticSuggestion>) -> Self {
-        Self {
-            suggestions,
-            cacheable: true,
-            need_fallback: false,
-        }
+    /// Impure source ran; result worth reusing between keystrokes.
+    pub(crate) fn is_cacheable(&self) -> bool {
+        matches!(self, Self::Cacheable(_) | Self::Declined)
     }
 
-    /// An impure source that declined: fall back, but stay `cacheable` since the
-    /// expensive attempt ran.
-    pub(crate) fn fallback() -> Self {
-        Self {
-            suggestions: vec![],
-            cacheable: true,
-            need_fallback: true,
-        }
+    /// Whether this source declined, so the next one should be tried.
+    pub(crate) fn needs_fallback(&self) -> bool {
+        matches!(self, Self::Declined | Self::Absent)
     }
 
-    /// Like [`Self::fallback`] but cheap — no source ran, so nothing to cache.
-    pub(crate) fn absent() -> Self {
-        Self {
-            suggestions: vec![],
-            cacheable: false,
-            need_fallback: true,
+    /// Mark cheap results cacheable when the caller did expensive work.
+    pub(crate) fn caching(self) -> Self {
+        match self {
+            Self::Pure(suggestions) => Self::Cacheable(suggestions),
+            Self::Absent => Self::Declined,
+            already => already,
         }
-    }
-
-    /// Force [`Self::cacheable`] on when the caller did expensive work (e.g. parsing a
-    /// module off disk) around a cheap lookup.
-    pub(crate) fn caching(mut self) -> Self {
-        self.cacheable = true;
-        self
     }
 }
 
-/// Convert an engine [`Span`] to reedline coordinates by subtracting the working-set
-/// `offset`. Both ends saturate so spans before `offset` can't underflow into an index that
-/// would panic (`is_char_boundary`); callers may pass untrusted spans.
+/// An engine [`Span`] in reedline coordinates: subtract `offset`, saturating so spans
+/// before it can't underflow into an index that would panic (`is_char_boundary`); callers
+/// may pass untrusted spans.
 pub(crate) fn to_reedline_span(span: Span, offset: usize) -> reedline::Span {
     reedline::Span::new(
         span.start.saturating_sub(offset),

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -125,9 +125,11 @@ impl IntoValue for SemanticSuggestion {
             };
             record.insert("kind", kind_str.into_value(span));
 
-            if let Some(ty) = ty {
-                record.insert("type", ty.into_value(span));
-            }
+            // Always a column: kinds without a type report `null`.
+            record.insert(
+                "type",
+                ty.map_or_else(|| Value::nothing(span), |ty| ty.into_value(span)),
+            );
         }
 
         Value::record(record, span)

--- a/crates/nu-cli/src/completions/cell_path_completions.rs
+++ b/crates/nu-cli/src/completions/cell_path_completions.rs
@@ -74,7 +74,7 @@ impl Completer for CellPathCompletion<'_> {
             }
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }
 

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -304,8 +304,8 @@ impl Completer for CommandCompletion {
         }
 
         match externals {
-            true => Fetched::cacheable(suggestions),
-            false => Fetched::pure(suggestions),
+            true => Fetched::Cacheable(suggestions),
+            false => Fetched::Pure(suggestions),
         }
     }
 }

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -941,8 +941,9 @@ impl CompletionEngine {
         let subcommands =
             self.subcommand_suggestions(working_set, call.head.start, site.cursor, offset);
 
-        // The value kinds share one shape; only the `ArgType` and custom-completer lookup differ.
-        let argument_value = |engine: &Self, arg_type, custom, arg_slot| {
+        // The value kinds share one shape; only the `ArgType`, custom-completer, and declared
+        // shape lookups differ.
+        let argument_value = |engine: &Self, arg_type, custom, arg_slot, declared_shape| {
             engine.complete_argument_value(
                 custom,
                 ArgValueCompletion {
@@ -951,6 +952,7 @@ impl CompletionEngine {
                     need_fallback: subcommands.suggestions.is_empty(),
                     completer: engine,
                     arg_idx: arg_slot,
+                    declared_shape,
                     cursor: site.cursor,
                 },
                 completion_context,
@@ -964,24 +966,30 @@ impl CompletionEngine {
             SiteKind::FlagName { .. } => {
                 self.complete_flag_names(call.decl_id, completion_context, &signature, element)
             }
-            SiteKind::FlagValue { flag, arg_slot, .. } => argument_value(
-                self,
-                ArgType::Flag(Cow::Borrowed(flag.name())),
-                find_flag(&signature, *flag).and_then(|flag| flag.completion),
-                *arg_slot,
-            ),
+            SiteKind::FlagValue { flag, arg_slot, .. } => {
+                let resolved = find_flag(&signature, *flag);
+                argument_value(
+                    self,
+                    ArgType::Flag(Cow::Borrowed(flag.name())),
+                    resolved.as_ref().and_then(|flag| flag.completion.clone()),
+                    *arg_slot,
+                    resolved.and_then(|flag| flag.arg),
+                )
+            }
             SiteKind::Positional {
                 sig_positional,
                 arg_slot,
                 ..
-            } => argument_value(
-                self,
-                ArgType::Positional(*sig_positional),
-                signature
-                    .get_positional(*sig_positional)
-                    .and_then(|positional| positional.completion.clone()),
-                *arg_slot,
-            ),
+            } => {
+                let positional = signature.get_positional(*sig_positional);
+                argument_value(
+                    self,
+                    ArgType::Positional(*sig_positional),
+                    positional.and_then(|positional| positional.completion.clone()),
+                    *arg_slot,
+                    positional.map(|positional| positional.shape.clone()),
+                )
+            }
             _ => Dispatched::default(),
         };
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -593,8 +593,9 @@ impl Dispatched {
 impl From<Fetched> for Dispatched {
     fn from(fetched: Fetched) -> Self {
         Self {
-            suggestions: fetched.suggestions,
-            cacheable: fetched.cacheable,
+            // Read the cacheable flag before `into_suggestions` consumes the outcome.
+            cacheable: fetched.is_cacheable(),
+            suggestions: fetched.into_suggestions(),
         }
     }
 }
@@ -891,7 +892,7 @@ impl CompletionEngine {
         {
             let mut completion = CommandWideCompletion::closure(closure, external_call);
             let fetched = completion.fetch(completion_context);
-            external_answered = !fetched.need_fallback;
+            external_answered = !fetched.needs_fallback();
             dispatched.merge(fetched.into());
         }
 
@@ -1415,7 +1416,7 @@ impl CompletionEngine {
                     self.custom_completion_helper(other, element_line.as_ref(), context, cursor)
                 }
             };
-            let need_fallback = attempt.need_fallback;
+            let need_fallback = attempt.needs_fallback();
             results.merge(attempt.into());
             if !need_fallback {
                 return results;
@@ -1423,7 +1424,7 @@ impl CompletionEngine {
         }
 
         let attempt = self.command_wide_completion_helper(signature, element_expression, context);
-        let need_fallback = attempt.need_fallback;
+        let need_fallback = attempt.needs_fallback();
         results.merge(attempt.into());
         if !need_fallback {
             return results;
@@ -1578,7 +1579,7 @@ impl CompletionEngine {
             }
             // Engine-provided completions are handled in `complete_argument_value`; decline
             // if one arrives by another path.
-            Completion::Builtin(_) => Fetched::absent(),
+            Completion::Builtin(_) => Fetched::Absent,
         }
     }
 
@@ -1611,7 +1612,7 @@ impl CompletionEngine {
                 };
                 completion.fetch(&context)
             }
-            None => Fetched::absent(),
+            None => Fetched::Absent,
         }
     }
 

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1438,7 +1438,6 @@ impl CompletionEngine {
             return results;
         }
 
-        arg_value.need_fallback &= results.suggestions.is_empty();
         results.merge(arg_value.fetch(context).into());
         results
     }

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -255,7 +255,7 @@ pub(crate) fn complete_paths(ctx: &Context, directories_only: bool) -> Fetched {
     .collect();
 
     hidden_files_last(&mut items);
-    Fetched::cacheable(items)
+    Fetched::Cacheable(items)
 }
 
 /// # Parameters

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -270,23 +270,23 @@ impl Completer for CustomCompletion {
                     self.line_pos - self.line.len(),
                     offset,
                 ),
-                Value::Nothing { .. } => return Fetched::fallback(),
+                Value::Nothing { .. } => return Fetched::Declined,
                 _ => {
                     log::error!(
                         "Custom completer returned invalid value of type {}",
                         value.get_type()
                     );
-                    return Fetched::cacheable(vec![]);
+                    return Fetched::Cacheable(vec![]);
                 }
             },
             Err(e) => {
                 log::error!("Error getting custom completions: {e}");
-                return Fetched::cacheable(vec![]);
+                return Fetched::Cacheable(vec![]);
             }
         };
 
         if !should_filter {
-            return Fetched::cacheable(suggestions);
+            return Fetched::Cacheable(suggestions);
         }
 
         let mut matcher = NuMatcher::new(prefix.as_ref(), &completion_options, should_sort);
@@ -303,7 +303,7 @@ impl Completer for CustomCompletion {
                 matcher.add(description, sugg);
             }
         }
-        Fetched::cacheable(matcher.suggestion_results())
+        Fetched::Cacheable(matcher.suggestion_results())
     }
 }
 
@@ -414,9 +414,9 @@ impl<'a> Completer for CommandWideCompletion<'a> {
         if let Some(results) =
             convert_whole_command_completion_results(offset, span, result, command_span)
         {
-            Fetched::cacheable(results)
+            Fetched::Cacheable(results)
         } else {
-            Fetched::fallback()
+            Fetched::Declined
         }
     }
 }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -281,7 +281,9 @@ impl Completer for CustomCompletion {
             },
             Err(e) => {
                 log::error!("Error getting custom completions: {e}");
-                return Fetched::Cacheable(vec![]);
+                // Error does not equal empty success (matches `CommandWideCompletion`):
+                // fall back so file completion still runs when a custom completer errors.
+                return Fetched::Declined;
             }
         };
 

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -155,6 +155,6 @@ impl Completer for DotNuCompletion {
                 .collect::<Vec<_>>(),
         );
 
-        Fetched::cacheable(all_results)
+        Fetched::Cacheable(all_results)
     }
 }

--- a/crates/nu-cli/src/completions/env_var_completions.rs
+++ b/crates/nu-cli/src/completions/env_var_completions.rs
@@ -25,6 +25,6 @@ impl Completer for EnvVarCompletion {
             });
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -93,6 +93,6 @@ impl Completer for ExportableCompletion<'_> {
                 );
             }
         }
-        Fetched::pure(results)
+        Fetched::Pure(results)
     }
 }

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -42,6 +42,6 @@ impl Completer for FlagCompletion {
                 add_suggestion(format!("--{long}"), named.desc.clone());
             }
         }
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/src/completions/operator_completions.rs
+++ b/crates/nu-cli/src/completions/operator_completions.rs
@@ -235,7 +235,7 @@ impl Completer for OperatorCompletion<'_> {
                 Expr::FullCellPath(path) => {
                     // for `$ <tab>`
                     if let Expr::Garbage = path.head.expr {
-                        return Fetched::pure(vec![]);
+                        return Fetched::Pure(vec![]);
                     }
                     let value =
                         eval_cell_path(working_set, stack, &path.head, &path.tail, path.head.span)
@@ -279,6 +279,6 @@ impl Completer for OperatorCompletion<'_> {
                 kind: Some(SuggestionKind::Operator),
             });
         }
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/src/completions/static_completions.rs
+++ b/crates/nu-cli/src/completions/static_completions.rs
@@ -45,6 +45,6 @@ impl Completer for StaticCompletion {
             }
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -67,6 +67,6 @@ impl Completer for VariableCompletion {
             });
         }
 
-        Fetched::pure(matcher.suggestion_results())
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -928,6 +928,24 @@ fn customcompletions_error_falls_back_to_file_completion() {
     );
 }
 
+/// A completer that calls an interactive command (`input`, `input list`, `input listen`,
+/// `term query`) runs on a background thread detached from the terminal, so the command
+/// should decline rather than race reedline for it; the completer then falls back to file
+/// completion.
+#[test]
+fn interactive_command_in_completer_falls_back_to_file_completion() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = "def comp [] { ['a' 'b'] | input list }; def my-command [arg: string@comp] {}";
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let line = "my-command custom_completion.";
+    match_suggestions(
+        &vec!["custom_completion.nu"],
+        &completer.complete_blocking(line, line.len()),
+    );
+}
+
 /// Suppress completions for invalid values
 #[test]
 fn customcompletions_invalid() {

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -3767,3 +3767,36 @@ fn stale_file_completions_do_not_answer_a_flag_token() {
             .collect::<Vec<_>>()
     );
 }
+
+/// Completing an empty argument slot for a `directory`-typed
+/// argument (like cd) must offer directories ONLY.
+#[test]
+fn empty_directory_arg_slot_completes_directories_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(dir.path().join("alpha_dir")).expect("create dir");
+    std::fs::create_dir(dir.path().join("beta_dir")).expect("create dir");
+    std::fs::write(dir.path().join("gamma.txt"), "").expect("write file");
+
+    let pwd = AbsolutePathBuf::try_from(dir.path().to_path_buf()).expect("absolute tempdir");
+    let (_, _, mut engine, mut stack) = new_engine_helper(pwd);
+
+    // Custom positional and flag, both `directory`-typed, exercise the same paths as `cd`.
+    let command = "def my-cd [dir: directory] {}; def my-flag [--dir: directory] {}";
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let alpha = folder("alpha_dir");
+    let beta = folder("beta_dir");
+    for line in ["cd ", "my-cd ", "my-flag --dir "] {
+        let suggestions = completer.complete_blocking(line, line.len());
+        let values: Vec<&str> = suggestions.iter().map(|s| s.value.as_str()).collect();
+        assert!(
+            values.contains(&alpha.as_str()) && values.contains(&beta.as_str()),
+            "`{line}` should offer the directories, got: {values:?}"
+        );
+        assert!(
+            !values.iter().any(|value| value.contains("gamma")),
+            "`{line}` leaked a non-directory completion: {values:?}"
+        );
+    }
+}

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -932,10 +932,15 @@ fn customcompletions_error_falls_back_to_file_completion() {
 /// `term query`) runs on a background thread detached from the terminal, so the command
 /// should decline rather than race reedline for it; the completer then falls back to file
 /// completion.
-#[test]
-fn interactive_command_in_completer_falls_back_to_file_completion() {
+#[rstest]
+#[case::input("input")]
+#[case::input_reedline("input --reedline")]
+#[case::input_list("['a' 'b'] | input list")]
+#[case::input_listen("input listen")]
+#[case::term_query("term query 'x'")]
+fn interactive_command_in_completer_falls_back_to_file_completion(#[case] body: &str) {
     let (_, _, mut engine, mut stack) = new_engine();
-    let command = "def comp [] { ['a' 'b'] | input list }; def my-command [arg: string@comp] {}";
+    let command = format!("def comp [] {{ {body} }}; def my-command [arg: string@comp] {{}}");
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -912,6 +912,22 @@ fn hide_env_completions() {
     match_suggestions(&expected, &suggestions);
 }
 
+/// A custom completer that errors (unlike an explicit `null` decline) must still fall
+/// back to file completion.
+#[test]
+fn customcompletions_error_falls_back_to_file_completion() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let command = "def comp [] { error make {msg: 'boom'} }; def my-command [arg: string@comp] {}";
+    assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let line = "my-command custom_completion.";
+    match_suggestions(
+        &vec!["custom_completion.nu"],
+        &completer.complete_blocking(line, line.len()),
+    );
+}
+
 /// Suppress completions for invalid values
 #[test]
 fn customcompletions_invalid() {

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -91,8 +91,12 @@ impl Command for Input {
         .any(|x| *x);
 
         if !use_reedline {
+            // `legacy_input` guards the terminal itself via `RawModeGuard`.
             return self.legacy_input(engine_state, stack, call, input);
         }
+
+        // Reedline grabs the terminal itself, so check the precondition here.
+        stack.require_stdin(call.head)?;
 
         let prompt_str: Option<String> = call.opt(engine_state, stack, 0)?;
         let default_val: Option<String> = call.get_flag(engine_state, stack, "default")?;

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -1,8 +1,9 @@
+use crate::platform::RawModeGuard;
 use crossterm::event::{
     DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
     EnableMouseCapture, KeyCode, KeyEventKind, KeyModifiers, MouseEvent, MouseEventKind,
 };
-use crossterm::{execute, terminal};
+use crossterm::execute;
 use nu_engine::command_prelude::*;
 use std::time::Duration;
 
@@ -96,7 +97,7 @@ There are 4 `key_type` variants:
         let add_raw = call.has_flag(engine_state, stack, "raw")?;
         let config = stack.get_config(engine_state);
 
-        terminal::enable_raw_mode().map_err(|err| IoError::new(err, head, None))?;
+        let _raw_mode = RawModeGuard::acquire(stack, head)?;
 
         if config.use_kitty_protocol {
             if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
@@ -134,7 +135,6 @@ There are 4 `key_type` variants:
                     ShellError::Generic(GenericError::new("Error with user input", "", head))
                 })?
             {
-                terminal::disable_raw_mode().map_err(|err| IoError::new(err, head, None))?;
                 return Err(ShellError::Generic(GenericError::new(
                     "Timed out while waiting for user input",
                     "no input was received within the timeout duration",
@@ -146,7 +146,6 @@ There are 4 `key_type` variants:
             })?;
             let event = parse_event(head, &event, &event_type_filter, add_raw);
             if let Some(event) = event {
-                terminal::disable_raw_mode().map_err(|err| IoError::new(err, head, None))?;
                 if config.use_kitty_protocol {
                     let _ = execute!(
                         std::io::stdout(),

--- a/crates/nu-command/src/platform/input/legacy_input.rs
+++ b/crates/nu-command/src/platform/input/legacy_input.rs
@@ -41,6 +41,12 @@ pub trait LegacyInput {
         }
 
         let default_val: Option<String> = call.get_flag(engine_state, stack, "default")?;
+
+        // Acquire the guard (and its `require_stdin` check) before writing anything, so a
+        // detached stack (e.g. a completer running off the main thread) errors out before the
+        // prompt is printed to stdout, instead of corrupting the active display first.
+        let raw_mode = RawModeGuard::acquire(stack, call.head)?;
+
         if let Some(prompt) = &prompt {
             match &default_val {
                 None => print!("{prompt}"),
@@ -51,7 +57,6 @@ pub trait LegacyInput {
 
         let mut buf = String::new();
 
-        let raw_mode = RawModeGuard::acquire(stack, call.head)?;
         // clear terminal events
         while crossterm::event::poll(Duration::from_secs(0)).map_err(&from_io_error)? {
             // If there's an event, read it to remove it from the queue

--- a/crates/nu-command/src/platform/input/legacy_input.rs
+++ b/crates/nu-command/src/platform/input/legacy_input.rs
@@ -1,3 +1,4 @@
+use crate::platform::RawModeGuard;
 use crossterm::{
     cursor,
     event::{Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -50,7 +51,7 @@ pub trait LegacyInput {
 
         let mut buf = String::new();
 
-        crossterm::terminal::enable_raw_mode().map_err(&from_io_error)?;
+        let raw_mode = RawModeGuard::acquire(stack, call.head)?;
         // clear terminal events
         while crossterm::event::poll(Duration::from_secs(0)).map_err(&from_io_error)? {
             // If there's an event, read it to remove it from the queue
@@ -71,8 +72,6 @@ pub trait LegacyInput {
                                     || k.modifiers == KeyModifiers::CONTROL
                                 {
                                     if k.modifiers == KeyModifiers::CONTROL && c == 'c' {
-                                        crossterm::terminal::disable_raw_mode()
-                                            .map_err(&from_io_error)?;
                                         return Err(IoError::new(
                                             shell_error::io::ErrorKind::from_std(
                                                 std::io::ErrorKind::Interrupted,
@@ -105,7 +104,6 @@ pub trait LegacyInput {
                 },
                 Ok(_) => continue,
                 Err(event_error) => {
-                    crossterm::terminal::disable_raw_mode().map_err(&from_io_error)?;
                     return Err(from_io_error(event_error).into());
                 }
             }
@@ -124,7 +122,8 @@ pub trait LegacyInput {
                 execute!(std::io::stdout(), Print(buf.to_string())).map_err(&from_io_error)?;
             }
         }
-        crossterm::terminal::disable_raw_mode().map_err(&from_io_error)?;
+        // Leave raw mode before the trailing newline so it gets the usual carriage return.
+        drop(raw_mode);
         std::io::stdout().write_all(b"\n").map_err(&from_io_error)?;
         match default_val {
             Some(val) if buf.is_empty() => Ok(Value::string(val, call.head).into_pipeline_data()),

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -562,6 +562,8 @@ Use --no-footer and --no-separator to hide the footer and separator line."#
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        // The widget below manages raw mode itself, so check the precondition here.
+        stack.require_stdin(head)?;
         let prompt: Option<String> = call.opt(engine_state, stack, 0)?;
         let multi = call.has_flag(engine_state, stack, "multi")?;
         let fuzzy = call.has_flag(engine_state, stack, "fuzzy")?;

--- a/crates/nu-command/src/platform/mod.rs
+++ b/crates/nu-command/src/platform/mod.rs
@@ -6,6 +6,7 @@ mod input;
 mod is_redirected;
 mod is_terminal;
 mod kill;
+mod raw_mode;
 mod sleep;
 mod term;
 #[cfg(unix)]
@@ -24,6 +25,7 @@ pub use input::InputListen;
 pub use is_redirected::IsRedirected;
 pub use is_terminal::IsTerminal;
 pub use kill::Kill;
+pub(crate) use raw_mode::RawModeGuard;
 pub use sleep::Sleep;
 pub use term::{Term, TermQuery, TermSize};
 #[cfg(unix)]

--- a/crates/nu-command/src/platform/raw_mode.rs
+++ b/crates/nu-command/src/platform/raw_mode.rs
@@ -1,0 +1,22 @@
+use nu_protocol::{ShellError, Span, engine::Stack, shell_error::io::IoError};
+
+/// RAII guard for crossterm raw mode: [`acquire`](Self::acquire) checks
+/// [`Stack::require_stdin`] and enables raw mode; [`Drop`] disables it on any exit path.
+#[must_use = "raw mode is disabled as soon as the guard is dropped"]
+pub(crate) struct RawModeGuard;
+
+impl RawModeGuard {
+    /// Enter raw mode, or error per [`Stack::require_stdin`]. `span` points at the offending
+    /// call.
+    pub(crate) fn acquire(stack: &Stack, span: Span) -> Result<Self, ShellError> {
+        stack.require_stdin(span)?;
+        crossterm::terminal::enable_raw_mode().map_err(|err| IoError::new(err, span, None))?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+}

--- a/crates/nu-command/src/platform/term/term_query.rs
+++ b/crates/nu-command/src/platform/term/term_query.rs
@@ -3,6 +3,7 @@ use std::{
     time::Duration,
 };
 
+use crate::platform::RawModeGuard;
 use nu_engine::command_prelude::*;
 use nu_protocol::shell_error::{generic::GenericError, io::IoError};
 
@@ -99,10 +100,7 @@ The `prefix` is not included in the output."
         let prefix = prefix.unwrap_or_default();
         let terminator: Option<Vec<u8>> = call.get_flag(engine_state, stack, "terminator")?;
 
-        crossterm::terminal::enable_raw_mode().map_err(|err| IoError::new(err, call.head, None))?;
-        scopeguard::defer! {
-            let _ = crossterm::terminal::disable_raw_mode();
-        }
+        let _raw_mode = RawModeGuard::acquire(stack, call.head)?;
 
         // clear terminal events
         while crossterm::event::poll(Duration::from_secs(0))

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -1292,6 +1292,30 @@ impl Stack {
         self
     }
 
+    /// Error if this stack is detached from the controlling terminal (see
+    /// [`suppress_stdin`](Self::suppress_stdin), set on completion threads). Commands that grab
+    /// the terminal (`input`, `input list`, `input listen`, `term query`) call this first so
+    /// they decline instead of racing reedline for it; completers turn the error into a
+    /// fallback. `span` points at the offending call.
+    pub fn require_stdin(&self, span: Span) -> Result<(), ShellError> {
+        if self.suppress_stdin {
+            Err(ShellError::Generic(
+                GenericError::new(
+                    "Interactive input is unavailable in this context",
+                    "this command reads from the terminal",
+                    span,
+                )
+                .with_help(
+                    "external and custom completers run detached from the terminal, so \
+                     interactive commands like `input`, `input list`, `input listen`, and \
+                     `term query` cannot be used inside them",
+                ),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     /// Clears any pipe redirections, keeping the current stdout and stderr.
     ///
     /// This will irreversibly reset some of the output redirections, and so it only makes sense to use this on an owned `Stack`


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->


fixes #18862 
## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

- This restores the cd regression, by properly catching/passing the syntax kind throughout the pipeline
- This also provides a fix for external completors which fail, allowing graceful fallback to file completions

## User-facing changes (Release notes)

### Fix completions for `cd` and custom completers

Fixed completions for empty directory-typed arguments such as `cd <tab>` so they suggest directories instead of all paths.

Custom completers that error, return no result, or try to run interactive input commands now gracefully fall back to file completions instead of leaving the completion list empty or racing the line editor for terminal input.

`commandline complete` now includes a `type: null` field for completion items that do not have a more specific type.

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

