### PR TITLE
fix(yaml): do not parse embedded float tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "granit-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
+checksum = "4ccd1be9ebf2bd5520dbfcfb72b70ef492f654061299a097056f3e73410e38ec"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -8229,12 +8229,12 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb49c0aa8a5bb88c00b833c11bae50d1611fb89e01336f53b05f7c643b1c883"
+checksum = "a1ec1f5cac0eb96063c64b28705255a7ed6e7d77f95c1d25e9f8b8c928006ce1"
 dependencies = [
  "annotate-snippets",
- "base64 0.23.0",
+ "base64 0.22.1",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -34,6 +34,17 @@ fn table_to_yml_text_and_from_yml_text_back_into_table() -> Result {
 }
 
 #[test]
+fn embedded_yaml_float_tokens_remain_strings() -> Result {
+    test()
+        .run(r#""key: a.infra" | from yaml | get key"#)
+        .expect_value_eq("a.infra")?;
+
+    test()
+        .run(r#""key: a.nanotube" | from yaml | get key"#)
+        .expect_value_eq("a.nanotube")
+}
+
+#[test]
 fn convert_dict_to_yaml_with_boolean_key() -> Result {
     let code = r#""true: BooleanKey " | from yaml --key-resolution verbatim"#;
 

--- a/crates/nu-heavy-utils/src/yaml/parse.rs
+++ b/crates/nu-heavy-utils/src/yaml/parse.rs
@@ -915,11 +915,11 @@ mod v1_x {
     use super::*;
 
     pub static INFINITY: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"[-+]?\.(inf|Inf|INF)").expect("valid infinity regex for spec v1.x")
+        Regex::new(r"^[-+]?\.(inf|Inf|INF)$").expect("valid infinity regex for spec v1.x")
     });
 
     pub static NAN: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\.(nan|NaN|NAN)").expect("valid NaN regex for spec v1.x"));
+        LazyLock::new(|| Regex::new(r"^\.(nan|NaN|NAN)$").expect("valid NaN regex for spec v1.x"));
 
     pub fn maybe_parse_null<'i>(_: &mut ParseCtx<'i>, input: &str) -> Option<()> {
         match input {


### PR DESCRIPTION
## Description
Fixes #18889.

This PR updates YAML scalar resolution so `.inf` and `.nan` are only parsed as special floating-point values when the complete plain scalar matches the token. Previously, the shared YAML 1.1/1.2 regular expressions were unanchored, so strings containing those tokens, such as `a.infra` and `a.nanotube`, could be decoded as floats.

It also adds a public `from yaml` regression test for embedded `.inf` and `.nan` text. Exact YAML special values such as `.inf` and `.nan` keep their existing numeric behavior.

## User-facing changes (Release notes)
Fixed an issue where YAML values containing `.inf` or `.nan` as embedded text could be incorrectly converted to floating-point values. Values such as `a.infra` and `a.nanotube` now remain strings when decoded with `from yaml`.

## Additional notes
Verification from the PR:
- `cargo fmt --all -- --check`
- `CARGO_NET_OFFLINE=true cargo test -p nu-command --test tests format_conversions::yaml::embedded_yaml_float_tokens_remain_strings -- --exact`
- `CARGO_NET_OFFLINE=true cargo test -p nu-heavy-utils --lib yaml::parse::tests`
- `git diff --check`