### PR TITLE
Support IPv6 zone IDs in HTTP commands

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -2,7 +2,7 @@ use crate::{
     formats::value_to_json_value,
     network::{
         http::{
-            resolver::{DnsLookupResolver, LookupError},
+            resolver::{DnsLookupResolver, LookupError, ScopedIpv6},
             timeout_extractor_reader::UreqTimeoutExtractorReader,
         },
         tls::tls_config,
@@ -30,6 +30,7 @@ use std::convert::TryInto;
 use std::{
     collections::HashMap,
     io::{self, Cursor, Read},
+    net::Ipv6Addr,
     path::{Path, PathBuf},
     str::FromStr,
     sync::mpsc::{self, RecvTimeoutError},
@@ -111,6 +112,13 @@ impl RedirectMode {
     pub(crate) const MODES: &[&str] = &["follow", "error", "manual"];
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParsedHttpUrl {
+    pub requested_url: String,
+    pub request_url: String,
+    pub scoped_ipv6: Option<ScopedIpv6>,
+}
+
 /// Helper function to add the --unix-socket flag to command signatures.
 pub fn add_unix_socket_flag(sig: Signature) -> Signature {
     sig.named(
@@ -167,7 +175,7 @@ pub fn http_client_pool(
     #[cfg(feature = "native-tls")]
     let connector = connector.chain(NativeTlsConnector::default());
 
-    let resolver = DnsLookupResolver;
+    let resolver = DnsLookupResolver::default();
     let agent = ureq::Agent::with_parts(config_builder.build(), connector, resolver);
 
     let arc_agent = Arc::new(agent);
@@ -187,6 +195,7 @@ pub fn reset_http_client_pool(
         allow_insecure,
         redirect_mode,
         unix_socket_path,
+        None,
         engine_state,
         stack,
     )?;
@@ -199,6 +208,7 @@ pub fn http_client(
     allow_insecure: bool,
     redirect_mode: RedirectMode,
     unix_socket_path: Option<PathBuf>,
+    scoped_ipv6: Option<ScopedIpv6>,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<ureq::Agent, ShellError> {
@@ -247,7 +257,7 @@ pub fn http_client(
     #[cfg(feature = "native-tls")]
     let connector = connector.chain(NativeTlsConnector::default());
 
-    let resolver = DnsLookupResolver;
+    let resolver = DnsLookupResolver::new(scoped_ipv6);
     Ok(ureq::Agent::with_parts(config, connector, resolver))
 }
 
@@ -255,7 +265,7 @@ pub fn http_parse_url(
     call: &Call,
     span: Span,
     raw_url: Value,
-) -> Result<Spanned<(String, Url)>, ShellError> {
+) -> Result<Spanned<ParsedHttpUrl>, ShellError> {
     let url_span = raw_url.span();
     let mut requested_url = raw_url.coerce_into_string()?;
     if requested_url.starts_with(':') {
@@ -264,19 +274,67 @@ pub fn http_parse_url(
         requested_url = format!("http://{requested_url}");
     }
 
-    let url = match url::Url::parse(&requested_url) {
-        Ok(u) => u,
-        Err(_e) => {
-            return Err(ShellError::UnsupportedInput {
-                msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com".to_string(),
-                input: format!("value: '{requested_url:?}'"),
-                msg_span: call.head,
-                input_span: span,
-            });
-        }
-    };
+    let (request_url, scoped_ipv6) = extract_scoped_ipv6(&requested_url)
+        .map(|(request_url, scoped_ipv6)| (request_url, Some(scoped_ipv6)))
+        .or_else(|| {
+            Url::parse(&requested_url)
+                .ok()
+                .map(|_| (requested_url.clone(), None))
+        })
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
+                .to_string(),
+            input: format!("value: '{requested_url:?}'"),
+            msg_span: call.head,
+            input_span: span,
+        })?;
 
-    Ok((requested_url, url).into_spanned(url_span))
+    Ok(ParsedHttpUrl {
+        requested_url,
+        request_url,
+        scoped_ipv6,
+    }
+    .into_spanned(url_span))
+}
+
+fn extract_scoped_ipv6(url: &str) -> Option<(String, ScopedIpv6)> {
+    let authority_start = url.find("://")? + 3;
+    let authority_end = url[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(url.len(), |offset| authority_start + offset);
+    let authority_text = &url[authority_start..authority_end];
+    let authority = authority_text.parse::<http::uri::Authority>().ok()?;
+    let host = authority.host();
+    let scoped_host = host.strip_prefix('[')?.strip_suffix(']')?;
+    let (address_text, raw_zone_id) = scoped_host.split_once('%')?;
+    let address = address_text.parse::<Ipv6Addr>().ok()?;
+
+    if !address.is_unicast_link_local() {
+        return None;
+    }
+
+    // RFC 9844 recommends the raw `%zone` UI form. Also accept RFC 6874's
+    // older `%25zone` form for compatibility with existing scripts.
+    let encoded_zone_id = raw_zone_id
+        .strip_prefix("25")
+        .filter(|zone_id| !zone_id.is_empty())
+        .unwrap_or(raw_zone_id);
+    let zone_id = percent_encoding::percent_decode_str(encoded_zone_id)
+        .decode_utf8()
+        .ok()?
+        .into_owned();
+    if zone_id.is_empty() || zone_id.chars().any(char::is_control) {
+        return None;
+    }
+
+    let host_offset = authority_text.rfind(host)?;
+    let host_start = authority_start + host_offset;
+    let host_end = host_start + host.len();
+    let mut request_url = url.to_string();
+    request_url.replace_range(host_start..host_end, &format!("[{address_text}]"));
+    Url::parse(&request_url).ok()?;
+
+    Some((request_url, ScopedIpv6::new(address, zone_id)))
 }
 
 pub fn http_parse_redirect_mode(mode: Option<Spanned<String>>) -> Result<RedirectMode, ShellError> {
@@ -1076,6 +1134,7 @@ pub(crate) fn handle_response_status(
 
 pub(crate) struct RequestMetadata<'a> {
     pub requested_url: &'a str,
+    pub request_url: &'a str,
     pub span: Span,
     pub headers: Headers,
     pub redirect_mode: RedirectMode,
@@ -1087,6 +1146,7 @@ pub(crate) fn request_handle_response(
     stack: &mut Stack,
     RequestMetadata {
         requested_url,
+        request_url,
         span,
         headers,
         redirect_mode,
@@ -1104,7 +1164,7 @@ pub(crate) fn request_handle_response(
                 engine_state,
                 stack,
                 span,
-                requested_url,
+                request_url,
                 &flags,
                 response,
                 &content_type,
@@ -1320,6 +1380,62 @@ fn retrieve_credential_from_authority(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_http_parse_url_accepts_ipv6_zone_ids() {
+        let span = Span::test_data();
+        let call = Call::new(span);
+        let cases = [
+            ("http://[fe80::1%lo]/", "http://[fe80::1]/", "lo"),
+            ("http://[fe80::1%25lo]/", "http://[fe80::1]/", "lo"),
+            (
+                "http://user:pass@[fe80::abcd%25en%2D0]:8080/path?x=1",
+                "http://user:pass@[fe80::abcd]:8080/path?x=1",
+                "en-0",
+            ),
+        ];
+
+        for (input, request_url, zone_id) in cases {
+            let parsed = http_parse_url(&call, span, Value::test_string(input))
+                .expect("scoped IPv6 URL should parse")
+                .item;
+            assert_eq!(parsed.requested_url, input);
+            assert_eq!(parsed.request_url, request_url);
+            let expected = ScopedIpv6::new(
+                request_url
+                    .split(['[', ']'])
+                    .nth(1)
+                    .expect("test URL should contain an IPv6 host")
+                    .parse()
+                    .expect("test URL should contain a valid IPv6 host"),
+                zone_id.to_string(),
+            );
+            assert_eq!(parsed.scoped_ipv6, Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_http_parse_url_does_not_treat_path_as_ipv6_zone() {
+        let span = Span::test_data();
+        let call = Call::new(span);
+        let input = "http://example.com/path[part%25other]";
+        let parsed = http_parse_url(&call, span, Value::test_string(input))
+            .expect("regular URL should parse")
+            .item;
+
+        assert_eq!(parsed.requested_url, input);
+        assert_eq!(parsed.request_url, input);
+        assert_eq!(parsed.scoped_ipv6, None);
+    }
+
+    #[test]
+    fn test_http_parse_url_rejects_zone_on_global_ipv6() {
+        let span = Span::test_data();
+        let call = Call::new(span);
+        let result = http_parse_url(&call, span, Value::test_string("http://[2001:db8::1%lo]/"));
+
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_retrieving_credentials_from_authority() {

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -222,25 +222,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.delete(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.delete(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.delete(&requested_url)
+        client.delete(&request_url)
     };
     request = request_set_timeout(args.timeout, request)?;
     request = request_add_authorization_header(args.user, args.password, request);
@@ -277,6 +281,7 @@ fn helper(
         stack,
         RequestMetadata {
             requested_url: &requested_url,
+            request_url: &request_url,
             span,
             headers: request_headers,
             redirect_mode,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -199,25 +199,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.get(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.get(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.get(&requested_url)
+        client.get(&request_url)
     };
 
     request = request_set_timeout(args.timeout, request)?;
@@ -240,6 +244,7 @@ fn helper(
         stack,
         RequestMetadata {
             requested_url: &requested_url,
+            request_url: &request_url,
             span,
             headers: request_headers,
             redirect_mode,

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -176,25 +176,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.head(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.head(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.head(&requested_url)
+        client.head(&request_url)
     };
 
     request = request_set_timeout(args.timeout, request)?;
@@ -219,6 +223,7 @@ fn helper(
             stack,
             RequestMetadata {
                 requested_url: &requested_url,
+                request_url: &request_url,
                 span,
                 headers: request_headers,
                 redirect_mode,

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -172,25 +172,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = RedirectMode::Follow;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.options(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.options(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.options(&requested_url)
+        client.options(&request_url)
     };
     request = request_set_timeout(args.timeout, request)?;
     request = request_add_authorization_header(args.user, args.password, request);
@@ -215,6 +219,7 @@ fn helper(
             stack,
             RequestMetadata {
                 requested_url: &requested_url,
+                request_url: &request_url,
                 span,
                 headers: request_headers,
                 redirect_mode,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -223,25 +223,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.patch(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.patch(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.patch(&requested_url)
+        client.patch(&request_url)
     };
 
     request = request_set_timeout(args.timeout, request)?;
@@ -272,6 +276,7 @@ fn helper(
         stack,
         RequestMetadata {
             requested_url: &requested_url,
+            request_url: &request_url,
             span,
             headers: request_headers,
             redirect_mode,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -247,25 +247,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.post(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.post(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.post(&requested_url)
+        client.post(&request_url)
     };
 
     request = request_set_timeout(args.timeout, request)?;
@@ -296,6 +300,7 @@ fn helper(
         stack,
         RequestMetadata {
             requested_url: &requested_url,
+            request_url: &request_url,
             span,
             headers: request_headers,
             redirect_mode,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -228,25 +228,29 @@ fn helper(
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
     let Spanned {
-        item: (requested_url, _),
+        item: parsed_url,
         span: request_span,
     } = http_parse_url(call, span, args.url)?;
+    let requested_url = parsed_url.requested_url;
+    let request_url = parsed_url.request_url;
+    let scoped_ipv6 = parsed_url.scoped_ipv6;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
 
     let cwd = engine_state.cwd(None)?;
     let unix_socket_path = expand_unix_socket_path(args.unix_socket, &cwd);
 
-    let mut request = if args.pool {
-        http_client_pool(engine_state, stack)?.put(&requested_url)
+    let mut request = if args.pool && scoped_ipv6.is_none() {
+        http_client_pool(engine_state, stack)?.put(&request_url)
     } else {
         let client = http_client(
             args.insecure,
             redirect_mode,
             unix_socket_path,
+            scoped_ipv6,
             engine_state,
             stack,
         )?;
-        client.put(&requested_url)
+        client.put(&request_url)
     };
 
     request = request_set_timeout(args.timeout, request)?;
@@ -276,6 +280,7 @@ fn helper(
         stack,
         RequestMetadata {
             requested_url: &requested_url,
+            request_url: &request_url,
             span,
             headers: request_headers,
             redirect_mode,

--- a/crates/nu-command/src/network/http/resolver.rs
+++ b/crates/nu-command/src/network/http/resolver.rs
@@ -1,6 +1,7 @@
 use std::{
+    borrow::Cow,
     error, fmt, io,
-    net::{SocketAddr, SocketAddrV4, SocketAddrV6},
+    net::{Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
 use http::Uri;
@@ -10,8 +11,49 @@ use ureq::{
     unversioned::transport::NextTimeout,
 };
 
-#[derive(Debug)]
-pub struct DnsLookupResolver;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScopedIpv6 {
+    address: Ipv6Addr,
+    zone_id: String,
+}
+
+impl ScopedIpv6 {
+    pub fn new(address: Ipv6Addr, zone_id: String) -> Self {
+        Self { address, zone_id }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DnsLookupResolver {
+    scoped_ipv6: Option<ScopedIpv6>,
+}
+
+impl DnsLookupResolver {
+    pub fn new(scoped_ipv6: Option<ScopedIpv6>) -> Self {
+        Self { scoped_ipv6 }
+    }
+
+    fn lookup_host<'a>(&self, uri: &'a Uri) -> Option<Cow<'a, str>> {
+        let uri_host = uri.host()?;
+        let unbracketed_host = uri_host
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(uri_host);
+        let address = unbracketed_host.parse::<Ipv6Addr>().ok();
+        let lookup_host = if address.is_some() {
+            unbracketed_host
+        } else {
+            uri_host
+        };
+
+        match &self.scoped_ipv6 {
+            Some(scoped_ipv6) if address == Some(scoped_ipv6.address) => {
+                Some(Cow::Owned(format!("{lookup_host}%{}", scoped_ipv6.zone_id)))
+            }
+            _ => Some(Cow::Borrowed(lookup_host)),
+        }
+    }
+}
 
 impl Resolver for DnsLookupResolver {
     fn resolve(
@@ -20,7 +62,7 @@ impl Resolver for DnsLookupResolver {
         config: &Config,
         _timeout: NextTimeout,
     ) -> Result<ResolvedSocketAddrs, ureq::Error> {
-        let host = uri.host();
+        let host = self.lookup_host(uri);
         // Determine the port: use explicit port if provided, otherwise derive from scheme
         let port = uri.port_u16().unwrap_or_else(|| match uri.scheme_str() {
             Some("https") => 443,
@@ -30,7 +72,7 @@ impl Resolver for DnsLookupResolver {
         // Pass None as service to avoid "Service not supported for this socket type" errors
         // in certain environments (e.g., Docker containers on some Linux distributions).
         // We'll set the port manually on each resolved address.
-        let addr_info_iter = dns_lookup::getaddrinfo(host, None, None)
+        let addr_info_iter = dns_lookup::getaddrinfo(host.as_deref(), None, None)
             .map_err(|err| ureq::Error::Other(Box::new(LookupError(err))))?;
 
         let ip_family = config.ip_family();
@@ -96,3 +138,32 @@ impl fmt::Display for LookupError {
 }
 
 impl error::Error for LookupError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_ipv6_is_only_applied_to_the_original_host() {
+        let resolver = DnsLookupResolver::new(Some(ScopedIpv6::new(
+            "fe80::1".parse().expect("valid test address"),
+            "eth0".to_string(),
+        )));
+        let original = "http://[fe80::1]/".parse().expect("valid test URI");
+        let redirect = "http://[fe80::2]/".parse().expect("valid test URI");
+
+        assert_eq!(
+            resolver.lookup_host(&original).as_deref(),
+            Some("fe80::1%eth0")
+        );
+        assert_eq!(resolver.lookup_host(&redirect).as_deref(), Some("fe80::2"));
+    }
+
+    #[test]
+    fn ipv6_brackets_are_not_passed_to_getaddrinfo() {
+        let resolver = DnsLookupResolver::default();
+        let uri = "http://[::1]/".parse().expect("valid test URI");
+
+        assert_eq!(resolver.lookup_host(&uri).as_deref(), Some("::1"));
+    }
+}


### PR DESCRIPTION
## Description

Adds support for IPv6 unicast link-local zone IDs across the HTTP commands. Both the raw `%zone` form recommended by RFC 9844 and the legacy RFC 6874 `%25zone` form are accepted.

The zone ID is removed from the request URI and retained only by the resolver for local address lookup, so it is not sent in the `Host` header or used for TLS SNI. Resolver scope is bound to the original IPv6 host so redirects cannot inherit it. Scoped requests bypass the shared pool because resolver state is request-specific.

Validation included the repository's three Clippy gates, full workspace and standard-library tests, workspace doctests, focused HTTP tests, and a real link-local IPv6 smoke test for both forms with the wire `Host` header verified to contain no zone ID.

## User-facing changes (Release notes)

Nushell HTTP commands now accept link-local IPv6 URLs with raw or percent-encoded zone IDs, such as `http://[fe80::1%eth0]/` and `http://[fe80::1%25eth0]/`.

## Additional notes

Fixes #9065
