### PR TITLE
fix(completions): keep the REPL usable when a completer runs `fzf` or `input list`

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -701,10 +701,10 @@ impl CompletionEngine {
     }
 
     /// Parse once; if this site needs a user closure, dispatch on this thread.
-    fn complete_user_closure_on_repl_thread(
-        &self,
-        query: &CompletionQuery,
-    ) -> Option<(Suggestions, bool)> {
+    ///
+    /// Results are not cached: a picker (`fzf`, `input list`, `carapace`) is not a function
+    /// of the line, so a stored pick would skip the UI on the next Tab.
+    fn complete_user_closure_on_repl_thread(&self, query: &CompletionQuery) -> Option<Suggestions> {
         self.with_completion_site(query, |working_set, block, site, line, offset| {
             if !self.query_runs_user_closure(working_set, site, line, offset) {
                 return None;
@@ -717,12 +717,13 @@ impl CompletionEngine {
                 offset,
                 line,
             );
-            let suggestions = dispatched
-                .suggestions
-                .into_iter()
-                .map(|semantic_suggestion| semantic_suggestion.suggestion)
-                .collect();
-            Some((suggestions, dispatched.cacheable))
+            Some(
+                dispatched
+                    .suggestions
+                    .into_iter()
+                    .map(|semantic_suggestion| semantic_suggestion.suggestion)
+                    .collect(),
+            )
         })
     }
 
@@ -2007,13 +2008,7 @@ impl ReedlineCompleter for NuCompleter {
             return CompletionResult::fresh(suggestions).with_partial(partial);
         }
 
-        if let Some((suggestions, cacheable)) =
-            self.engine.complete_user_closure_on_repl_thread(&query)
-        {
-            if cacheable {
-                self.cache
-                    .store(query.clone(), self.cache_env, suggestions.clone());
-            }
+        if let Some(suggestions) = self.engine.complete_user_closure_on_repl_thread(&query) {
             self.settle_pending(&query);
             let partial = partial_of(line, &suggestions);
             return CompletionResult::fresh(suggestions).with_partial(partial);

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -661,6 +661,148 @@ impl CompletionEngine {
         (suggestions, dispatched.cacheable)
     }
 
+    /// Parse `query` once and run `f` with the resolved completion site.
+    ///
+    /// `CompletionQuery` is already the prefix up to the floored cursor, so this
+    /// does not slice or floor again.
+    fn with_completion_site<R>(
+        &self,
+        query: &CompletionQuery,
+        f: impl FnOnce(&StateWorkingSet, &Arc<Block>, &CompletionSite, &str, usize) -> R,
+    ) -> R {
+        let line = query.typed();
+        let position = query.cursor();
+        let mut working_set = StateWorkingSet::new(&self.engine_state);
+        let offset = working_set.next_span_start();
+        let block = parse(&mut working_set, Some("completer"), line.as_bytes(), false);
+        let site = self.resolve_completion_site(&block, &working_set, position, offset, line);
+        f(&working_set, &block, &site, line, offset)
+    }
+
+    fn query_runs_user_closure(
+        &self,
+        working_set: &StateWorkingSet,
+        site: &CompletionSite,
+        line: &str,
+        offset: usize,
+    ) -> bool {
+        self.site_runs_user_closure(site, working_set)
+            || self.multiword_argument_runs_user_closure(site, working_set, line, offset)
+    }
+
+    /// User-closure completers (external completer, `@complete`, custom commands)
+    /// take the TTY. They must run on the REPL thread with reedline blocked, not
+    /// on the background worker.
+    #[cfg(test)]
+    fn should_complete_on_repl_thread(&self, query: &CompletionQuery) -> bool {
+        self.with_completion_site(query, |working_set, _, site, line, offset| {
+            self.query_runs_user_closure(working_set, site, line, offset)
+        })
+    }
+
+    /// Parse once; if this site needs a user closure, dispatch on this thread.
+    fn complete_user_closure_on_repl_thread(
+        &self,
+        query: &CompletionQuery,
+    ) -> Option<(Suggestions, bool)> {
+        self.with_completion_site(query, |working_set, block, site, line, offset| {
+            if !self.query_runs_user_closure(working_set, site, line, offset) {
+                return None;
+            }
+            let _tty = crate::util::ReplTerminalGuard::capture();
+            let dispatched = self.fetch_completions_by_block(
+                Arc::clone(block),
+                working_set,
+                query.cursor(),
+                offset,
+                line,
+            );
+            let suggestions = dispatched
+                .suggestions
+                .into_iter()
+                .map(|semantic_suggestion| semantic_suggestion.suggestion)
+                .collect();
+            Some((suggestions, dispatched.cacheable))
+        })
+    }
+
+    fn has_external_completer(&self) -> bool {
+        self.engine_state
+            .get_config()
+            .completions
+            .external
+            .completer
+            .is_some()
+    }
+
+    fn signature_runs_user_closure(&self, signature: &Signature) -> bool {
+        match signature.complete {
+            Some(CommandWideCompleter::Command(_)) => true,
+            Some(CommandWideCompleter::External) => self.has_external_completer(),
+            None => false,
+        }
+    }
+
+    fn site_runs_user_closure(&self, site: &CompletionSite, working_set: &StateWorkingSet) -> bool {
+        match &site.kind {
+            SiteKind::ExternalArg { .. } => self.has_external_completer(),
+            SiteKind::FlagName { call, .. } => {
+                self.signature_runs_user_closure(&working_set.get_decl(call.decl_id).signature())
+            }
+            SiteKind::FlagValue { call, flag, .. } => {
+                let signature = working_set.get_decl(call.decl_id).signature();
+                let resolved = find_flag(&signature, *flag);
+                let custom = resolved.as_ref().and_then(|flag| flag.completion.as_ref());
+                matches!(custom, Some(Completion::Command(_)))
+                    || self.signature_runs_user_closure(&signature)
+            }
+            SiteKind::Positional {
+                call,
+                sig_positional,
+                ..
+            } => {
+                let signature = working_set.get_decl(call.decl_id).signature();
+                let custom = signature
+                    .get_positional(*sig_positional)
+                    .and_then(|positional| positional.completion.as_ref());
+                matches!(custom, Some(Completion::Command(_)))
+                    || self.signature_runs_user_closure(&signature)
+            }
+            _ => false,
+        }
+    }
+
+    fn multiword_argument_runs_user_closure(
+        &self,
+        site: &CompletionSite,
+        working_set: &StateWorkingSet,
+        contents: &str,
+        offset: usize,
+    ) -> bool {
+        if !matches!(site.kind, SiteKind::Command { .. })
+            || !working_set
+                .get_span_contents(site.span)
+                .iter()
+                .any(u8::is_ascii_whitespace)
+        {
+            return false;
+        }
+
+        let mut parse_ws = StateWorkingSet::new(&self.engine_state);
+        let _ = parse_ws.add_file("completer", contents.as_bytes());
+        let Some(shorter) = parse_shorter_head_reading(&mut parse_ws, site.span, None) else {
+            return false;
+        };
+        let position = site.cursor.saturating_sub(offset);
+        let shorter_site = self.finalize_site(
+            self.resolve_expression_site(&shorter, site.cursor, &parse_ws),
+            contents,
+            position,
+            offset,
+        );
+        self.site_runs_user_closure(&shorter_site, &parse_ws)
+    }
+
     pub fn fetch_completions_at(&self, line: &str, position: usize) -> Vec<SemanticSuggestion> {
         self.dispatch_completions_at(line, position).suggestions
     }
@@ -1835,6 +1977,18 @@ impl ReedlineCompleter for NuCompleter {
             return CompletionResult::fresh(suggestions).with_partial(partial);
         }
 
+        if let Some((suggestions, cacheable)) =
+            self.engine.complete_user_closure_on_repl_thread(&query)
+        {
+            if cacheable {
+                self.cache
+                    .store(query.clone(), self.cache_env, suggestions.clone());
+            }
+            self.settle_pending(&query);
+            let partial = partial_of(line, &suggestions);
+            return CompletionResult::fresh(suggestions).with_partial(partial);
+        }
+
         let fallback = self.stale_fallback(&query);
         let partial = partial_of(line, &fallback);
 
@@ -1927,6 +2081,53 @@ mod completer_tests {
 
         // Extending a flag the user was already typing stays sound.
         assert!(q("from csv --sep").narrows(&q("from csv --s"), token(9)));
+    }
+
+    #[test]
+    fn background_engine_suppresses_stdin() {
+        let engine = test_engine();
+        let stack = Arc::new(Stack::new());
+        let foreground = CompletionEngine::new(engine, stack);
+        assert!(!foreground.stack.suppress_stdin);
+        let background = foreground.to_background();
+        assert!(background.stack.suppress_stdin);
+    }
+
+    #[test]
+    fn internal_command_completion_stays_on_the_worker() {
+        let engine = CompletionEngine::new(test_engine(), Arc::new(Stack::new()));
+        assert!(!engine.should_complete_on_repl_thread(&q("ls | c")));
+    }
+
+    fn engine_with_external_completer() -> Arc<EngineState> {
+        use nu_engine::eval_block;
+        use nu_protocol::{PipelineData, debugger::WithoutDebug};
+
+        let mut engine = (*test_engine()).clone();
+        let mut stack = Stack::new();
+        let mut working_set = StateWorkingSet::new(&engine);
+        let block = parse(
+            &mut working_set,
+            None,
+            b"$env.config.completions.external.completer = {|spans| $spans}",
+            false,
+        );
+        assert!(working_set.parse_errors.is_empty());
+        engine
+            .merge_delta(working_set.render())
+            .expect("merge_delta");
+        eval_block::<WithoutDebug>(&engine, &mut stack, &block, PipelineData::empty())
+            .expect("eval completer config");
+        engine.merge_env(&mut stack).expect("merge_env");
+        Arc::new(engine)
+    }
+
+    #[test]
+    fn external_arg_with_completer_runs_on_the_repl_thread() {
+        let engine =
+            CompletionEngine::new(engine_with_external_completer(), Arc::new(Stack::new()));
+        assert!(engine.should_complete_on_repl_thread(&q("nvim foo")));
+        assert!(!engine.should_complete_on_repl_thread(&q("ls | c")));
     }
 
     /// The worker runs on an isolated stack and must still produce identical results.

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -59,6 +59,9 @@ impl Completer for NuMenuCompleter {
 
         let input = Value::nothing(self.span).into_pipeline_data();
 
+        // Do not wrap this in `ReplTerminalGuard`. That disable/enable bounce
+        // runs on every menu refresh. Nested `input list` restores via
+        // `RawModeGuard`; fzf restores termios itself.
         let res = eval_block::<WithoutDebug>(&self.engine_state, &mut self.stack, block, input)
             .map(|p| p.body);
 

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -22,6 +22,35 @@ use nu_utils::time::Instant;
 use nu_utils::{escape_quote_string, perf};
 use std::path::Path;
 
+/// Captures whether the process was already in raw mode, then restores that
+/// on drop after a Tab completer closure that may have taken the TTY (`fzf`).
+///
+/// Tests and other cooked-mode callers stay cooked: we only re-enable raw
+/// mode when it was on before the closure ran. Menu sources must not use this;
+/// bouncing raw mode on every refresh flickers the prompt.
+#[must_use = "captures raw-mode state that is restored on drop"]
+pub(crate) struct ReplTerminalGuard {
+    was_raw: bool,
+}
+
+impl ReplTerminalGuard {
+    pub(crate) fn capture() -> Self {
+        let was_raw = crossterm::terminal::is_raw_mode_enabled().unwrap_or(false);
+        Self { was_raw }
+    }
+}
+
+impl Drop for ReplTerminalGuard {
+    fn drop(&mut self) {
+        if self.was_raw {
+            // Crossterm's Unix `enable_raw_mode` is a no-op when it already
+            // recorded raw mode, so it will not `tcsetattr` after fzf.
+            let _ = crossterm::terminal::disable_raw_mode();
+            let _ = crossterm::terminal::enable_raw_mode();
+        }
+    }
+}
+
 // This will collect environment variables from std::env and adds them to a stack.
 //
 // In order to ensure the values have spans, it first creates a dummy file, writes the collected

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -929,8 +929,10 @@ fn customcompletions_error_falls_back_to_file_completion() {
 }
 
 /// A completer that calls an interactive command (`input`, `input list`, `input listen`,
-/// `term query`) runs on the REPL thread so it can take the TTY. In these tests there
-/// is no terminal, so the command errors and the completer falls back to file completion.
+/// `term query`) runs on the REPL thread so it can take the TTY. With no console the
+/// command errors and the completer falls back to file completion. Windows test
+/// processes have a console, so detach stdin there: the command declines via
+/// `require_stdin` instead of blocking on keys, and we still assert file fallback.
 #[rstest]
 #[case::input("input")]
 #[case::input_reedline("input --reedline")]
@@ -941,6 +943,9 @@ fn interactive_command_in_completer_falls_back_to_file_completion(#[case] body: 
     let (_, _, mut engine, mut stack) = new_engine();
     let command = format!("def comp [] {{ {body} }}; def my-command [arg: string@comp] {{}}");
     assert!(support::merge_input(command.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    #[cfg(windows)]
+    let stack = stack.suppress_stdin();
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let line = "my-command custom_completion.";

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -16,7 +16,7 @@ use nu_protocol::{
 };
 use nu_std::load_standard_library;
 use nu_test_support::fs;
-use reedline::{Span, Suggestion, Suggestions};
+use reedline::{Completer, CompletionResult, Span, Suggestion, Suggestions};
 use rstest::{fixture, rstest};
 use support::{
     completions_helpers::{
@@ -929,9 +929,8 @@ fn customcompletions_error_falls_back_to_file_completion() {
 }
 
 /// A completer that calls an interactive command (`input`, `input list`, `input listen`,
-/// `term query`) runs on a background thread detached from the terminal, so the command
-/// should decline rather than race reedline for it; the completer then falls back to file
-/// completion.
+/// `term query`) runs on the REPL thread so it can take the TTY. In these tests there
+/// is no terminal, so the command errors and the completer falls back to file completion.
 #[rstest]
 #[case::input("input")]
 #[case::input_reedline("input --reedline")]
@@ -1223,6 +1222,18 @@ fn dotnu_completions_const_nu_lib_dirs() {
     let completion_str = "use ./asdf";
     let suggestions = completer.complete_blocking(completion_str, completion_str.len());
     match_suggestions(&vec!["./asdf.nu"], &suggestions);
+}
+
+/// Interactive pickers in the external completer need the TTY, so that closure
+/// must not go through the background worker (`complete()` returns Fresh).
+#[test]
+fn external_completer_runs_on_the_repl_thread() {
+    let mut completer = custom_completer();
+    let result = completer.complete("foo test", 8);
+    assert!(
+        matches!(result, CompletionResult::Fresh { .. }),
+        "external completer must run on the REPL thread, got {result:?}"
+    );
 }
 
 #[test]

--- a/crates/nu-command/src/platform/input/legacy_input.rs
+++ b/crates/nu-command/src/platform/input/legacy_input.rs
@@ -43,8 +43,7 @@ pub trait LegacyInput {
         let default_val: Option<String> = call.get_flag(engine_state, stack, "default")?;
 
         // Acquire the guard (and its `require_stdin` check) before writing anything, so a
-        // detached stack (e.g. a completer running off the main thread) errors out before the
-        // prompt is printed to stdout, instead of corrupting the active display first.
+        // detached stack (completion worker or MCP) errors out before the prompt is printed.
         let raw_mode = RawModeGuard::acquire(stack, call.head)?;
 
         if let Some(prompt) = &prompt {

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -1,12 +1,10 @@
+use crate::platform::RawModeGuard;
 use crossterm::{
     cursor::{Hide, MoveDown, MoveToColumn, MoveUp, Show},
     event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
     execute,
     style::Print,
-    terminal::{
-        self, BeginSynchronizedUpdate, Clear, ClearType, EndSynchronizedUpdate, disable_raw_mode,
-        enable_raw_mode,
-    },
+    terminal::{self, BeginSynchronizedUpdate, Clear, ClearType, EndSynchronizedUpdate},
 };
 use nu_ansi_term::{Style, ansi::RESET};
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
@@ -562,7 +560,8 @@ Use --no-footer and --no-separator to hide the footer and separator line."#
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        // The widget below manages raw mode itself, so check the precondition here.
+        // `RawModeGuard` below enables raw mode; check the detached-stack
+        // precondition first so a completion thread declines before drawing.
         stack.require_stdin(head)?;
         let prompt: Option<String> = call.opt(engine_state, stack, 0)?;
         let multi = call.has_flag(engine_state, stack, "multi")?;
@@ -693,6 +692,9 @@ Use --no-footer and --no-separator to hide the footer and separator line."#
                 item_generator: Some(item_generator),
             },
         );
+        // `require_stdin` ran above; this guard restores reedline's raw mode if
+        // we were already in it (menu source / main-thread completer).
+        let _raw_mode = RawModeGuard::enter(head)?;
         let answer = widget.run().map_err(|err| {
             IoError::new_with_additional_context(err, call.head, None, INTERACT_ERROR)
         })?;
@@ -1729,11 +1731,6 @@ impl<'a> SelectWidget<'a> {
 
     fn run(&mut self) -> io::Result<InteractMode> {
         let mut stderr = io::stderr();
-
-        enable_raw_mode().map_err(io_context("enable raw mode"))?;
-        scopeguard::defer! {
-            let _ = disable_raw_mode();
-        }
 
         // Only hide cursor for non-fuzzy modes (fuzzy modes need visible cursor for text input)
         if self.mode != SelectMode::Fuzzy && self.mode != SelectMode::FuzzyMulti {

--- a/crates/nu-command/src/platform/raw_mode.rs
+++ b/crates/nu-command/src/platform/raw_mode.rs
@@ -1,22 +1,51 @@
 use nu_protocol::{ShellError, Span, engine::Stack, shell_error::io::IoError};
 
 /// RAII guard for crossterm raw mode: [`acquire`](Self::acquire) checks
-/// [`Stack::require_stdin`] and enables raw mode; [`Drop`] disables it on any exit path.
-#[must_use = "raw mode is disabled as soon as the guard is dropped"]
-pub(crate) struct RawModeGuard;
+/// [`Stack::require_stdin`] and enables raw mode; [`Drop`] restores the previous
+/// raw-mode state on any exit path.
+///
+/// Nested use (for example `input list` while reedline already has raw mode on)
+/// must not `disable_raw_mode` on drop — that leaves the line editor cooked and
+/// breaks backspace. If raw mode was already enabled, drop re-applies it.
+#[must_use = "dropping the guard restores the previous raw-mode state"]
+pub(crate) struct RawModeGuard {
+    /// When true, the terminal was already in raw mode; leave it that way.
+    leave_raw: bool,
+}
 
 impl RawModeGuard {
     /// Enter raw mode, or error per [`Stack::require_stdin`]. `span` points at the offending
     /// call.
     pub(crate) fn acquire(stack: &Stack, span: Span) -> Result<Self, ShellError> {
         stack.require_stdin(span)?;
-        crossterm::terminal::enable_raw_mode().map_err(|err| IoError::new(err, span, None))?;
-        Ok(Self)
+        Self::enter(span)
+    }
+
+    /// Enable raw mode without the stdin check. Caller must have already called
+    /// [`Stack::require_stdin`] if this context can be detached from the terminal.
+    pub(crate) fn enter(span: Span) -> Result<Self, ShellError> {
+        let was_raw = crossterm::terminal::is_raw_mode_enabled()
+            .map_err(|err| IoError::new(err, span, None))?;
+        if !was_raw {
+            crossterm::terminal::enable_raw_mode().map_err(|err| IoError::new(err, span, None))?;
+        }
+        Ok(Self { leave_raw: was_raw })
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
-        let _ = crossterm::terminal::disable_raw_mode();
+        if self.leave_raw {
+            reapply_raw_mode();
+        } else {
+            let _ = crossterm::terminal::disable_raw_mode();
+        }
     }
+}
+
+/// Crossterm's Unix `enable_raw_mode` is a no-op when it already recorded raw
+/// mode, so it will not `tcsetattr` after fzf. Disable first to force a re-apply.
+fn reapply_raw_mode() {
+    let _ = crossterm::terminal::disable_raw_mode();
+    let _ = crossterm::terminal::enable_raw_mode();
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -266,7 +266,6 @@ If you create a custom command with this name, that will be used instead."
                 // MCP and background completions must not inherit the live terminal.
                 if engine_state.is_mcp || stack.suppress_stdin {
                     command.stdin(Stdio::null());
-                    prepare_background_command(&mut command);
                 } else {
                     command.stdin(Stdio::inherit());
                 }
@@ -277,6 +276,12 @@ If you create a custom command with this name, that will be used instead."
                 Some(value)
             }
         };
+
+        // Detach even when stdin is a pipe of candidates (`ls | fzf`). Otherwise
+        // the child keeps `/dev/tty` and races reedline from a completion thread.
+        if engine_state.is_mcp || stack.suppress_stdin {
+            prepare_background_command(&mut command);
+        }
 
         // Log the command we're about to run in case it's useful for debugging purposes.
         log::trace!("run-external spawning: {command:?}");
@@ -838,15 +843,14 @@ mod background_isolation_tests {
     use std::process::{Command, Stdio};
 
     #[cfg(unix)]
-    #[test]
-    fn setsid_removes_controlling_terminal() {
+    fn assert_child_has_no_tty(stdin: Stdio) {
         let mut cmd = Command::new("sh");
         // Subshell so a failed redirect does not exit before the `||` branch.
         cmd.args([
             "-c",
             "(exec 3>/dev/tty) 2>/dev/null && echo has_tty || echo no_tty",
         ])
-        .stdin(Stdio::null())
+        .stdin(stdin)
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
         prepare_background_command(&mut cmd);
@@ -857,6 +861,18 @@ mod background_isolation_tests {
             "no_tty",
             "child must not retain a controlling terminal after setsid"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn setsid_removes_controlling_terminal() {
+        assert_child_has_no_tty(Stdio::null());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn setsid_removes_controlling_terminal_with_piped_stdin() {
+        assert_child_has_no_tty(Stdio::piped());
     }
 
     #[cfg(windows)]

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -284,7 +284,18 @@ $env.config.completions.partial = true
 # Default: true
 $env.config.completions.use_ls_colors = true
 
-# completions.cache_size (int): Completion cache size (0 disables the cache).
+# completions.cache_size (int): How many Tab-completion prefixes to remember.
+# Results are stored by the text up to the cursor (for example `ls fo`) and
+# reused on the next Tab of that same prefix so Nushell does not re-scan
+# files or command names. Least-recently-used entries are dropped when the
+# limit is reached. The cache is shared across prompts and is discarded when
+# PATH, the working directory, or the set of commands changes.
+# 0: Disable the cache; every Tab recomputes.
+# A larger value remembers more prefixes (uses more memory).
+# A smaller value forgets sooner.
+# Closures on `$env.config.completions.external.completer` and custom
+# `@comp` / `@complete` completers are not stored, so an interactive picker
+# (fzf, `input list`) runs again on the next Tab.
 # Default: 100
 $env.config.completions.cache_size = 100
 

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -307,6 +307,10 @@ $env.config.completions.external.max_results = 100
 # The closure receives a |spans| parameter - a list of strings representing
 # tokens on the current commandline. Usually set to call a third-party
 # completion system like Carapace.
+# Evaluating this closure blocks the line editor and may take the TTY, which
+# interactive pickers (fzf, `input list`) need. Completers that only print a
+# list should return quickly. Custom menu `source` closures already run on
+# the REPL thread the same way.
 # Default: null
 $env.config.completions.external.completer = null
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -99,8 +99,9 @@ pub struct Stack {
     /// Locally updated config. Use [`.get_config()`](Self::get_config) to access correctly.
     pub config: Option<Arc<Config>>,
     pub(crate) out_dest: StackOutDest,
-    /// When `true`, external processes spawned with `PipelineData::Empty` input
-    /// receive `/dev/null` for stdin instead of inheriting the terminal.
+    /// When `true`, external processes spawned from this stack are detached from
+    /// the controlling terminal, and empty stdin is `/dev/null` instead of inheriting
+    /// the TTY. Used on completion threads so children cannot race reedline.
     pub suppress_stdin: bool,
     /// Active block-local scope bindings (commands/modules), outer → inner.
     ///
@@ -1279,14 +1280,16 @@ impl Stack {
         self
     }
 
-    /// Causes external processes spawned with empty input to receive
-    /// `/dev/null` for stdin instead of inheriting the terminal.
+    /// Causes external processes spawned from this stack to detach from the
+    /// controlling terminal. Empty input also receives `/dev/null` for stdin
+    /// instead of inheriting the terminal.
     ///
     /// Use this together with [`suppress_output`](Self::suppress_output) for
     /// background tasks (e.g. completion threads).  Without it, subprocesses
     /// spawned by closure-based completers (carapace, fish_complete, etc.)
     /// inherit the live terminal fd and can race with reedline's reads,
-    /// causing `Input/output error` (EIO).
+    /// causing `Input/output error` (EIO). Piped stdin (candidate lists for
+    /// `fzf`) is still detached so the child cannot open `/dev/tty`.
     pub fn suppress_stdin(mut self) -> Self {
         self.suppress_stdin = true;
         self
@@ -1306,9 +1309,9 @@ impl Stack {
                     span,
                 )
                 .with_help(
-                    "external and custom completers run detached from the terminal, so \
+                    "this stack is detached from the terminal (completion worker or MCP), so \
                      interactive commands like `input`, `input list`, `input listen`, and \
-                     `term query` cannot be used inside them",
+                     `term query` cannot run here",
                 ),
             ))
         } else {

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -15,8 +15,9 @@ pub use child_pgroup::stdin_fd;
 /// Detach `command` from the parent's controlling terminal/console.
 ///
 /// Used for background completion subprocesses so they cannot call
-/// `tcsetattr` / `SetConsoleMode` and corrupt reedline. Caller must also
-/// redirect stdin to null. No-op on platforms without a process API.
+/// `tcsetattr` / `SetConsoleMode` and corrupt reedline, nor open `/dev/tty`
+/// to read keystrokes meant for it. Caller must also keep stdin off the
+/// terminal (null or a pipe). No-op on platforms without a process API.
 pub fn prepare_background_command(command: &mut Command) {
     #[cfg(unix)]
     child_pgroup::prepare_isolated_command(command);


### PR DESCRIPTION
## Description

Tab completion and custom menus were fighting interactive pickers (`fzf`, `input list`) for the terminal. That is #18879.

Tab runs `NuCompleter` on a background worker with `suppress_stdin`. That isolation is right for carapace-style completers that only print a list. It is wrong for a completer that needs the TTY:

- `input list` hit `require_stdin` and declined, so Tab fell back to file completion.
- `^fzf` with a piped candidate list skipped `setsid`, opened `/dev/tty` on the worker, and raced reedline. The prompt hung after fzf exited.

Ctrl+T goes through a menu `source` on the REPL thread, so fzf already worked there. `input list` did not: it always `disable_raw_mode()` on the way out, even when reedline already had raw mode on. Backspace then died inside the same `read_line`.

External-arg Tab is now blocking by design whenever a completer closure is configured. That is the same path fzf needs. Call it out in the release notes so Carapace configs are not a surprise.

`ReplTerminalGuard` only restores raw mode after that closure. It does not re-enable bracketed paste or the kitty keyboard protocol. Reedline turns those on at `read_line` start; they are ANSI modes, not termios. Carapace does not touch them. Fzf might. If paste-after-fzf on the same prompt misbehaves, a follow-up should emit `EnableBracketedPaste` / kitty push from the guard using `$env.config.bracketed_paste` and `use_kitty_protocol`.

## User-facing changes (Release notes)

### Interactive pickers in completions

Tab completion can run an interactive picker from `$env.config.completions.external.completer` (and from custom `@comp` / `@complete` closures). Closures such as fzf or `input list` take the TTY while the line editor waits. Completers that only print a list should still return quickly.

After `input list` (or a similar picker) returns from a completion or a custom menu, the prompt keeps raw mode. Backspace and other editing keys work again.

Subprocesses spawned from a background completion thread stay detached from the terminal even when their stdin is a pipe, so they cannot steal the TTY from the line editor.

### Tab waits for the external completer

When `$env.config.completions.external.completer` is set, Tab on an external command waits for that closure before the line editor continues. That lets a picker such as fzf or `input list` take the terminal. Completers that only print a list (for example Carapace) should return quickly; a slow closure freezes the prompt until it finishes.

File and command-name completion still run in the background. Custom menu `source` closures were already synchronous.

To make every Tab wait, not only user completers:

```nushell
nu --experimental-options '[background-completions=false]'
```
Results from the external completer and from `@comp` / `@complete` are not cached, so a picker runs again on the next Tab.

## Additional notes
closes https://github.com/nushell/nushell/issues/18879
closes https://github.com/nushell/nushell/issues/18771
