### PR TITLE
Allow float value strings with commas in `into float`

### DIFF
--- a/crates/nu-cmd-base/src/input_handler.rs
+++ b/crates/nu-cmd-base/src/input_handler.rs
@@ -13,6 +13,12 @@ pub struct CellPathOnlyArgs {
     cell_paths: Option<Vec<CellPath>>,
 }
 
+impl CellPathOnlyArgs {
+    pub const fn empty() -> Self {
+        CellPathOnlyArgs { cell_paths: None }
+    }
+}
+
 impl CmdArgument for CellPathOnlyArgs {
     fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
         self.cell_paths.take()

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -1,5 +1,8 @@
+use std::borrow::Cow;
+
 use nu_cmd_base::input_handler::{CellPathOnlyArgs, operate};
 use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
 
 #[derive(Clone)]
 pub struct IntoFloat;
@@ -88,9 +91,30 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
     match input {
         Value::Float { .. } => input.clone(),
         Value::String { val: s, .. } => {
-            let other = s.trim();
+            let val = s.trim();
+            let has_comma = val.contains(',');
+            let has_dot = val.contains('.');
 
-            match other.parse::<f64>() {
+            if has_comma && has_dot {
+                return Value::error(
+                    ShellError::Generic(
+                        GenericError::new(
+                            "Ambivalence in conversion",
+                            "input contains both `,` and `.`",
+                            span,
+                        )
+                        .with_code("nu::shell::cant_convert::ambivalence"),
+                    ),
+                    span,
+                );
+            }
+
+            let val = match has_comma {
+                false => Cow::Borrowed(val),
+                true => Cow::Owned(val.replace(',', ".")),
+            };
+
+            match val.parse::<f64>() {
                 Ok(x) => Value::float(x, head),
                 Err(reason) => Value::error(
                     ShellError::CantConvert {
@@ -129,6 +153,11 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
 mod tests {
     use super::*;
     use nu_protocol::Type::Error;
+    use pretty_assertions::assert_matches;
+    use rstest::rstest;
+
+    static ARGS: &CellPathOnlyArgs = &CellPathOnlyArgs::empty();
+    static SPAN: Span = Span::test_data();
 
     #[test]
     fn test_examples() -> nu_test_support::Result {
@@ -141,7 +170,7 @@ mod tests {
         let word = Value::test_string("3.1415");
         let expected = Value::test_float(3.1415);
 
-        let actual = action(&word, &CellPathOnlyArgs::from(vec![]), Span::test_data());
+        let actual = action(&word, ARGS, SPAN);
         assert_eq!(actual, expected);
     }
 
@@ -149,11 +178,7 @@ mod tests {
     fn communicates_parsing_error_given_an_invalid_floatlike_string() {
         let invalid_str = Value::test_string("11.6anra");
 
-        let actual = action(
-            &invalid_str,
-            &CellPathOnlyArgs::from(vec![]),
-            Span::test_data(),
-        );
+        let actual = action(&invalid_str, ARGS, SPAN);
 
         assert_eq!(actual.get_type(), Error);
     }
@@ -162,12 +187,24 @@ mod tests {
     fn int_to_float() {
         let input_int = Value::test_int(10);
         let expected = Value::test_float(10.0);
-        let actual = action(
-            &input_int,
-            &CellPathOnlyArgs::from(vec![]),
-            Span::test_data(),
-        );
+        let actual = action(&input_int, ARGS, SPAN);
 
         assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::dot("12.34")]
+    #[case::comma("12,34")]
+    fn parse_dot_or_comma(#[case] input: &str) {
+        assert_eq!(
+            action(&Value::test_string(input), ARGS, SPAN),
+            Value::test_float(12.34)
+        );
+    }
+
+    #[test]
+    fn dot_and_comma_fails() {
+        let err = action(&Value::test_string("12.34,56"), ARGS, SPAN);
+        assert_matches!(err, Value::Error { error, .. } if error.to_string() == "Ambivalence in conversion");
     }
 }

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -193,12 +193,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case::dot("12.34")]
-    #[case::comma("12,34")]
-    fn parse_dot_or_comma(#[case] input: &str) {
+    #[case::dot("12.34", 12.34)]
+    #[case::comma("12,34", 12.34)]
+    #[case::positive_dot("+12.34", 12.34)]
+    #[case::positive_comma("+12,34", 12.34)]
+    #[case::negative_dot("-12.34", -12.34)]
+    #[case::negative_comma("-12,34", -12.34)]
+    fn parse_dot_or_comma(#[case] input: &str, #[case] expected: f64) {
         assert_eq!(
             action(&Value::test_string(input), ARGS, SPAN),
-            Value::test_float(12.34)
+            Value::test_float(expected)
         );
     }
 

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -99,11 +99,11 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
                 return Value::error(
                     ShellError::Generic(
                         GenericError::new(
-                            "Ambivalence in conversion",
+                            "Ambiguity in conversion",
                             "input contains both `,` and `.`",
                             span,
                         )
-                        .with_code("nu::shell::cant_convert::ambivalence"),
+                        .with_code("nu::shell::cant_convert::ambiguity"),
                     ),
                     span,
                 );
@@ -205,6 +205,6 @@ mod tests {
     #[test]
     fn dot_and_comma_fails() {
         let err = action(&Value::test_string("12.34,56"), ARGS, SPAN);
-        assert_matches!(err, Value::Error { error, .. } if error.to_string() == "Ambivalence in conversion");
+        assert_matches!(err, Value::Error { error, .. } if error.to_string() == "Ambiguity in conversion");
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
Currently it's a bit annoying parsing a floating point number that is using a comma as a decimal separator. This PR allows that by replacing a comma with a dot if the string contains a comma but no dot.

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->
Floating point number strings may now be parsed via `into float` if they use a comma as decimal separator.
