### PR TITLE
Added an audit ignore for h2 until we have a hyper-util update

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,6 @@ ignore = [
   # untrusted .xlsx files could be get OOM or CPU DoS
   "RUSTSEC-2026-0194",
   "RUSTSEC-2026-0195",
+  # h2 is used by nu-mcp (hyper-util), we need to wait for a patch upstream
+  "RUSTSEC-2026-0258",
 ]


### PR DESCRIPTION
# Description
Ignore cargo-audit vulnerability "RUSTSEC-2026-0258". This is related to h2 usage in hyper-util by nu-mcp. This should be fixed once there is a fix to hyper-util.
