### PR TITLE
chore(reedline): bump reedline to e692224

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,8 +7605,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753088c970c4e63f91114d0dbef96c84fbaf3fde8943877f4254d33e97ce2193"
+source = "git+https://github.com/nushell/reedline?branch=main#e692224120157b717e377c5606d76c4656e98568"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -504,7 +504,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = { git = "https://github.com/nushell/nu-ansi-term.git", branch = "main" }
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1006,6 +1006,11 @@ fn event_from_record(
             let mode = extract_value("mode", record, span)?;
             ReedlineEvent::ViChangeMode(mode.as_str()?.to_owned())
         }
+        #[cfg(feature = "helix")]
+        Ok(RED::HelixChangeMode) => {
+            let mode = extract_value("mode", record, span)?;
+            ReedlineEvent::HelixChangeMode(mode.as_str()?.to_owned())
+        }
         // Non-sensical for user configuration:
         //
         // `ReedlineEvent::Mouse` - itself a no-op
@@ -1068,6 +1073,8 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::ExecuteHostCommand => "ExecuteHostCommand cmd: <string>",
         RED::OpenEditor => "OpenEditor",
         RED::ViChangeMode => "ViChangeMode mode: <string>",
+        #[cfg(feature = "helix")]
+        RED::HelixChangeMode => "HelixChangeMode mode: <string>",
         // Non-sensical for user configuration
         RED::Mouse | RED::Resize => return None,
     })

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -634,6 +634,27 @@ $env.config.hooks.command_not_found = null
 #   }
 # ]
 
+# Example: Bind Ctrl+g to leave insert mode. A mode event only applies to its own
+# state machine and reports itself inapplicable elsewhere, so `until` hands the
+# key on and one binding covers both editors:
+# $env.config.keybindings ++= [
+#   {
+#     name: leave_insert_mode
+#     modifier: control
+#     keycode: char_g
+#     mode: [vi_insert helix_insert]
+#     event: {
+#       until: [
+#         { send: ViChangeMode, mode: normal }
+#         { send: HelixChangeMode, mode: normal }
+#       ]
+#     }
+#   }
+# ]
+# `ViChangeMode` takes "normal", "insert" or "visual"; `HelixChangeMode` takes
+# "normal", "insert" or "select", and requires the `helix` feature. An unknown
+# mode name leaves the mode alone rather than erroring.
+
 # -------------
 # Abbreviations
 # -------------


### PR DESCRIPTION
## Description

Bumps reedline to `e692224`, three commits past `v0.50.0`.
nushell/reedline#1182 adds a `HelixChangeMode` event, thus `ReedlineEventDiscriminants` no longer matches exhaustively.

It gets its own arm rather than sharing `ViChangeMode`'s, since `Helix::handle_mode_specific_event` matches only `HelixChangeMode` and reports anything else `Inapplicable`, so sharing would be a silent no-op.
Both arms are `#[cfg(feature = "helix")]`, since the variant is gated upstream.
`cargo check` (helix on) and `cargo check -p nu-cli` (helix off) are clean.

## User-facing changes (Release notes)

### Add `HelixChangeMode` keybinding support

Keybindings can now switch helix modes with `{ send: HelixChangeMode, mode: normal }`, taking `normal`, `insert` or `select`.
An `until` list covers vi and helix in one binding, since a mode event is inapplicable in the other editor's state machine:

```nu
$env.config.keybindings ++= [
  {
    name: leave_insert_mode
    modifier: control
    keycode: char_g
    mode: [vi_insert helix_insert]
    event: { until: [
      { send: ViChangeMode, mode: normal }
      { send: HelixChangeMode, mode: normal }
    ] }
  }
]
