### PR TITLE
Add `complete stream` to tag stdout and stderr chunks as they arrive

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -129,6 +129,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         #[cfg(feature = "os")]
         bind_command! {
             Complete,
+            CompleteStream,
             External,
             Exec,
             NuCheck,

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -21,7 +21,7 @@ impl Command for Complete {
     }
 
     fn extra_description(&self) -> &str {
-        "In order to capture stdout, stderr, and exit_code, externally piped in commands need to be wrapped with `do`"
+        "In order to capture stdout, stderr, and exit_code, externally piped in commands need to be wrapped with `do`. Use `complete stream` to tag stdout and stderr chunks as they arrive instead of collecting them."
     }
 
     fn run(

--- a/crates/nu-command/src/system/complete_stream.rs
+++ b/crates/nu-command/src/system/complete_stream.rs
@@ -1,0 +1,388 @@
+use nu_engine::command_prelude::*;
+use nu_protocol::ListStream;
+use nu_protocol::OutDest;
+use nu_protocol::Signals;
+use nu_protocol::process::{ChildPipe, ChildProcess, ExitStatusGuard};
+use nu_protocol::shell_error::generic::GenericError;
+use nu_protocol::shell_error::io::IoError;
+use std::io::{self, Read};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::thread::{self, JoinHandle};
+
+const CHUNK_SIZE: usize = 8192;
+
+#[derive(Clone)]
+pub struct CompleteStream;
+
+impl Command for CompleteStream {
+    fn name(&self) -> &str {
+        "complete stream"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("complete stream")
+            .category(Category::System)
+            .input_output_types(vec![(
+                Type::Any,
+                Type::List(Box::new(Type::Record(
+                    vec![("stream".into(), Type::String), ("chunk".into(), Type::Any)].into(),
+                ))),
+            )])
+            .switch(
+                "lines",
+                "Split each stream on newlines instead of emitting raw read chunks.",
+                Some('l'),
+            )
+            .allow_variants_without_examples(true)
+    }
+
+    fn description(&self) -> &str {
+        "Stream tagged chunks from an external command's stdout and stderr as they arrive."
+    }
+
+    fn extra_description(&self) -> &str {
+        r#"Only external commands can be piped into `complete stream`. Like `complete`, this command
+requests both stdout and stderr as separate pipes.
+
+Each output record has a `stream` column (`stdout` or `stderr`) and a `chunk` column. By default
+`chunk` is whatever one `read` returned, at most 8192 bytes, typed as a string when the bytes are
+valid UTF-8 and as binary otherwise.
+
+`--lines` splits each pipe independently on `\n` (also stripping a preceding `\r`), keeps empty
+lines, and emits a leftover fragment at EOF. A line longer than 8192 bytes is emitted in 8192-byte
+fragments so a newline-free infinite producer cannot hang `| first`.
+
+Order is read-arrival order of those chunks, not the child's original write order. Non-zero exit
+status does not fail the pipeline. After the stream is fully consumed (or dropped),
+`$env.LAST_EXIT_CODE` is set to the child's status. Dropping the stream early (for example
+`| first`) closes the pipes so an infinite producer exits instead of hanging.
+
+A wrapper command must take the external as pipeline input (`def cs [] { complete stream }`).
+Writing `$in | complete stream` collects the child first and loses the separate pipes."#
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["stdout", "stderr", "chunk", "complete"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let split_lines = call.has_flag(engine_state, stack, "lines")?;
+
+        match input {
+            PipelineData::ByteStream(stream, metadata) => {
+                let Ok(mut child) = stream.into_child() else {
+                    return Err(not_external(head));
+                };
+
+                child.ignore_error(true);
+
+                let exit = ExitStatusGuard::new(
+                    child.clone_exit_status_future(),
+                    child.clone_ignore_error(),
+                )
+                .with_span(head)
+                .with_record_last_exit();
+
+                let iter = spawn_readers(child, split_lines, head, engine_state.signals().clone())?;
+                let stream = ListStream::new(iter, head, engine_state.signals().clone())
+                    .with_exit_status(exit);
+                Ok(PipelineData::list_stream(stream, metadata))
+            }
+            PipelineData::Value(Value::Error { error, .. }, _) => Err(*error),
+            _ => Err(not_external(head)),
+        }
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![
+            Example {
+                description: "Tag stdout and stderr chunks from an external command as they arrive",
+                example: "nu -c 'print out; print -e err' | complete stream",
+                result: None,
+            },
+            Example {
+                description: "Split each stream on newlines",
+                example: "nu -c 'print out; print -e err' | complete stream --lines",
+                result: None,
+            },
+        ]
+    }
+
+    fn pipe_redirection(&self) -> (Option<OutDest>, Option<OutDest>) {
+        (Some(OutDest::PipeSeparate), Some(OutDest::PipeSeparate))
+    }
+}
+
+fn not_external(span: Span) -> ShellError {
+    ShellError::Generic(GenericError::new(
+        "complete stream only works with external commands",
+        "complete stream only works on external commands",
+        span,
+    ))
+}
+
+enum StreamEvent {
+    Chunk {
+        stream: &'static str,
+        bytes: Vec<u8>,
+    },
+    IoError(io::Error),
+}
+
+struct CompleteStreamIter {
+    rx: Option<Receiver<StreamEvent>>,
+    child: Option<ChildProcess>,
+    threads: Vec<JoinHandle<()>>,
+    span: Span,
+    finished: bool,
+}
+
+impl Iterator for CompleteStreamIter {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Some(rx) = self.rx.as_ref() else {
+            self.finish();
+            return None;
+        };
+
+        match rx.recv() {
+            Ok(StreamEvent::Chunk { stream, bytes }) => {
+                Some(chunk_record(stream, bytes, self.span))
+            }
+            Ok(StreamEvent::IoError(err)) => Some(Value::error(
+                IoError::new(err, self.span, None).into(),
+                self.span,
+            )),
+            Err(_) => {
+                self.finish();
+                None
+            }
+        }
+    }
+}
+
+impl Drop for CompleteStreamIter {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+impl CompleteStreamIter {
+    fn finish(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        // Disconnect the consumer so reader threads unblock on `send`. They drop their
+        // pipes instead of copying remaining bytes, so an infinite producer (`yes`, `iecho`)
+        // gets EPIPE/SIGPIPE and exits instead of being drained forever.
+        self.rx.take();
+        for handle in self.threads.drain(..) {
+            let _ = handle.join();
+        }
+        if let Some(child) = self.child.take() {
+            let _ = child.wait_with_output();
+        }
+    }
+}
+
+fn spawn_readers(
+    mut child: ChildProcess,
+    split_lines: bool,
+    span: Span,
+    signals: Signals,
+) -> Result<CompleteStreamIter, ShellError> {
+    let (tx, rx) = mpsc::sync_channel(0);
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let mut threads = Vec::new();
+
+    if let Some(stdout) = stdout {
+        threads.push(spawn_reader(
+            stdout,
+            "stdout",
+            tx.clone(),
+            split_lines,
+            signals.clone(),
+            span,
+        )?);
+    }
+    if let Some(stderr) = stderr {
+        match spawn_reader(stderr, "stderr", tx.clone(), split_lines, signals, span) {
+            Ok(handle) => threads.push(handle),
+            Err(err) => {
+                // Unblock a stdout reader that may already be waiting on `send`.
+                drop(tx);
+                drop(rx);
+                for handle in threads {
+                    let _ = handle.join();
+                }
+                let _ = child.wait_with_output();
+                return Err(err);
+            }
+        }
+    }
+    // Drop the extra sender so `rx` disconnects when both reader threads finish.
+    drop(tx);
+
+    Ok(CompleteStreamIter {
+        rx: Some(rx),
+        child: Some(child),
+        threads,
+        span,
+        finished: false,
+    })
+}
+
+fn spawn_reader(
+    pipe: ChildPipe,
+    stream: &'static str,
+    tx: SyncSender<StreamEvent>,
+    split_lines: bool,
+    signals: Signals,
+    span: Span,
+) -> Result<JoinHandle<()>, ShellError> {
+    thread::Builder::new()
+        .name(format!("complete stream {stream}"))
+        .spawn(move || read_pipe(pipe, stream, tx, split_lines, signals))
+        .map_err(|err| IoError::new(err, span, None).into())
+}
+
+fn read_pipe(
+    mut pipe: ChildPipe,
+    stream: &'static str,
+    tx: SyncSender<StreamEvent>,
+    split_lines: bool,
+    signals: Signals,
+) {
+    let mut buf = [0_u8; CHUNK_SIZE];
+    let mut leftover = Vec::new();
+
+    loop {
+        if signals.interrupted() {
+            return;
+        }
+
+        match pipe.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let bytes = &buf[..n];
+                if split_lines {
+                    leftover.extend_from_slice(bytes);
+                    if !emit_lines(&mut leftover, stream, &tx)
+                        || !emit_oversize_leftover(&mut leftover, stream, &tx)
+                    {
+                        return;
+                    }
+                } else if tx
+                    .send(StreamEvent::Chunk {
+                        stream,
+                        bytes: bytes.to_vec(),
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(err) => {
+                let _ = tx.send(StreamEvent::IoError(err));
+                return;
+            }
+        }
+    }
+
+    if split_lines && !leftover.is_empty() {
+        let _ = tx.send(StreamEvent::Chunk {
+            stream,
+            bytes: leftover,
+        });
+    }
+}
+
+/// Emit leftover bytes that never saw a newline so `| first` cannot hang on
+/// a newline-free infinite producer.
+fn emit_oversize_leftover(
+    leftover: &mut Vec<u8>,
+    stream: &'static str,
+    tx: &SyncSender<StreamEvent>,
+) -> bool {
+    while leftover.len() >= CHUNK_SIZE {
+        let chunk: Vec<u8> = leftover.drain(..CHUNK_SIZE).collect();
+        if tx
+            .send(StreamEvent::Chunk {
+                stream,
+                bytes: chunk,
+            })
+            .is_err()
+        {
+            leftover.clear();
+            return false;
+        }
+    }
+    true
+}
+
+/// Returns `false` if the consumer dropped the channel.
+fn emit_lines(leftover: &mut Vec<u8>, stream: &'static str, tx: &SyncSender<StreamEvent>) -> bool {
+    while let Some(idx) = leftover.iter().position(|&b| b == b'\n') {
+        let mut line: Vec<u8> = leftover.drain(..=idx).collect();
+        strip_newline_bytes(&mut line);
+        if tx
+            .send(StreamEvent::Chunk {
+                stream,
+                bytes: line,
+            })
+            .is_err()
+        {
+            leftover.clear();
+            return false;
+        }
+    }
+    true
+}
+
+fn strip_newline_bytes(line: &mut Vec<u8>) {
+    if line.last() == Some(&b'\n') {
+        line.pop();
+        if line.last() == Some(&b'\r') {
+            line.pop();
+        }
+    }
+}
+
+fn chunk_record(stream: &str, bytes: Vec<u8>, span: Span) -> Value {
+    Value::record(
+        record! {
+            "stream" => Value::string(stream, span),
+            "chunk" => bytes_to_chunk(bytes, span),
+        },
+        span,
+    )
+}
+
+fn bytes_to_chunk(bytes: Vec<u8>, span: Span) -> Value {
+    match String::from_utf8(bytes) {
+        Ok(string) => Value::string(string, span),
+        Err(err) => Value::binary(err.into_bytes(), span),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() -> nu_test_support::Result {
+        nu_test_support::test().examples(CompleteStream)
+    }
+}

--- a/crates/nu-command/src/system/complete_stream.rs
+++ b/crates/nu-command/src/system/complete_stream.rs
@@ -62,7 +62,7 @@ Writing `$in | complete stream` collects the child first and loses the separate 
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["stdout", "stderr", "chunk", "complete"]
+        vec!["stdout", "stderr", "chunk"]
     }
 
     fn run(

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,4 +1,5 @@
 mod complete;
+mod complete_stream;
 mod exec;
 mod nu_check;
 #[cfg(any(
@@ -22,6 +23,7 @@ mod uname;
 mod which_;
 
 pub use complete::Complete;
+pub use complete_stream::CompleteStream;
 pub use exec::Exec;
 pub use nu_check::NuCheck;
 #[cfg(any(

--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -164,3 +164,264 @@ fn pipefail_parenthesized_pipeline_let_keeps_scope() -> Result {
     assert!(matches!(err, ParseError::VariableNotFound { .. }));
     Ok(())
 }
+
+#[test]
+fn ordinary_list_stream_does_not_set_last_exit_code() -> Result {
+    let code = "
+        if ('LAST_EXIT_CODE' in ($env | columns)) { hide-env LAST_EXIT_CODE }
+        let _ = (1..5 | each {|i| $i})
+        1..5 | each {|i| $i}
+        'LAST_EXIT_CODE' in ($env | columns)
+    ";
+
+    test().run(code).expect_value_eq(false)
+}
+
+#[test]
+fn complete_stream_rejects_internal_commands() -> Result {
+    let err = test()
+        .run("[1 2 3] | complete stream")
+        .expect_shell_error()?;
+    assert_matches!(err, ShellError::Generic(_));
+    Ok(())
+}
+
+#[test]
+#[deps(TESTBIN_ECHO_ENV_MIXED)]
+fn complete_stream_tags_stdout_and_stderr_lines() -> Result {
+    let code = "
+        $env.FOO = 'hello'
+        $env.BAR = 'world'
+        let logs = (echo_env_mixed out-err FOO BAR | complete stream --lines)
+        {
+            stdout: ($logs | where stream == stdout | get chunk | str join)
+            stderr: ($logs | where stream == stderr | get chunk | str join)
+        }
+    ";
+
+    test().run(code).expect_value_eq(test_record! {
+        "stdout" => "hello",
+        "stderr" => "world",
+    })
+}
+
+#[test]
+#[deps(TESTBIN_COCOCO)]
+fn complete_stream_stdout_only() -> Result {
+    test()
+        .run("cococo test | complete stream --lines")
+        .expect_value_eq(test_table![
+            ["stream", "chunk"];
+            ["stdout", "test"],
+        ])
+}
+
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_nonzero_exit_does_not_fail() -> Result {
+    let code = "
+        fail 42 | complete stream --lines
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(42)
+}
+
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_sets_last_exit_code_after_collect() -> Result {
+    let code = "
+        let logs = (fail 7 | complete stream --lines)
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(7)
+}
+
+#[test]
+#[exp(PIPE_FAIL)]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_does_not_raise_pipefail() -> Result {
+    let code = "
+        fail 3 | complete stream --lines
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(3)
+}
+
+#[test]
+#[deps(TESTBIN_ECHO_ENV_MIXED)]
+fn complete_stream_first_does_not_hang() -> Result {
+    let code = "
+        $env.FOO = 'hello'
+        $env.BAR = 'world'
+        echo_env_mixed out-err FOO BAR | complete stream --lines | first | get chunk | is-empty
+    ";
+
+    test().run(code).expect_value_eq(false)
+}
+
+#[test]
+#[deps(TESTBIN_IECHO)]
+fn complete_stream_first_on_infinite_stdout_does_not_hang() -> Result {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome: Result<String> =
+            test().run("iecho y | complete stream --lines | first | get chunk");
+        let _ = tx.send(outcome);
+    });
+    let outcome = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("complete stream | first hung on infinite stdout");
+    assert_eq!(outcome?, "y");
+    Ok(())
+}
+
+#[test]
+#[deps(TESTBIN_IECHO)]
+fn complete_stream_take_on_infinite_stdout_does_not_hang() -> Result {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome: Result<Vec<String>> =
+            test().run("iecho y | complete stream --lines | take 3 | get chunk");
+        let _ = tx.send(outcome);
+    });
+    let outcome = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("complete stream | take hung on infinite stdout");
+    assert_eq!(outcome?, ["y", "y", "y"]);
+    Ok(())
+}
+
+#[test]
+#[exp(PIPE_FAIL)]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_wrapper_def_does_not_raise_pipefail() -> Result {
+    let code = "
+        def cs [] { complete stream --lines }
+        fail 3 | cs
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(3)
+}
+
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_wrapper_def_sets_last_exit_code() -> Result {
+    let code = "
+        def cs [] { complete stream --lines }
+        let logs = (fail 7 | cs)
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(7)
+}
+
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_first_sets_last_exit_code() -> Result {
+    let code = "
+        fail 9 | complete stream --lines | first
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(9)
+}
+
+#[test]
+#[deps(TESTBIN_FAIL)]
+fn complete_stream_get_chunk_sets_last_exit_code() -> Result {
+    let code = "
+        fail 8 | complete stream --lines | get chunk
+        $env.LAST_EXIT_CODE
+    ";
+
+    test().run(code).expect_value_eq(8)
+}
+
+#[test]
+#[deps(TESTBIN_ECHO_ENV_MIXED)]
+fn complete_stream_wrapper_captures_stderr() -> Result {
+    let code = "
+        def cs [] { complete stream --lines }
+        $env.FOO = 'hello'
+        $env.BAR = 'world'
+        let logs = (echo_env_mixed out-err FOO BAR | cs)
+        {
+            stdout: ($logs | where stream == stdout | get chunk | str join)
+            stderr: ($logs | where stream == stderr | get chunk | str join)
+        }
+    ";
+
+    test().run(code).expect_value_eq(test_record! {
+        "stdout" => "hello",
+        "stderr" => "world",
+    })
+}
+
+#[test]
+#[deps(TESTBIN_ECHO_ENV_MIXED)]
+fn complete_stream_try_pipe_first_keeps_chunks() -> Result {
+    let code = "
+        $env.FOO = 'hello'
+        $env.BAR = 'world'
+        try { echo_env_mixed out-err FOO BAR | complete stream --lines } | first | get chunk | is-empty
+    ";
+
+    test().run(code).expect_value_eq(false)
+}
+
+#[test]
+#[deps(TESTBIN_IECHO)]
+fn complete_stream_try_with_inner_first_does_not_hang() -> Result {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome: Result<String> =
+            test().run("try { iecho y | complete stream --lines | first | get chunk }");
+        let _ = tx.send(outcome);
+    });
+    let outcome = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("try { complete stream | first } hung on infinite stdout");
+    assert_eq!(outcome?, "y");
+    Ok(())
+}
+
+#[test]
+#[deps(TESTBIN_REPEATER)]
+fn complete_stream_lines_emits_oversize_fragment() -> Result {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome: Result<i64> = test()
+            .run("repeater a 20000 | complete stream --lines | first | get chunk | str length");
+        let _ = tx.send(outcome);
+    });
+    let outcome = rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("complete stream --lines hung on newline-free input");
+    assert_eq!(outcome?, 8192);
+    Ok(())
+}
+
+#[test]
+#[deps(NU)]
+fn complete_stream_emits_partial_line_at_eof() -> Result {
+    let code = r#"
+        nu --no-config-file --commands "print -n leftover" | complete stream --lines
+    "#;
+
+    test().run(code).expect_value_eq(test_table![
+        ["stream", "chunk"];
+        ["stdout", "leftover"],
+    ])
+}
+
+#[test]
+#[deps(TESTBIN_COCOCO)]
+fn complete_stream_without_lines_contains_stdout() -> Result {
+    test()
+        .run("cococo hello | complete stream | get chunk | str join | str trim")
+        .expect_value_eq("hello")
+}

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -239,18 +239,17 @@ impl<'a> EvalContext<'a> {
     ///
     /// It doesn't check exit status when collecting.
     fn collect_reg(&mut self, reg_id: RegId, fallback_span: Span) -> Result<Value, ShellError> {
-        // NOTE: collect_reg is used to collect the reg to a variable.
-        // So it's good to pick the inner PipelineData directly, and drop the ExitStatus queue.
+        // Used to collect a register into a variable. `pipefail` is not applied, but
+        // `$env.LAST_EXIT_CODE` is still recorded for children whose errors were ignored
+        // (`complete stream`).
+        let data = self.take_reg(reg_id);
+        let span = data.body.span().unwrap_or(fallback_span);
         #[cfg(feature = "os")]
-        let body = {
-            let mut data = self.take_reg(reg_id);
-            data.exit.clear();
-            data.body
-        };
-        #[cfg(not(feature = "os"))]
-        let body = self.take_reg(reg_id).body;
-        let span = body.span().unwrap_or(fallback_span);
-        body.into_value(span)
+        let exits = data.exit;
+        let value = data.body.into_value(span)?;
+        #[cfg(feature = "os")]
+        apply_ignored_exit_codes(self.stack, exits, span)?;
+        Ok(value)
     }
 
     /// Get a string from data or produce evaluation error if it's invalid UTF-8
@@ -498,18 +497,26 @@ fn eval_instruction<D: DebugContext>(
         Instruction::Collect { src_dst } => {
             let data = ctx.take_reg(*src_dst);
             #[cfg(feature = "os")]
+            let exits = data.exit.clone();
+            #[cfg(feature = "os")]
             let value = collect(data, *span, true)?;
             #[cfg(not(feature = "os"))]
             let value = collect(data, *span)?;
+            #[cfg(feature = "os")]
+            apply_ignored_exit_codes(ctx.stack, exits, *span)?;
             ctx.put_reg(*src_dst, PipelineExecutionData::from(value));
             Ok(Continue)
         }
         Instruction::TryCollect { src_dst } => {
             let data = ctx.take_reg(*src_dst);
             #[cfg(feature = "os")]
+            let exits = data.exit.clone();
+            #[cfg(feature = "os")]
             let value = collect(data, *span, false)?;
             #[cfg(not(feature = "os"))]
             let value = collect(data, *span)?;
+            #[cfg(feature = "os")]
+            apply_ignored_exit_codes(ctx.stack, exits, *span)?;
             ctx.put_reg(*src_dst, PipelineExecutionData::from(value));
             Ok(Continue)
         }
@@ -781,6 +788,16 @@ fn eval_instruction<D: DebugContext>(
                 let result_exit_status_future = result
                     .clone_exit_status_future()
                     .map(|f| f.with_span(*span));
+                // `complete stream` (and wrappers that return its list stream) attach the
+                // same child future onto the list stream. Drop the inherited duplicate so
+                // pipefail does not depend on the command's name string.
+                if let Some(result_guard) = result_exit_status_future.as_ref() {
+                    original_exit.retain(|existing| {
+                        existing
+                            .as_ref()
+                            .is_none_or(|guard| !guard.tracks_same_child(result_guard))
+                    });
+                }
                 original_exit.push(result_exit_status_future);
                 ctx.put_reg(
                     *src_dst,
@@ -1858,6 +1875,44 @@ fn get_env_var_name<'a>(ctx: &mut EvalContext<'_>, key: &'a str) -> Cow<'a, str>
         .unwrap_or(Cow::Borrowed(key))
 }
 
+/// Copy `$env.LAST_EXIT_CODE` from child guards that asked to record it.
+///
+/// `complete stream` marks its child this way so a later `| first` still sees the
+/// status after the list stream itself is gone. Other ignored children (`ignore`)
+/// do not set the flag.
+#[cfg(feature = "os")]
+fn apply_ignored_exit_codes(
+    stack: &mut Stack,
+    exits: Vec<Option<nu_protocol::process::ExitStatusGuard>>,
+    span: Span,
+) -> Result<(), ShellError> {
+    let mut last_code = None;
+    for guard in exits.into_iter().flatten() {
+        if !guard.records_last_exit() {
+            continue;
+        }
+        let ignore_error = {
+            let guard_flag = guard
+                .ignore_error
+                .lock()
+                .expect("lock ignore error should success");
+            *guard_flag
+        };
+        if !ignore_error {
+            continue;
+        }
+        let mut future = guard
+            .exit_status_future
+            .lock()
+            .expect("lock exit_status future should success");
+        last_code = Some(future.wait(guard.span.unwrap_or(span))?.code());
+    }
+    if let Some(code) = last_code {
+        stack.set_last_exit_code(code, span);
+    }
+    Ok(())
+}
+
 /// Helper to collect values into [`PipelineData`], preserving original span and metadata
 ///
 /// The metadata is removed if it is the file data source, as that's just meant to mark streams.
@@ -1885,6 +1940,8 @@ fn drain(
     data: PipelineExecutionData,
 ) -> Result<InstructionResult, ShellError> {
     use self::InstructionResult::*;
+
+    let span = data.body.span().unwrap_or(Span::unknown());
 
     match data.body {
         PipelineData::ByteStream(stream, ..) => {
@@ -1926,6 +1983,9 @@ fn drain(
         PipelineData::Value(..) | PipelineData::Empty => {}
     }
 
+    #[cfg(feature = "os")]
+    apply_ignored_exit_codes(ctx.stack, data.exit.clone(), span)?;
+
     let pipefail = nu_experimental::PIPE_FAIL.get();
     if !pipefail {
         return Ok(Continue);
@@ -1943,10 +2003,29 @@ fn drain_if_end(
     ctx: &mut EvalContext<'_>,
     data: PipelineExecutionData,
 ) -> Result<PipelineData, ShellError> {
-    let stack = &mut ctx
-        .stack
-        .push_redirection(ctx.redirect_out.clone(), ctx.redirect_err.clone());
-    let result = data.body.drain_to_out_dests(ctx.engine_state, stack)?;
+    let span = data.body.span().unwrap_or(Span::unknown());
+    #[cfg(feature = "os")]
+    let exits = data.exit.clone();
+    // Never consume a live stream here. `try { stream } | first` would deadlock if we
+    // waited on or drained the producer before `first` received. The caller prints or
+    // collects when this is actually the last pipeline element.
+    let result = match data.body {
+        PipelineData::ListStream(..) | PipelineData::ByteStream(..) => data.body,
+        body => {
+            let stack = &mut ctx
+                .stack
+                .push_redirection(ctx.redirect_out.clone(), ctx.redirect_err.clone());
+            body.drain_to_out_dests(ctx.engine_state, stack)?
+        }
+    };
+
+    #[cfg(feature = "os")]
+    if !matches!(
+        result,
+        PipelineData::ListStream(..) | PipelineData::ByteStream(..)
+    ) {
+        apply_ignored_exit_codes(ctx.stack, exits, span)?;
+    }
 
     let pipefail = nu_experimental::PIPE_FAIL.get();
     if !pipefail {

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -642,11 +642,17 @@ rest.name
             let (attribute_vals, examples) =
                 handle_special_attributes(attributes, working_set, &mut signature);
 
+            let pipe_redirection = working_set
+                .get_block(block_id)
+                .pipe_redirection(working_set);
             let declaration = working_set.get_decl_mut(decl_id);
 
-            *declaration = signature
-                .clone()
-                .into_block_command(block_id, attribute_vals, examples);
+            *declaration = signature.clone().into_block_command(
+                block_id,
+                attribute_vals,
+                examples,
+                pipe_redirection,
+            );
 
             let block = working_set.get_block_mut(block_id);
             block.signature = signature;
@@ -795,8 +801,6 @@ fn parse_extern_inner(
                 let (attribute_vals, examples) =
                     handle_special_attributes(attributes, working_set, &mut signature);
 
-                let declaration = working_set.get_decl_mut(decl_id);
-
                 if let Some(block_id) = body_expr.and_then(|x| x.as_block()) {
                     if signature.rest_positional.is_none() {
                         working_set.error(ParseError::InternalError(
@@ -804,10 +808,15 @@ fn parse_extern_inner(
                             name_expr.span,
                         ));
                     } else {
+                        let pipe_redirection = working_set
+                            .get_block(block_id)
+                            .pipe_redirection(working_set);
+                        let declaration = working_set.get_decl_mut(decl_id);
                         *declaration = signature.clone().into_block_command(
                             block_id,
                             attribute_vals,
                             examples,
+                            pipe_redirection,
                         );
 
                         working_set.get_block_mut(block_id).signature = signature;
@@ -828,7 +837,7 @@ fn parse_extern_inner(
                         span: call_span,
                     };
 
-                    *declaration = Box::new(decl);
+                    *working_set.get_decl_mut(decl_id) = Box::new(decl);
                 }
             } else {
                 working_set.error(ParseError::InternalError(

--- a/crates/nu-protocol/src/pipeline/byte_stream.rs
+++ b/crates/nu-protocol/src/pipeline/byte_stream.rs
@@ -736,7 +736,7 @@ impl ByteStream {
             #[cfg(feature = "os")]
             ByteStreamSource::Child(mut child) => {
                 // All `OutDest`s except `OutDest::PipeSeparate` will cause `stderr` to be `None`.
-                // Only `save`, `tee`, and `complete` set the stderr `OutDest` to `OutDest::PipeSeparate`,
+                // Only `save`, `tee`, `complete`, and `complete stream` set the stderr `OutDest` to `OutDest::PipeSeparate`,
                 // and those commands have proper simultaneous handling of stdout and stderr.
                 debug_assert!(child.stderr.is_none(), "stderr should not exist");
 

--- a/crates/nu-protocol/src/pipeline/list_stream.rs
+++ b/crates/nu-protocol/src/pipeline/list_stream.rs
@@ -2,6 +2,8 @@
 //! elements
 //!
 //! For more general infos regarding our pipelining model refer to [`PipelineData`]
+#[cfg(feature = "os")]
+use crate::process::ExitStatusGuard;
 use crate::{Config, PipelineData, ShellError, Signals, Span, Value};
 
 pub type ValueIterator = Box<dyn Iterator<Item = Value> + Send + 'static>;
@@ -17,6 +19,9 @@ pub struct ListStream {
     stream: ValueIterator,
     span: Span,
     caller_spans: Vec<Span>,
+    /// Child whose stdout/stderr were converted into this stream, if any.
+    #[cfg(feature = "os")]
+    exit: Option<ExitStatusGuard>,
 }
 
 impl ListStream {
@@ -30,7 +35,22 @@ impl ListStream {
             stream: Box::new(InterruptIter::new(iter, signals)),
             span,
             caller_spans: vec![],
+            #[cfg(feature = "os")]
+            exit: None,
         }
+    }
+
+    /// Attach a child-process exit guard so consumers can wait for the status after draining.
+    #[cfg(feature = "os")]
+    pub fn with_exit_status(mut self, exit: ExitStatusGuard) -> Self {
+        self.exit = Some(exit);
+        self
+    }
+
+    /// Exit guard attached with [`ListStream::with_exit_status`], if any.
+    #[cfg(feature = "os")]
+    pub fn exit_status_guard(&self) -> Option<ExitStatusGuard> {
+        self.exit.clone()
     }
 
     /// Returns the [`Span`] associated with this [`ListStream`].
@@ -123,6 +143,8 @@ impl ListStream {
             stream: Box::new(f(self.stream)),
             span: self.span,
             caller_spans: self.caller_spans,
+            #[cfg(feature = "os")]
+            exit: self.exit,
         }
     }
 
@@ -148,6 +170,28 @@ impl IntoIterator for ListStream {
 impl From<ListStream> for PipelineData {
     fn from(stream: ListStream) -> Self {
         Self::list_stream(stream, None)
+    }
+}
+
+#[cfg(all(test, feature = "os"))]
+mod tests {
+    use super::*;
+    use crate::Span;
+
+    #[test]
+    fn new_list_stream_has_no_exit_status() {
+        let stream = ListStream::new(std::iter::empty(), Span::test_data(), Signals::empty());
+        assert!(stream.exit_status_guard().is_none());
+
+        let mapped = stream.modify(|iter| iter);
+        assert!(mapped.exit_status_guard().is_none());
+    }
+
+    #[test]
+    fn new_list_stream_clone_exit_status_future_is_none() {
+        let stream = ListStream::new(std::iter::empty(), Span::test_data(), Signals::empty());
+        let data = PipelineData::from(stream);
+        assert!(data.clone_exit_status_future().is_none());
     }
 }
 

--- a/crates/nu-protocol/src/pipeline/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline/pipeline_data.rs
@@ -872,7 +872,8 @@ impl PipelineData {
     #[cfg(feature = "os")]
     pub fn clone_exit_status_future(&self) -> Option<ExitStatusGuard> {
         match self {
-            PipelineData::Empty | PipelineData::Value(..) | PipelineData::ListStream(..) => None,
+            PipelineData::Empty | PipelineData::Value(..) => None,
+            PipelineData::ListStream(stream, ..) => stream.exit_status_guard(),
             PipelineData::ByteStream(stream, ..) => match stream.source() {
                 ByteStreamSource::Read(..) | ByteStreamSource::File(..) => None,
                 ByteStreamSource::Child(c) => {

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -93,11 +93,13 @@ pub fn check_ok(status: ExitStatus, ignore_error: bool, span: Span) -> Result<()
 ///
 /// It's useful for `pipefail` feature, which tracks exit status code with potentially
 /// ignore the error.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExitStatusGuard {
     pub exit_status_future: Arc<Mutex<ExitStatusFuture>>,
     pub ignore_error: Arc<Mutex<bool>>,
     pub span: Option<Span>,
+    /// When true, draining/collecting copies this child's status onto `$env.LAST_EXIT_CODE`.
+    record_last_exit: bool,
 }
 
 impl ExitStatusGuard {
@@ -109,15 +111,29 @@ impl ExitStatusGuard {
             exit_status_future,
             ignore_error,
             span: None,
+            record_last_exit: false,
         }
     }
 
     pub fn with_span(self, span: Span) -> Self {
         Self {
-            exit_status_future: self.exit_status_future,
-            ignore_error: self.ignore_error,
             span: Some(span),
+            ..self
         }
+    }
+
+    pub fn with_record_last_exit(mut self) -> Self {
+        self.record_last_exit = true;
+        self
+    }
+
+    pub fn records_last_exit(&self) -> bool {
+        self.record_last_exit
+    }
+
+    /// True when both guards wait on the same child exit-status future.
+    pub fn tracks_same_child(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.exit_status_future, &other.exit_status_future)
     }
 }
 

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BlockId, CompareTypes, DeclId, DeprecationEntry, Example, FromValue, IntoValue, PipelineData,
-    ShellError, Span, SyntaxShape, Type, TypeSet, Value, VarId,
+    BlockId, CompareTypes, DeclId, DeprecationEntry, Example, FromValue, IntoValue, OutDest,
+    PipelineData, ShellError, Span, SyntaxShape, Type, TypeSet, Value, VarId,
     engine::{Call, Command, CommandType, EngineState, Stack},
     shell_error::generic::GenericError,
 };
@@ -881,12 +881,14 @@ impl Signature {
         block_id: BlockId,
         attributes: Vec<(String, Value)>,
         examples: Vec<CustomExample>,
+        pipe_redirection: (Option<OutDest>, Option<OutDest>),
     ) -> Box<dyn Command> {
         Box::new(BlockCommand {
             signature: self,
             block_id,
             attributes,
             examples,
+            pipe_redirection,
         })
     }
 }
@@ -971,6 +973,7 @@ struct BlockCommand {
     block_id: BlockId,
     attributes: Vec<(String, Value)>,
     examples: Vec<CustomExample>,
+    pipe_redirection: (Option<OutDest>, Option<OutDest>),
 }
 
 impl Command for BlockCommand {
@@ -1028,6 +1031,10 @@ impl Command for BlockCommand {
             .iter()
             .map(String::as_str)
             .collect()
+    }
+
+    fn pipe_redirection(&self) -> (Option<OutDest>, Option<OutDest>) {
+        self.pipe_redirection.clone()
     }
 
     fn deprecation_info(&self) -> Vec<DeprecationEntry> {


### PR DESCRIPTION
## Description

This was from an idea on Discord. I'm not sure it's really worth all these changes but you be the judge.

In this PR I added `complete stream`, a subcommand of `complete` that keeps both stdout and stderr of an external as separate pipes and yields tagged records while the child is still running.

`complete stream` sits in the same family as `complete`. It is not a filter after a merged byte stream. It takes a child process, spawns one reader thread per pipe, and sends `{stream, chunk}` records over `sync_channel(0)`. That algorithm is the same on macOS, Linux, and Windows. Cross-stream order is read-arrival order of those bounded sends, not the child's original write order.

## User-facing changes (Release notes)

New `complete stream` command

Nushell can now stream tagged stdout and stderr from an external without waiting for the process to finish.

`complete` still collects both pipes into one record with `stdout`, `stderr`, and `exit_code`. `complete stream` instead yields a live list of records `{stream, chunk}` as data arrives. `stream` is `"stdout"` or `"stderr"`. By default `chunk` is a raw read of at most 8192 bytes (string if valid UTF-8, otherwise binary). `--lines` splits each pipe independently on newlines.

```nushell
❯ nu -c '"output line" | print ; "err line" | print --stderr ; "2nd output line" | print ; "2nd err line" | print --stderr' | complete stream --lines
╭─#─┬─stream─┬──────chunk──────╮
│ 0 │ stdout │ output line     │
│ 1 │ stderr │ err line        │
│ 2 │ stdout │ 2nd output line │
│ 3 │ stderr │ 2nd err line    │
╰───┴────────┴─────────────────╯
```

Order is read-arrival order of those chunks, _not the child's original write order_. Non-zero exit status does not fail the pipeline. After the stream is consumed or dropped, `$env.LAST_EXIT_CODE` holds the child's status.

Dropping the stream early (`| first`) closes the pipes so an infinite producer exits instead of hanging. `--lines` emits 8192-byte fragments when a line never ends, so a newline-free producer cannot stall `| first`.

Only externals can be piped in. A wrapper must pass the external as pipeline input:

```nushell
def cs [] { complete stream --lines }
```

`$in | complete stream` collects the child first and loses the separate pipes.


## Additional notes

closes https://github.com/nushell/nushell/issues/18814