### PR TITLE
fix unmatched `{` at end of `format pattern` and `parse` patterns

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -141,8 +141,17 @@ fn extract_formatting_operations(
     };
 
     let mut is_fixed = true;
+    // `batching` stops on `None`. An unclosed `{` at end-of-pattern yields
+    // FixedText first, then the next call peeks empty; report that error once.
+    let mut reported_unclosed = false;
     let ops = pattern.char_indices().peekable().batching(move |it| {
-        let start_index = it.peek()?.0;
+        let Some(&(start_index, _)) = it.peek() else {
+            if is_fixed || reported_unclosed {
+                return None;
+            }
+            reported_unclosed = true;
+            return Some(Err(()));
+        };
         let mut buf = String::new();
         while let Some((index, ch)) = it.next() {
             match ch {

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -338,12 +338,13 @@ fn build_regex(input: &str, span: Span) -> Result<String, ShellError> {
         }
 
         column.push(c);
-        if loop_input.peek().is_none() {
-            return Err(ShellError::DelimiterError {
-                msg: "Found opening `{` without an associated closing `}`".to_owned(),
-                span,
-            });
-        }
+    }
+
+    if in_column {
+        return Err(ShellError::DelimiterError {
+            msg: "Found opening `{` without an associated closing `}`".to_owned(),
+            span,
+        });
     }
 
     if !before.is_empty() {

--- a/crates/nu-command/tests/commands/format/mod.rs
+++ b/crates/nu-command/tests/commands/format/mod.rs
@@ -2,6 +2,7 @@ use nu_test_support::{
     fs::Stub::{EmptyFile, FileWithContentToBeTrimmed},
     prelude::*,
 };
+use rstest::rstest;
 
 mod duration;
 mod filesize;
@@ -55,16 +56,17 @@ fn cant_use_variables() -> Result {
     Ok(())
 }
 
-#[test]
-fn error_unmatched_brace() -> Result {
-    let code = r#"
-        open cargo_sample.toml
-        | format pattern "{package.name"
-    "#;
-
+#[rstest]
+#[case::unclosed_column("{package.name")]
+#[case::lone_open("{")]
+#[case::lone_close("}")]
+#[case::trailing_open("hello {")]
+#[case::closed_then_open("{name}{")]
+fn error_unmatched_brace(#[case] pattern: &str) -> Result {
+    // Pattern must be a source literal. `format pattern` derives spans from the
+    // argument span vs string length, and panics when the value comes from a variable.
     let err = test()
-        .cwd("tests/fixtures/formats")
-        .run(code)
+        .run(format!("{{}} | format pattern '{pattern}'"))
         .expect_error()?;
 
     let ShellError::DelimiterError { msg, .. } = err else {
@@ -73,6 +75,11 @@ fn error_unmatched_brace() -> Result {
 
     assert_eq!(msg, "there are unmatched curly braces");
     Ok(())
+}
+
+#[test]
+fn escaped_open_brace_is_literal() -> Result {
+    test().run("{} | format pattern '{{'").expect_value_eq("{")
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -2,6 +2,7 @@ use indoc::indoc;
 use nu_protocol::{ByteStream, ByteStreamType, PipelineData, ShellError, Signals, Span};
 use nu_test_support::{fs::Stub, prelude::*};
 use pretty_assertions::assert_matches;
+use rstest::rstest;
 
 mod simple {
     use super::*;
@@ -88,15 +89,15 @@ mod simple {
         test().run(code).expect_value_eq("something bad happened")
     }
 
-    #[test]
-    fn errors_when_missing_closing_brace() -> Result {
-        let code = r#"
-            "(abc)123"
-            | parse "(abc){name"
-            | get name
-        "#;
-
-        let err = test().run(code).expect_shell_error()?;
+    #[rstest]
+    #[case::unclosed_name("(abc){name")]
+    #[case::lone_open("{")]
+    #[case::trailing_open("hello {")]
+    #[case::closed_then_open("{name}{")]
+    fn errors_when_missing_closing_brace(#[case] pattern: &str) -> Result {
+        let err = test()
+            .run_with_data(r#"let pattern = $in; "(abc)123" | parse $pattern"#, pattern)
+            .expect_shell_error()?;
         assert_matches!(
             err,
             ShellError::DelimiterError { msg, .. }
@@ -104,6 +105,20 @@ mod simple {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn escaped_open_brace_is_literal() -> Result {
+        test()
+            .run(r#""{" | parse "{{" | length"#)
+            .expect_value_eq(1)
+    }
+
+    #[test]
+    fn unmatched_close_brace_is_literal() -> Result {
+        test()
+            .run(r#""hello}" | parse "hello}" | length"#)
+            .expect_value_eq(1)
     }
 
     #[test]


### PR DESCRIPTION
## Description

`format pattern` already reported `nu::shell::delimiter_error` for a lone `}`. A pattern that ended with `{` did not. It succeeded and dropped the brace.

```nushell
{} | format pattern '}'
# Error: nu::shell::delimiter_error
#   × Delimiter error
#    ╭─[source:1:6]
#  1 │ {} | format pattern '}'
#    ·      ───────┬──────
#    ·             ╰── there are unmatched curly braces

{} | format pattern '{' | $in == ""
# true

{} | format pattern 'hello {'
# "hello "
```

## User-facing changes (Release notes)

`format pattern` and `parse` now error on an unclosed `{`

`format pattern` already reported a delimiter error for a lone `}`. A pattern that ended with `{` succeeded and dropped the brace. `parse` simple patterns did the same.

Both commands now treat an unescaped `{` without a matching `}` as a delimiter error.

```nushell
{} | format pattern '{'
# Error: nu::shell::delimiter_error (there are unmatched curly braces)

"hello " | parse "hello {"
# Error: nu::shell::delimiter_error (Found opening `{` without an associated closing `}`)
```

Escaped braces (`{{` and `}}`) still insert a literal brace. A lone `}` in `parse` is still a literal character to match, not an error. `parse --regex` is unchanged.

## Additional notes
closes https://github.com/nushell/nushell/issues/18869