### PR TITLE
fix(config): merge keybindings by name and key instead of name alone

### DIFF
--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -613,10 +613,11 @@ $env.config.hooks.command_not_found = null
 # still applied underneath and are listed by `keybindings default`.
 #
 # Assigning this list merges into the defaults rather than replacing them.
-# An entry replaces an existing binding with the same name and the same key
-# (modifier/keycode/mode); anything else is appended, with a one-time warning
-# when two bindings share a name. Set `event: null` on a matching binding to
-# unbind a key, or assign `[]` to clear the whole list.
+# An entry replaces the existing binding with the same name (updating its key
+# or event in place); when several bindings share a name, the key
+# (modifier/keycode/mode) decides which one it is, and a name reused for a
+# genuinely new key appends with a one-time warning. Set `event: null` on a
+# matching binding to unbind a key, or assign `[]` to clear the whole list.
 
 # Example: Add Alt+. keybinding to insert the last token from previous command:
 # $env.config.keybindings ++= [

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -612,10 +612,11 @@ $env.config.hooks.command_not_found = null
 # etc.). Inspect with `$env.config.keybindings`. Reedline's base emacs/vi maps are
 # still applied underneath and are listed by `keybindings default`.
 #
-# Assigning this list merges into the defaults rather than replacing them, so
-# `=` never clears the Nushell menu bindings. Entries are matched by `name`,
-# or by modifier/keycode/mode when unnamed; a match is overwritten, anything
-# else appended. Set `event: null` on a matching binding to unbind a key.
+# Assigning this list merges into the defaults rather than replacing them.
+# An entry replaces an existing binding with the same name and the same key
+# (modifier/keycode/mode); anything else is appended, with a one-time warning
+# when two bindings share a name. Set `event: null` on a matching binding to
+# unbind a key, or assign `[]` to clear the whole list.
 
 # Example: Add Alt+. keybinding to insert the last token from previous command:
 # $env.config.keybindings ++= [

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -612,7 +612,8 @@ $env.config.hooks.command_not_found = null
 # etc.). Inspect with `$env.config.keybindings`. Reedline's base emacs/vi maps are
 # still applied underneath and are listed by `keybindings default`.
 #
-# Assigning this list merges into the defaults rather than replacing them.
+# Assigning this list merges into the current bindings rather than replacing
+# them (an emptied list stays empty; defaults are not reintroduced).
 # An entry replaces the existing binding with the same name (updating its key
 # or event in place); when several bindings share a name, the key
 # (modifier/keycode/mode) decides which one it is, and a name reused for a

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -1,10 +1,11 @@
 //! Module containing the internal representation of user configuration
 
-use crate::FromValue;
+use crate::config::reedline::{KeyIdentity, name_of};
 use crate::{self as nu_protocol, Filesize};
+use crate::{ConfigWarning, FromValue};
 use helper::*;
 use prelude::*;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 pub use ansi_coloring::UseAnsiColoring;
 pub use clip::ClipConfig;
@@ -265,35 +266,7 @@ impl UpdateFromValue for Config {
                 },
 
                 "keybindings" => match Vec::<ParsedKeybinding>::from_value(val.clone()) {
-                    Ok(keybindings) => {
-                        for keybinding in keybindings {
-                            // An unnamed binding has no name to merge on, so match it on
-                            // the key it binds. Otherwise it matches nothing and is
-                            // appended again on every assignment, growing the list each
-                            // time a config is re-sourced.
-                            let found_index =
-                                self.keybindings.iter().position(|existing_keybinding| {
-                                    match (&keybinding.name, &existing_keybinding.name) {
-                                        (Some(name), Some(existing_name)) => {
-                                            name.to_expanded_string("", self)
-                                                == existing_name.to_expanded_string("", self)
-                                        }
-                                        (None, None) => {
-                                            keybinding.modifier == existing_keybinding.modifier
-                                                && keybinding.keycode == existing_keybinding.keycode
-                                                && keybinding.mode == existing_keybinding.mode
-                                        }
-                                        _ => false,
-                                    }
-                                });
-
-                            if let Some(index) = found_index {
-                                self.keybindings[index] = keybinding;
-                            } else {
-                                self.keybindings.push(keybinding);
-                            }
-                        }
-                    }
+                    Ok(keybindings) => self.merge_keybindings(keybindings, val.span(), errors),
                     Err(error) => errors.error(error.into()),
                 },
 
@@ -365,6 +338,85 @@ impl Config {
         self.update(value, &mut path, &mut errors);
 
         errors.check()
+    }
+
+    fn merge_keybindings(
+        &mut self,
+        incoming: Vec<ParsedKeybinding>,
+        span: Span,
+        errors: &mut ConfigErrors,
+    ) {
+        if incoming.is_empty() {
+            self.keybindings.clear();
+            return;
+        }
+
+        let mut shared_names = BTreeSet::new();
+        let identities = incoming.into_iter().map(|kb| {
+            let name = name_of(&kb);
+            let id = KeyIdentity::of(&kb);
+            (kb, name, id)
+        });
+
+        // Snapshot of existing identities, kept in lockstep with the list.
+        // `claimed` marks entries already spoken for by this assignment, so a
+        // second incoming binding with the same name starts a new entry
+        // instead of re-keying its sibling.
+        struct Existing {
+            name: Option<String>,
+            id: KeyIdentity,
+            claimed: bool,
+        }
+        let mut ex_kbs: Vec<Existing> = self
+            .keybindings
+            .iter()
+            .map(|ex| Existing {
+                name: name_of(ex),
+                id: KeyIdentity::of(ex),
+                claimed: false,
+            })
+            .collect();
+
+        for (kb, name, id) in identities {
+            // The same binding (name and key): replace, claimed or not, so a
+            // re-sourced config stays idempotent and event updates land.
+            if let Some(i) = ex_kbs.iter().position(|ex| ex.name == name && ex.id == id) {
+                ex_kbs[i].claimed = true;
+                self.keybindings[i] = kb;
+                continue;
+            }
+
+            // A named binding with a new key re-keys the unclaimed entry of
+            // that name in place, keeping its position in the list.
+            if name.is_some()
+                && let Some(i) = ex_kbs.iter().position(|ex| ex.name == name && !ex.claimed)
+            {
+                ex_kbs[i].id = id;
+                ex_kbs[i].claimed = true;
+                self.keybindings[i] = kb;
+                continue;
+            }
+
+            // A new binding. If its name is already taken (necessarily by a
+            // claimed entry), both stay active; say so once.
+            if let Some(name) = &name
+                && ex_kbs.iter().any(|ex| ex.name.as_ref() == Some(name))
+            {
+                shared_names.insert(name.clone());
+            }
+            ex_kbs.push(Existing {
+                name,
+                id,
+                claimed: true,
+            });
+            self.keybindings.push(kb);
+        }
+        if !shared_names.is_empty() {
+            errors.warn(ConfigWarning::SharedKeybindingName {
+                names: shared_names.into_iter().collect::<Vec<_>>().join(", "),
+                span,
+            });
+        }
     }
 }
 
@@ -455,5 +507,304 @@ mod tests {
             expected,
             "reassigning `keybindings` duplicated the unnamed binding"
         );
+    }
+
+    // --- merge semantics: replace on same name+key, append+warn on shared name ---
+
+    fn keybinding(
+        name: Option<&str>,
+        modifier: &str,
+        keycode: &str,
+        mode: Value,
+    ) -> ParsedKeybinding {
+        ParsedKeybinding {
+            name: name.map(Value::test_string),
+            modifier: Value::test_string(modifier),
+            keycode: Value::test_string(keycode),
+            event: Value::test_nothing(),
+            mode,
+        }
+    }
+
+    /// Run one `$env.config.keybindings = [...]` assignment; returns the warning.
+    fn assign(
+        config: &mut Config,
+        old: &Config,
+        keybindings: Vec<ParsedKeybinding>,
+    ) -> Option<ShellWarning> {
+        let value = Value::test_record(record! {
+            "keybindings" => Value::test_list(
+                keybindings
+                    .into_iter()
+                    .map(|kb| kb.into_value(Span::test_data()))
+                    .collect(),
+            ),
+        });
+        config
+            .update_from_value(old, &value)
+            .expect("update should succeed")
+    }
+
+    fn count_named(config: &Config, name: &str) -> usize {
+        config
+            .keybindings
+            .iter()
+            .filter(|kb| {
+                kb.name
+                    .as_ref()
+                    .is_some_and(|n| n.to_expanded_string("", config) == name)
+            })
+            .count()
+    }
+
+    /// The atuin regression (nushell/nushell#18848): two bindings sharing a name
+    /// on different keys must both survive, with one warning.
+    #[test]
+    fn a_shared_name_on_different_keys_keeps_both_bindings_and_warns() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        let warning = assign(
+            &mut new,
+            &old,
+            vec![
+                keybinding(
+                    Some("atuin"),
+                    "control",
+                    "char_r",
+                    Value::test_string("emacs"),
+                ),
+                keybinding(Some("atuin"), "none", "up", Value::test_string("emacs")),
+            ],
+        );
+
+        assert_eq!(
+            count_named(&new, "atuin"),
+            2,
+            "one of the bindings was dropped"
+        );
+        assert!(warning.is_some(), "sharing a name should warn");
+    }
+
+    /// Re-sourcing the exact same binding is idempotent and silent.
+    #[test]
+    fn reassigning_the_same_binding_replaces_it_without_warning() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        let atuin = || {
+            keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )
+        };
+        assign(&mut new, &old, vec![atuin()]);
+        let len = new.keybindings.len();
+
+        let warning = assign(&mut new, &old, vec![atuin()]);
+        assert_eq!(
+            new.keybindings.len(),
+            len,
+            "re-sourcing duplicated the binding"
+        );
+        assert!(
+            warning.is_none(),
+            "an identical re-assignment must not warn"
+        );
+    }
+
+    /// Same name and key with a new event is the update case: replaced in place.
+    #[test]
+    fn a_new_event_on_the_same_key_replaces_the_binding() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )],
+        );
+        let len = new.keybindings.len();
+
+        let mut updated = keybinding(
+            Some("atuin"),
+            "control",
+            "char_r",
+            Value::test_string("emacs"),
+        );
+        updated.event = Value::test_string("marker");
+        assign(&mut new, &old, vec![updated]);
+
+        assert_eq!(new.keybindings.len(), len);
+        let event = new
+            .keybindings
+            .iter()
+            .rev()
+            .find(|kb| {
+                kb.name
+                    .as_ref()
+                    .is_some_and(|n| n.to_expanded_string("", &new) == "atuin")
+            })
+            .map(|kb| kb.event.clone());
+        assert_eq!(
+            event,
+            Some(Value::test_string("marker")),
+            "event was not updated"
+        );
+    }
+
+    /// `emacs` and `[emacs]` spell the same key, so the second assignment replaces.
+    #[test]
+    fn a_bare_mode_and_its_singleton_list_merge_into_one_binding() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )],
+        );
+        let warning = assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_list(vec![Value::test_string("emacs")]),
+            )],
+        );
+
+        assert_eq!(
+            count_named(&new, "atuin"),
+            1,
+            "the mode spellings did not merge"
+        );
+        assert!(warning.is_none());
+    }
+
+    /// The same new binding twice in one assignment collapses to one entry
+    /// (guards the identity snapshot staying in sync with the list).
+    #[test]
+    fn the_same_binding_twice_in_one_assignment_is_stored_once() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        let atuin = || {
+            keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )
+        };
+        assign(&mut new, &old, vec![atuin(), atuin()]);
+
+        assert_eq!(count_named(&new, "atuin"), 1, "the duplicate was appended");
+    }
+
+    /// Re-keying by name: assigning a named binding with a new key replaces the
+    /// existing binding of that name in place, keeping its list position
+    /// (`$env.config.keybindings.0.keycode = ...` depends on this).
+    #[test]
+    fn a_named_binding_with_a_new_key_replaces_in_place() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )],
+        );
+        let len = new.keybindings.len();
+        let index = new
+            .keybindings
+            .iter()
+            .position(|kb| {
+                kb.name
+                    .as_ref()
+                    .is_some_and(|n| n.to_expanded_string("", &new) == "atuin")
+            })
+            .expect("binding was added");
+
+        let warning = assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "none",
+                "up",
+                Value::test_string("emacs"),
+            )],
+        );
+
+        assert_eq!(new.keybindings.len(), len, "re-keying must not append");
+        assert_eq!(
+            new.keybindings[index].keycode,
+            Value::test_string("up"),
+            "the binding was not re-keyed in place"
+        );
+        assert!(warning.is_none(), "re-keying a lone name must not warn");
+    }
+
+    /// A changed mode set is a re-key too, not a sibling binding.
+    #[test]
+    fn a_named_binding_with_a_changed_mode_replaces_instead_of_appending() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_string("emacs"),
+            )],
+        );
+        let warning = assign(
+            &mut new,
+            &old,
+            vec![keybinding(
+                Some("atuin"),
+                "control",
+                "char_r",
+                Value::test_list(vec![
+                    Value::test_string("vi_normal"),
+                    Value::test_string("vi_insert"),
+                ]),
+            )],
+        );
+
+        assert_eq!(count_named(&new, "atuin"), 1, "the mode change appended");
+        assert!(warning.is_none());
+    }
+
+    /// Assigning an empty list is the reset escape hatch.
+    #[test]
+    fn assigning_an_empty_list_clears_the_keybindings() {
+        let old = Config::default();
+        let mut new = old.clone();
+
+        assign(&mut new, &old, vec![]);
+        assert!(new.keybindings.is_empty(), "`= []` should reset the list");
     }
 }

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use super::{config_update_string_enum, prelude::*};
 use crate as nu_protocol;
 use crate::{FromValue, engine::Closure};
@@ -10,6 +12,40 @@ pub struct ParsedKeybinding {
     pub keycode: Value,
     pub event: Value,
     pub mode: Value,
+}
+
+pub(crate) fn name_of(kb: &ParsedKeybinding) -> Option<String> {
+    kb.name
+        .as_ref()
+        .and_then(|v| v.coerce_str().ok())
+        .map(|s| s.to_string())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct KeyIdentity {
+    modifier: String,
+    keycode: String,
+    modes: BTreeSet<String>,
+}
+
+impl KeyIdentity {
+    pub(crate) fn of(kb: &ParsedKeybinding) -> Self {
+        let lower = |v: &Value| {
+            v.coerce_str()
+                .map(|s| s.to_ascii_lowercase())
+                .unwrap_or_default()
+        };
+        let modes = match &kb.mode {
+            Value::List { vals, .. } => vals.iter().map(lower).collect(),
+            v => BTreeSet::from([lower(v)]),
+        };
+
+        Self {
+            modifier: lower(&kb.modifier),
+            keycode: lower(&kb.keycode),
+            modes,
+        }
+    }
 }
 
 /// Definition of a parsed menu from the config object
@@ -132,5 +168,66 @@ impl FromStr for EditBindings {
 impl UpdateFromValue for EditBindings {
     fn update(&mut self, value: &Value, path: &mut ConfigPath, errors: &mut ConfigErrors) {
         config_update_string_enum(self, value, path, errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kb(modifier: &str, keycode: &str, mode: Value) -> ParsedKeybinding {
+        ParsedKeybinding {
+            name: None,
+            modifier: Value::test_string(modifier),
+            keycode: Value::test_string(keycode),
+            event: Value::test_nothing(),
+            mode,
+        }
+    }
+
+    #[test]
+    fn a_bare_mode_and_its_singleton_list_are_the_same_key() {
+        let bare = kb("control", "char_r", Value::test_string("emacs"));
+        let listed = kb(
+            "control",
+            "char_r",
+            Value::test_list(vec![Value::test_string("emacs")]),
+        );
+        assert_eq!(KeyIdentity::of(&bare), KeyIdentity::of(&listed));
+    }
+
+    #[test]
+    fn mode_list_order_does_not_matter() {
+        let forward = kb(
+            "control",
+            "char_r",
+            Value::test_list(vec![
+                Value::test_string("emacs"),
+                Value::test_string("vi_insert"),
+            ]),
+        );
+        let reversed = kb(
+            "control",
+            "char_r",
+            Value::test_list(vec![
+                Value::test_string("vi_insert"),
+                Value::test_string("emacs"),
+            ]),
+        );
+        assert_eq!(KeyIdentity::of(&forward), KeyIdentity::of(&reversed));
+    }
+
+    #[test]
+    fn spelling_case_does_not_matter() {
+        let lower = kb("control", "char_r", Value::test_string("emacs"));
+        let upper = kb("Control", "Char_R", Value::test_string("Emacs"));
+        assert_eq!(KeyIdentity::of(&lower), KeyIdentity::of(&upper));
+    }
+
+    #[test]
+    fn a_different_key_is_a_different_identity() {
+        let ctrl_r = kb("control", "char_r", Value::test_string("emacs"));
+        let up = kb("none", "up", Value::test_string("emacs"));
+        assert_ne!(KeyIdentity::of(&ctrl_r), KeyIdentity::of(&up));
     }
 }

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -23,7 +23,7 @@ pub(crate) fn name_of(kb: &ParsedKeybinding) -> Option<String> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct KeyIdentity {
-    modifier: String,
+    modifier: BTreeSet<String>,
     keycode: String,
     modes: BTreeSet<String>,
 }
@@ -41,8 +41,16 @@ impl KeyIdentity {
         };
 
         Self {
-            modifier: lower(&kb.modifier),
-            keycode: lower(&kb.keycode),
+            // Best-effort mirror of `add_parsed_keybinding`'s reading: modifiers
+            // are an unordered `_`-joined set and `esc`/`escape` are aliases. The
+            // exotic overlaps (`space` vs `char_ `, `char_u<hex>` vs `char_<c>`)
+            // are deliberately not canonicalized; a mismatch only costs an
+            // append plus a warning, never a lost binding.
+            modifier: lower(&kb.modifier).split('_').map(|s| s.into()).collect(),
+            keycode: match lower(&kb.keycode).as_str() {
+                "esc" => "escape".into(),
+                other => other.into(),
+            },
             modes,
         }
     }
@@ -222,6 +230,36 @@ mod tests {
         let lower = kb("control", "char_r", Value::test_string("emacs"));
         let upper = kb("Control", "Char_R", Value::test_string("Emacs"));
         assert_eq!(KeyIdentity::of(&lower), KeyIdentity::of(&upper));
+    }
+
+    // Canonicalization to match `add_parsed_keybinding`'s reading of the fields:
+    // modifiers are an unordered `_`-joined set, `esc`/`escape` are aliases,
+    // and mode names keep their underscores.
+
+    #[test]
+    fn modifier_component_order_does_not_matter() {
+        let cs = kb("control_shift", "char_r", Value::test_string("emacs"));
+        let sc = kb("shift_control", "char_r", Value::test_string("emacs"));
+        assert_eq!(KeyIdentity::of(&cs), KeyIdentity::of(&sc));
+    }
+
+    #[test]
+    fn esc_and_escape_are_the_same_key() {
+        let esc = kb("none", "esc", Value::test_string("emacs"));
+        let escape = kb("none", "escape", Value::test_string("emacs"));
+        assert_eq!(KeyIdentity::of(&esc), KeyIdentity::of(&escape));
+    }
+
+    #[test]
+    fn mode_names_are_not_split_on_underscores() {
+        // Guards the tokenizer split: `vi_normal` is one mode, not `vi` + `normal`.
+        let whole = kb("none", "char_r", Value::test_string("vi_normal"));
+        let parts = kb(
+            "none",
+            "char_r",
+            Value::test_list(vec![Value::test_string("vi"), Value::test_string("normal")]),
+        );
+        assert_ne!(KeyIdentity::of(&whole), KeyIdentity::of(&parts));
     }
 
     #[test]

--- a/crates/nu-protocol/src/errors/config.rs
+++ b/crates/nu-protocol/src/errors/config.rs
@@ -86,11 +86,13 @@ pub enum ConfigWarning {
     #[error("Multiple keybindings share a name")]
     #[diagnostic(
         code(nu::shell::shared_keybindings_name),
-        help("all of these bindings stay active; give each a unique name to silence this warning")
+        help(
+            "all of these bindings remain in the configuration; give each a unique name to silence this warning"
+        )
     )]
     SharedKeybindingName {
         names: String,
-        #[label("{names} each name more than one keybinding")]
+        #[label("{names}: each names more than one keybinding")]
         span: Span,
     },
 }

--- a/crates/nu-protocol/src/errors/config.rs
+++ b/crates/nu-protocol/src/errors/config.rs
@@ -83,6 +83,16 @@ pub enum ConfigWarning {
         span: Span,
         help: &'static str,
     },
+    #[error("Multiple keybindings share a name")]
+    #[diagnostic(
+        code(nu::shell::shared_keybindings_name),
+        help("all of these bindings stay active; give each a unique name to silence this warning")
+    )]
+    SharedKeybindingName {
+        names: String,
+        #[label("{names} each name more than one keybinding")]
+        span: Span,
+    },
 }
 
 // To keep track of reported warnings
@@ -92,6 +102,9 @@ impl Hash for ConfigWarning {
             ConfigWarning::IncompatibleOptions { label, help, .. } => {
                 label.hash(state);
                 help.hash(state);
+            }
+            ConfigWarning::SharedKeybindingName { names, .. } => {
+                names.hash(state);
             }
         }
     }

--- a/crates/nu-protocol/src/errors/shell_warning.rs
+++ b/crates/nu-protocol/src/errors/shell_warning.rs
@@ -69,12 +69,53 @@ impl Hash for ShellWarning {
                 dep_type.hash(state);
                 label.hash(state);
             }
-            // We always report config warnings, so no hash necessary
-            ShellWarning::InvalidConfig { .. } => (),
+            // Hash the contents so FirstUse dedups per warning batch, not
+            // once for all config warnings in the session.
+            ShellWarning::InvalidConfig { warnings } => warnings.hash(state),
             // EveryUse — hash unused for suppression; include fields for completeness
             ShellWarning::LastResultTruncated { limit_bytes, .. } => {
                 limit_bytes.hash(state);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ConfigWarning;
+
+    fn hash_of(warning: &ShellWarning) -> u64 {
+        let mut hasher = std::hash::DefaultHasher::new();
+        warning.hash(&mut hasher);
+        std::hash::Hasher::finish(&hasher)
+    }
+
+    fn shared_name_batch(names: &str) -> ShellWarning {
+        ShellWarning::InvalidConfig {
+            warnings: vec![ConfigWarning::SharedKeybindingName {
+                names: names.into(),
+                span: Span::test_data(),
+            }],
+        }
+    }
+
+    /// `report_mode` is `FirstUse`, which dedups by this hash; a constant hash
+    /// would suppress every config warning after the first batch of a session.
+    #[test]
+    fn different_config_warning_batches_hash_differently() {
+        assert_ne!(
+            hash_of(&shared_name_batch("atuin")),
+            hash_of(&shared_name_batch("other")),
+        );
+    }
+
+    /// The same batch re-reported (e.g. a re-sourced config) stays suppressed.
+    #[test]
+    fn an_identical_config_warning_batch_hashes_the_same() {
+        assert_eq!(
+            hash_of(&shared_name_batch("atuin")),
+            hash_of(&shared_name_batch("atuin")),
+        );
     }
 }


### PR DESCRIPTION
## Description

Since 0.115.0 assigning `$env.config.keybindings` merges by matching named bindings on `name` alone, so a named binding silently replaces an earlier one that binds a different key.
Atuin's generated `init.nu` names both its ctrl-r and up-arrow bindings `atuin`, thus ctrl-r silently fell back to the built-in history menu (#18848).

The merge now takes the name as the primary key, with the key identity (`modifier`/`keycode`/`mode`, normalised so `emacs` == `[emacs]`) deciding between bindings that share one.
An exact name-and-key match is replaced, so re-sourcing is idempotent and event updates land; a named binding with a new key re-keys the entry of that name in place, keeping its position (`$env.config.keybindings.0.keycode = ...` depends on this); anything else appends, with a one-time warning (`nu::shell::shared_keybindings_name`) when that fans a name out to a second key.
A claim flag lets atuin's two same-named bindings coexist: the first claims its entry exactly, so the second appends instead of re-keying its sibling.

Assigning `= []` now resets the list, which the merge semantics had silently made impossible.

## User-facing changes (Release notes)

### Fix `$env.config.keybindings` merging for shared names

Fixed an issue where two keybindings sharing a name on different keys silently dropped one of them (broke atuin's ctrl-r).
Nushell now warns once when keybindings share a name, matches mode spellings like `emacs` and `[emacs]` when merging, and `$env.config.keybindings = []` clears the list again.

## Additional notes

fixes #18848