### PR TITLE
Document behavior of `each` for more types of inputs.

### DIFF
--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -37,15 +37,13 @@ This "flattens" the output, turning an output that would otherwise be a
 list of lists like `list<list<string>>` into a flat list like `list<string>`.
 
 
-String or byte streams, empty pipelines, null values,
-ranges, and some custom values can also be used as inputs to 'each'.
-A stream of bytes or strings (usually from external commands)
-will be treated as though it was a list of chunks of the stream,
-where the size of the chunks are determined arbitrarily.
-Empty pipelines and null values are both returned unchanged from
-'each' without calling the provided closure.
-Ranges and custom values which can be iterated will be
-treated as lists of the values they represent."#
+String or byte streams, empty pipelines, null values, ranges, and some custom values
+can also be used as inputs to 'each'. A stream of bytes or strings
+(usually from external commands) will be treated as though it was a list of chunks
+of the stream, where the size of the chunks are determined arbitrarily.
+Empty pipelines and null values are both returned unchanged from 'each' without
+calling the provided closure. Ranges and custom values which can be iterated
+will be treated as lists of the values they represent."#
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -34,7 +34,18 @@ Instead of waiting for the stream to be collected before returning the result as
 a single item, `each --flatten` will return each item as soon as they are received.
 
 This "flattens" the output, turning an output that would otherwise be a
-list of lists like `list<list<string>>` into a flat list like `list<string>`."#
+list of lists like `list<list<string>>` into a flat list like `list<string>`.
+
+
+String or byte streams, empty pipelines, null values,
+ranges, and some custom values can also be used as inputs to 'each'.
+A stream of bytes or strings (usually from external commands)
+will be treated as though it was a list of chunks of the stream,
+where the size of the chunks are determined arbitrarily.
+Empty pipelines and null values are both returned unchanged from
+'each' without calling the provided closure.
+Ranges and custom values which can be iterated will be
+treated as lists of the values they represent."#
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -110,7 +121,8 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
             },
             Example {
                 example: r#"$env.name? | each { $"hello ($in)" } | default "bye""#,
-                description: "Update value if not null, otherwise do nothing.",
+                description: "Return \"hello $name\" for each name in the list of names $env.name, \
+                or return \"bye\" if $env.name does not exist.",
                 result: None,
             },
             Example {
@@ -121,6 +133,15 @@ list of lists like `list<list<string>>` into a flat list like `list<string>`."#
                     | find -i 'note: ' \
                     | str join \"\\n\"\
                     ",
+                result: None,
+            },
+            Example {
+                description: "Print chunks of data from an external command as soon as \
+                they become available.",
+                example: "\
+                ^$nu.current-exe -c 'print hello; sleep 0.5sec; print world' \
+                | each { print $in } | ignore\
+                ",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -15,35 +15,32 @@ impl Command for Each {
     }
 
     fn extra_description(&self) -> &str {
-        r#"Since tables are lists of records, passing a table into 'each' will
-iterate over each record, not necessarily each cell within it.
+        r#"Since tables are lists of records, passing a table into 'each' will iterate over each 
+record, not necessarily each cell within it.
 
-Avoid passing single records to this command. Since a record is a
-one-row structure, 'each' will only run once, behaving similar to 'do'.
-To iterate over a record's values, use 'items' or try converting it to a table
-with 'transpose' first.
+Avoid passing single records to this command. Since a record is a one-row structure, 
+'each' will only run once, behaving similar to 'do'. To iterate over a record's values, 
+use 'items' or try converting it to a table with 'transpose' first.
 
-
-By default, for each input there is a single output value.
-If the closure returns a stream rather than value, the stream is collected
-completely, and the resulting value becomes one of the items in `each`'s output.
+By default, for each input there is a single output value. If the closure returns a 
+stream rather than value, the stream is collected completely, and the resulting value 
+becomes one of the items in `each`'s output.
 
 To receive items from those streams without waiting for the whole stream to be
-collected, `each --flatten` can be used.
-Instead of waiting for the stream to be collected before returning the result as
-a single item, `each --flatten` will return each item as soon as they are received.
+collected, `each --flatten` can be used. Instead of waiting for the stream to be 
+collected before returning the result as a single item, `each --flatten` will return 
+each item as soon as they are received.
 
-This "flattens" the output, turning an output that would otherwise be a
-list of lists like `list<list<string>>` into a flat list like `list<string>`.
-
+This "flattens" the output, turning an output that would otherwise be a list of lists 
+like `list<list<string>>` into a flat list like `list<string>`.
 
 String or byte streams, empty pipelines, null values, ranges, and some custom values
-can also be used as inputs to 'each'. A stream of bytes or strings
-(usually from external commands) will be treated as though it was a list of chunks
-of the stream, where the size of the chunks are determined arbitrarily.
-Empty pipelines and null values are both returned unchanged from 'each' without
-calling the provided closure. Ranges and custom values which can be iterated
-will be treated as lists of the values they represent."#
+can also be used as inputs to 'each'. A stream of bytes or strings (usually from 
+external commands) will be treated as though it was a list of chunks of the stream, 
+where the size of the chunks are determined arbitrarily. Empty pipelines and null 
+values are both returned unchanged from 'each' without calling the provided closure. 
+Ranges and custom values which can be iterated will be treated as lists of the values 
+they represent."#
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
## Description

The `each` command supports more types of input than just lists, so I've documented most of these input types. Streams of strings or bytes, empty pipelines, null values, ranges, and iterable custom values now have their behaviors' documented.

Additionally, there was an example which showed off the behavior of null values as inputs to `each`, but it's description was not very understandable, so I updated it. I've also added an example demonstrating how `each` can be used to process chunks of data from external commands as soon as they are available.

I have not documented the behavior of `each` on scalar non-null values because comments in the code say this behavior is undesirable.

## User-facing changes (Release notes)

  - The `each` command's documentation now includes more information on supported input types.

## Additional notes

During this pr, I've noticed that if the input to `each {||}` is a `string (stream)`, then the output of `each` is a `list<string>`, but if the input to `each {||}` is a `string`, then the output of each is a `string`. This seems weird, as I feel `collect | each {||}` should always return the same type as `each {||}`. However, I haven't documented the behavior of `each` on `string` in this commit, so that can be a discussion for a later date.