### PR TITLE
fix `lines --skip-empty` for string and byte stream input

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -40,12 +40,12 @@ impl Command for Lines {
                     // source is a UTF-8 String, so strict mode should always produce valid UTF-8 strings
                     let lines = lines.strict(true);
 
-                    Ok(lines
-                        .map(move |line| match line {
-                            Ok(line) => Value::string(line, head),
-                            Err(err) => Value::error(err, head),
-                        })
-                        .into_pipeline_data(head, engine_state.signals().clone()))
+                    Ok(lines_to_pipeline_data(
+                        lines,
+                        skip_empty,
+                        head,
+                        engine_state.signals().clone(),
+                    ))
                 }
                 // Propagate existing errors
                 Value::Error { error, .. } => Err(*error),
@@ -84,12 +84,12 @@ impl Command for Lines {
             }
             PipelineData::ByteStream(stream, ..) => {
                 if let Some(lines) = stream.lines().map(|l| l.strict(strict)) {
-                    Ok(lines
-                        .map(move |line| match line {
-                            Ok(line) => Value::string(line, head),
-                            Err(err) => Value::error(err, head),
-                        })
-                        .into_pipeline_data(head, engine_state.signals().clone()))
+                    Ok(lines_to_pipeline_data(
+                        lines,
+                        skip_empty,
+                        head,
+                        engine_state.signals().clone(),
+                    ))
                 } else {
                     Ok(PipelineData::empty())
                 }
@@ -98,15 +98,40 @@ impl Command for Lines {
     }
 
     fn examples(&self) -> Vec<Example<'_>> {
-        vec![Example {
-            description: "Split multi-line string into lines",
-            example: r#"$"two\nlines" | lines"#,
-            result: Some(Value::list(
-                vec![Value::test_string("two"), Value::test_string("lines")],
-                Span::test_data(),
-            )),
-        }]
+        vec![
+            Example {
+                description: "Split multi-line string into lines",
+                example: r#"$"two\nlines" | lines"#,
+                result: Some(Value::list(
+                    vec![Value::test_string("two"), Value::test_string("lines")],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Skip empty lines",
+                example: r#""foo\n\nbar" | lines --skip-empty"#,
+                result: Some(Value::list(
+                    vec![Value::test_string("foo"), Value::test_string("bar")],
+                    Span::test_data(),
+                )),
+            },
+        ]
     }
+}
+
+fn lines_to_pipeline_data(
+    lines: impl Iterator<Item = Result<String, ShellError>> + Send + 'static,
+    skip_empty: bool,
+    span: Span,
+    signals: Signals,
+) -> PipelineData {
+    lines
+        .filter_map(move |line| match line {
+            Ok(line) if skip_empty && line.trim().is_empty() => None,
+            Ok(line) => Some(Value::string(line, span)),
+            Err(err) => Some(Value::error(err, span)),
+        })
+        .into_pipeline_data(span, signals)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -1,4 +1,6 @@
-use nu_protocol::{ShellError, shell_error::io::ErrorKind};
+use nu_protocol::{
+    ByteStream, PipelineData, ShellError, Signals, Span, shell_error::io::ErrorKind,
+};
 use nu_test_support::prelude::*;
 
 #[test]
@@ -55,6 +57,56 @@ fn lines_mixed_line_endings() -> Result {
     test()
         .run(r#""foo\nbar\r\nquux" | lines | length"#)
         .expect_value_eq(3)
+}
+
+#[test]
+fn lines_skip_empty_on_string() -> Result {
+    test()
+        .run(r#""foo\n\n\nbar\n\n\nqux" | lines --skip-empty"#)
+        .expect_value_eq(["foo", "bar", "qux"])
+}
+
+#[test]
+fn lines_keeps_empty_lines_without_skip_empty() -> Result {
+    test()
+        .run(r#""foo\n\nbar" | lines"#)
+        .expect_value_eq(["foo", "", "bar"])
+}
+
+#[test]
+fn lines_skip_empty_drops_whitespace_only_lines() -> Result {
+    test()
+        .run(r#""foo\n  \nbar" | lines --skip-empty"#)
+        .expect_value_eq(["foo", "bar"])
+}
+
+#[test]
+fn lines_skip_empty_on_list_stream() -> Result {
+    test()
+        .run(r#"["foo\n\n\nbar\n\n\nqux"] | each {} | lines --skip-empty"#)
+        .expect_value_eq(["foo", "bar", "qux"])
+}
+
+#[test]
+fn lines_skip_empty_on_byte_stream() -> Result {
+    let input = PipelineData::ByteStream(
+        ByteStream::read_string(
+            "foo\n\n\nbar\n\n\nqux".into(),
+            Span::test_data(),
+            Signals::empty(),
+        ),
+        None,
+    );
+
+    test()
+        .run_raw_with_data("lines --skip-empty", input)
+        .and_then(|outcome| {
+            outcome
+                .body
+                .into_value(Span::test_data())
+                .map_err(Error::from)
+        })
+        .expect_value_eq(["foo", "bar", "qux"])
 }
 
 #[test]


### PR DESCRIPTION
## Description

`lines --skip-empty` is documented as a general flag, but it only ran on one of the three input shapes `lines` accepts.

Reported on Discord:

```nushell
"foo\n\n\nbar\n\n\nqux" | lines --skip-empty
# [foo, "", "", bar, "", "", qux]
```

The empty lines should have been gone. This shape did work:

```nushell
["foo\n\n\nbar\n\n\nqux"] | each {} | lines --skip-empty
# [foo, bar, qux]
```

`each {}` is what turns a collected list into a `ListStream`. The flag was not "working for lists." It was only wired up in the list-stream branch.

## User-facing changes (Release notes)

`lines --skip-empty` now skips empty lines for string and byte stream input, not only list streams.

```nushell
"foo\n\nbar" | lines --skip-empty
# ╭───┬─────╮
# │ 0 │ foo │
# │ 1 │ bar │
# ╰───┴─────╯
```

Whitespace-only lines are treated as empty, same as they already were for list streams.

## Additional notes
