### PR TITLE
chore(reedline): bump reedline fc19b91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -2265,7 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3314,7 +3314,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -3704,7 +3704,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5965,7 +5965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7310,7 +7310,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.51.0"
-source = "git+https://github.com/nushell/reedline?branch=main#73b928a4c36c8f3cfe9f55fbf420674205154472"
+source = "git+https://github.com/nushell/reedline?branch=main#fc19b9124242ae0c01e8eec7b4bb5349a66b0c7e"
 dependencies = [
  "arboard",
  "chrono",
@@ -7969,7 +7969,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7982,7 +7982,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8041,7 +8041,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8670,6 +8670,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -9005,7 +9006,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10409,7 +10410,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,10 +235,7 @@ ratatui = { version = "0.30", default-features = false, features = [
   #"underline-color" # leave out so we don't bring in termwiz
 ] }
 rayon = "1.12.0"
-# default-features = false keeps reedline's default-on `helix` feature keyed to
-# the workspace `helix` feature chain, so nu-cli's cfg-gated glue and reedline's
-# helix types stay in lockstep even when a crate is built standalone.
-reedline = { version = "0.51.0", default-features = false }
+reedline = { version = "0.51.0" }
 regex = "1.13.1"
 rmp = "0.8.15"
 rmp-serde = "1.3.1"
@@ -395,7 +392,6 @@ tempfile = { workspace = true }
 # Enable all features while still avoiding mutually exclusive features.
 # Use this if `--all-features` fails.
 full = [
-  "helix",
   "lsp",
   "mcp",
   "network",
@@ -433,7 +429,6 @@ native-tls = ["nu-command/native-tls"]
 rustls-tls = ["nu-command/rustls-tls"]
 
 default = [
-  "helix",
   "lsp",
   "mcp",
   "network",
@@ -454,14 +449,6 @@ static-link-openssl = ["dep:openssl"]
 system-clipboard = [
   "reedline/system_clipboard",
   "nu-cli/system-clipboard",
-]
-
-# Helix/Kakoune-style edit mode from `reedline` (`$env.config.edit_mode = "helix"`).
-# Enabled by default; opt out for a build without the mode.
-helix = [
-  "nu-cli/helix",
-  "nu-command/helix",
-  "reedline/helix",
 ]
 
 # Stable (Default)

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -61,7 +61,6 @@ which = { workspace = true }
 [features]
 plugin = ["nu-plugin-engine"]
 system-clipboard = ["reedline/system_clipboard"]
-helix = ["reedline/helix"]
 sqlite = ["reedline/sqlite", "nu-protocol/sqlite", "nu-command/sqlite"]
 
 [lints]

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -1,7 +1,6 @@
 use nu_protocol::engine::{PromptContents, PromptState};
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
-#[cfg(feature = "helix")]
 use reedline::PromptHelixMode;
 use reedline::{
     DefaultPrompt, Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus,
@@ -140,11 +139,9 @@ fn indicator_for(contents: &PromptContents, edit_mode: PromptEditMode) -> String
         }
         // Helix reuses the vi indicators; normal and select share one, as they
         // share a keybinding table.
-        #[cfg(feature = "helix")]
         PromptEditMode::Helix(PromptHelixMode::Normal | PromptHelixMode::Select) => {
             contents.vi_normal.as_deref().unwrap_or("> ").to_string()
         }
-        #[cfg(feature = "helix")]
         PromptEditMode::Helix(PromptHelixMode::Insert) => {
             contents.vi_insert.as_deref().unwrap_or(": ").to_string()
         }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -15,7 +15,6 @@ use reedline::{
     TraversalDirection, WordEdge, WordKind, default_emacs_keybindings,
     default_vi_insert_keybindings, default_vi_normal_keybindings,
 };
-#[cfg(feature = "helix")]
 use reedline::{
     default_helix_insert_keybindings, default_helix_normal_keybindings,
     default_helix_select_keybindings,
@@ -602,7 +601,6 @@ pub enum KeybindingsMode {
         insert_keybindings: Keybindings,
         normal_keybindings: Keybindings,
     },
-    #[cfg(feature = "helix")]
     Helix {
         insert_keybindings: Keybindings,
         normal_keybindings: Keybindings,
@@ -616,11 +614,8 @@ struct KeybindingTables {
     emacs: Keybindings,
     vi_insert: Keybindings,
     vi_normal: Keybindings,
-    #[cfg(feature = "helix")]
     helix_insert: Keybindings,
-    #[cfg(feature = "helix")]
     helix_normal: Keybindings,
-    #[cfg(feature = "helix")]
     helix_select: Keybindings,
 }
 
@@ -633,11 +628,8 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
         emacs: default_emacs_keybindings(),
         vi_insert: default_vi_insert_keybindings(),
         vi_normal: default_vi_normal_keybindings(),
-        #[cfg(feature = "helix")]
         helix_insert: default_helix_insert_keybindings(),
-        #[cfg(feature = "helix")]
         helix_normal: default_helix_normal_keybindings(),
-        #[cfg(feature = "helix")]
         helix_select: default_helix_select_keybindings(),
     };
 
@@ -651,28 +643,16 @@ pub(crate) fn create_keybindings(config: &Config) -> Result<KeybindingsMode, She
             insert_keybindings: tables.vi_insert,
             normal_keybindings: tables.vi_normal,
         }),
-        #[cfg(feature = "helix")]
         EditBindings::Helix => Ok(KeybindingsMode::Helix {
             insert_keybindings: tables.helix_insert,
             normal_keybindings: tables.helix_normal,
             select_keybindings: tables.helix_select,
         }),
-        #[cfg(not(feature = "helix"))]
-        EditBindings::Helix => Err(ShellError::Generic(
-            nu_protocol::shell_error::generic::GenericError::new_internal(
-                "helix mode is not available in this build of nushell",
-                "`$env.config.edit_mode = \"helix\"` requires a build with the `helix` feature",
-            )
-            .with_help("rebuild nushell with `--features helix`"),
-        )),
     }
 }
 
-#[cfg(feature = "helix")]
 const VALID_KEYBINDING_MODES: &str =
     "'emacs', 'vi_insert', 'vi_normal', 'helix_insert', 'helix_normal', or 'helix_select'";
-#[cfg(not(feature = "helix"))]
-const VALID_KEYBINDING_MODES: &str = "'emacs', 'vi_insert', or 'vi_normal'";
 
 fn add_keybinding(
     mode: &Value,
@@ -688,28 +668,14 @@ fn add_keybinding(
             Ok(PEMD::Emacs) => add_parsed_keybinding(&mut tables.emacs, keybinding, config),
             Ok(PEMD::ViInsert) => add_parsed_keybinding(&mut tables.vi_insert, keybinding, config),
             Ok(PEMD::ViNormal) => add_parsed_keybinding(&mut tables.vi_normal, keybinding, config),
-            #[cfg(feature = "helix")]
             Ok(PEMD::HelixInsert) => {
                 add_parsed_keybinding(&mut tables.helix_insert, keybinding, config)
             }
-            #[cfg(feature = "helix")]
             Ok(PEMD::HelixNormal) => {
                 add_parsed_keybinding(&mut tables.helix_normal, keybinding, config)
             }
-            #[cfg(feature = "helix")]
             Ok(PEMD::HelixSelect) => {
                 add_parsed_keybinding(&mut tables.helix_select, keybinding, config)
-            }
-            // The default keybindings name the helix tables unconditionally, so
-            // a build without the `helix` feature skips them rather than
-            // rejecting a mode it has no table to bind into.
-            #[cfg(not(feature = "helix"))]
-            _ if matches!(
-                val.as_str(),
-                "helix_normal" | "helix_insert" | "helix_select"
-            ) =>
-            {
-                Ok(())
             }
             Ok(PEMD::Default | PEMD::Custom) | Err(_) => Err(ShellError::InvalidValue {
                 valid: VALID_KEYBINDING_MODES.into(),
@@ -738,11 +704,8 @@ pub(crate) fn display_edit_mode(mode: PromptEditModeDiscriminants) -> Option<Str
         PromptEditModeDiscriminants::Emacs => Some("emacs".into()),
         PromptEditModeDiscriminants::ViNormal => Some("vi_normal".into()),
         PromptEditModeDiscriminants::ViInsert => Some("vi_insert".into()),
-        #[cfg(feature = "helix")]
         PromptEditModeDiscriminants::HelixNormal => Some("helix_normal".into()),
-        #[cfg(feature = "helix")]
         PromptEditModeDiscriminants::HelixInsert => Some("helix_insert".into()),
-        #[cfg(feature = "helix")]
         PromptEditModeDiscriminants::HelixSelect => Some("helix_select".into()),
         PromptEditModeDiscriminants::Default | PromptEditModeDiscriminants::Custom => None,
     }
@@ -1006,7 +969,6 @@ fn event_from_record(
             let mode = extract_value("mode", record, span)?;
             ReedlineEvent::ViChangeMode(mode.as_str()?.to_owned())
         }
-        #[cfg(feature = "helix")]
         Ok(RED::HelixChangeMode) => {
             let mode = extract_value("mode", record, span)?;
             ReedlineEvent::HelixChangeMode(mode.as_str()?.to_owned())
@@ -1073,7 +1035,6 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::ExecuteHostCommand => "ExecuteHostCommand cmd: <string>",
         RED::OpenEditor => "OpenEditor",
         RED::ViChangeMode => "ViChangeMode mode: <string>",
-        #[cfg(feature = "helix")]
         RED::HelixChangeMode => "HelixChangeMode mode: <string>",
         // Non-sensical for user configuration
         RED::Mouse | RED::Resize => return None,
@@ -1290,9 +1251,7 @@ fn edit_from_record(
             EditCommand::MoveLeftBefore { c: char, select }
         }
         Ok(ECD::SelectAll) => EditCommand::SelectAll,
-        #[cfg(feature = "helix")]
         Ok(ECD::SelectLine) => EditCommand::SelectLine,
-        #[cfg(feature = "helix")]
         Ok(ECD::EraseSelection) => EditCommand::EraseSelection,
         Ok(ECD::CutSelection) => EditCommand::CutSelection {
             granularity: parse_granularity(record, config, span)?,
@@ -1492,9 +1451,7 @@ pub(crate) fn display_edit_command(edit: EditCommandDiscriminants) -> Option<&'s
         ECD::CutLeftUntil => "CutLeftUntil value: <char>",
         ECD::CutLeftBefore => "CutLeftBefore value: <char>",
         ECD::SelectAll => "SelectAll",
-        #[cfg(feature = "helix")]
         ECD::SelectLine => "SelectLine",
-        #[cfg(feature = "helix")]
         ECD::EraseSelection => "EraseSelection",
         ECD::CutSelection => "CutSelection granularity?: <string>",
         ECD::CopySelection => "CopySelection",
@@ -2101,8 +2058,6 @@ mod test {
     #[test]
     fn default_config_keybindings_apply() {
         // Nushell menu keybindings on Config::default must parse as valid reedline events.
-        // Without the `helix` feature this also covers the helix modes the defaults
-        // name but this build has no table for.
         let config = Config::default();
         assert!(!config.keybindings.is_empty());
         assert!(!config.menus.is_empty());
@@ -2110,7 +2065,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "helix")]
     fn default_config_binds_menu_keys_in_helix_mode() {
         // The Nushell menu keybindings are mode-scoped; helix missing from that
         // list left Tab and the other menu keys unbound in both helix tables.
@@ -2147,7 +2101,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "helix")]
     fn helix_select_keybindings_land_in_their_own_table() {
         use nu_protocol::ParsedKeybinding;
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -35,7 +35,6 @@ use nu_utils::{
     filesystem::{PermissionResult, have_permission},
     perf, stderr_write_all_and_flush, stdout_write_all_and_flush,
 };
-#[cfg(feature = "helix")]
 use reedline::Helix;
 #[cfg(feature = "sqlite")]
 use reedline::SqliteBackedHistory;
@@ -607,11 +606,8 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
         vi_insert: map_nucursorshape_to_cursorshape(config.cursor_shape.vi_insert),
         vi_normal: map_nucursorshape_to_cursorshape(config.cursor_shape.vi_normal),
         emacs: map_nucursorshape_to_cursorshape(config.cursor_shape.emacs),
-        #[cfg(feature = "helix")]
         hx_insert: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_insert),
-        #[cfg(feature = "helix")]
         hx_normal: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_normal),
-        #[cfg(feature = "helix")]
         hx_select: map_nucursorshape_to_cursorshape(config.cursor_shape.helix_select),
     };
     perf!("get config/cursor config", start_time, use_color);
@@ -1351,7 +1347,6 @@ fn setup_keybindings(engine_state: &EngineState, line_editor: Reedline) -> Reedl
                 let edit_mode = Box::new(Vi::new(insert_keybindings, normal_keybindings));
                 line_editor.with_edit_mode(edit_mode)
             }
-            #[cfg(feature = "helix")]
             KeybindingsMode::Helix {
                 insert_keybindings,
                 normal_keybindings,

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -259,7 +259,6 @@ rustls-tls = [
 plugin = ["nu-parser/plugin", "nu-test-support/plugin", "os"]
 sqlite = ["rusqlite"]
 # Weak on `reedline` so the flag is inert without `os` (which pulls reedline in).
-helix = ["reedline?/helix"]
 trash-support = ["trash"]
 
 [dev-dependencies]

--- a/crates/nu-command/src/platform/input/reedline_prompt.rs
+++ b/crates/nu-command/src/platform/input/reedline_prompt.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "helix")]
 use reedline::PromptHelixMode;
 use reedline::{
     Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, PromptViMode,
@@ -39,7 +38,6 @@ impl Prompt for ReedlinePrompt {
                 PromptViMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
                 PromptViMode::Visual => DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into(),
             },
-            #[cfg(feature = "helix")]
             PromptEditMode::Helix(helix_mode) => match helix_mode {
                 PromptHelixMode::Normal | PromptHelixMode::Select => {
                     DEFAULT_VI_NORMAL_PROMPT_INDICATOR.into()
@@ -47,12 +45,6 @@ impl Prompt for ReedlinePrompt {
                 PromptHelixMode::Insert => DEFAULT_VI_INSERT_PROMPT_INDICATOR.into(),
             },
             PromptEditMode::Custom(str) => format!("({str})").into(),
-            // Reedline's `helix` feature can be switched on by another crate in
-            // the build graph without this crate's `helix` feature following
-            // along; catch the then-uncovered variants instead of failing to
-            // compile.
-            #[allow(unreachable_patterns)]
-            _ => self.indicator.as_str().into(),
         }
     }
 

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -160,7 +160,7 @@ $env.config.clip.default_raw = false
 # "emacs": Use Emacs-style keybindings (default).
 # "vi": Use Vi-style keybindings with normal and insert modes.
 # "helix": Use Helix-style selection-first keybindings with normal, select, and
-#          insert modes. Requires the `helix` feature (enabled by default).
+#          insert modes.
 # Default: "emacs"
 $env.config.edit_mode = "emacs"
 
@@ -191,8 +191,6 @@ $env.config.cursor_shape.vi_insert = "inherit"
 $env.config.cursor_shape.vi_normal = "inherit"
 
 # cursor_shape.helix_normal (string): Cursor shape when in helix normal mode.
-# Requires the `helix` feature (enabled by default); likewise for
-# helix_select and helix_insert below.
 # One of: "block", "underscore", "line", "blink_block", "blink_underscore", "blink_line", or "inherit".
 # Default: "inherit"
 $env.config.cursor_shape.helix_normal = "inherit"
@@ -667,7 +665,7 @@ $env.config.hooks.command_not_found = null
 #   }
 # ]
 # `ViChangeMode` takes "normal", "insert" or "visual"; `HelixChangeMode` takes
-# "normal", "insert" or "select", and requires the `helix` feature. An unknown
+# "normal", "insert" or "select". An unknown
 # mode name leaves the mode alone rather than erroring.
 
 # -------------

--- a/crates/nu-protocol/src/config/defaults.rs
+++ b/crates/nu-protocol/src/config/defaults.rs
@@ -220,10 +220,6 @@ pub fn default_menus() -> Vec<ParsedMenu> {
 }
 
 /// Every edit mode the Nushell-owned keybindings below apply to.
-///
-/// The helix tables are named unconditionally, like `cursor_shape.helix_*`: a
-/// build without the `helix` feature has no table to bind them into and skips
-/// them when the keybindings are applied.
 fn all_modes() -> Value {
     Value::list(
         vec![

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -117,7 +117,6 @@ pub struct CursorShapeConfig {
     pub emacs: NuCursorShape,
     pub vi_insert: NuCursorShape,
     pub vi_normal: NuCursorShape,
-    /// Only takes effect in builds with the `helix` feature.
     pub helix_normal: NuCursorShape,
     pub helix_select: NuCursorShape,
     pub helix_insert: NuCursorShape,
@@ -155,8 +154,6 @@ pub enum EditBindings {
     Vi,
     #[default]
     Emacs,
-    /// Only usable in builds with the `helix` feature; selecting it elsewhere
-    /// reports an error when the keybindings are constructed.
     Helix,
 }
 


### PR DESCRIPTION
## Description

Bumps reedline to fc19b91,picking up two breaking reedline changes:
nushell/reedline#1161 (drop the `helix` feature flag)
and nushell/reedline#1162 (replace crossbeam with `std::sync::mpsc`).

The crossbeam swap costs nothing here,
since nushell never enables reedline's `external_printer` feature.

## User-facing changes (Release notes)

## Additional notes