### PR TITLE
fix(parser): preserve precision for whole-number filesize and duration literals

### DIFF
--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -1395,6 +1395,16 @@ pub fn parse_unit_value<'res>(
             return None;
         }
 
+        // Whole-number literals are parsed as an integer as well, so that large exact
+        // values can be preserved. The `f64` used below for fractional literals would
+        // silently round them, e.g. `6504534684301572998b` became
+        // `6504534684301573120b` (issue #10612).
+        let lhs_int = if lhs.contains(['.', 'e', 'E']) {
+            None
+        } else {
+            lhs.parse::<i64>().ok()
+        };
+
         let (decimal_part, number_part) = modf(match lhs.parse::<f64>() {
             Ok(it) => it,
             Err(_) => {
@@ -1431,20 +1441,46 @@ pub fn parse_unit_value<'res>(
 
         let num = match factor {
             Some(factor) => {
-                let num_base = num_float * factor;
-                if i64::MIN as f64 <= num_base && num_base <= i64::MAX as f64 {
+                // Integer fast-path: keep full precision when the literal is a whole
+                // number and the conversion to the base unit (bytes/nanoseconds) is
+                // exact. All the factors in the tables above are whole numbers, so
+                // `factor as i64` is lossless when `factor.fract() == 0.0`. On overflow
+                // we fall back to the (lossy) `f64` computation below.
+                let convert_factor = match convert {
+                    Some(convert_to) => convert_to.1,
+                    None => 1,
+                };
+                let exact = if factor.fract() == 0.0 {
+                    lhs_int
+                        .and_then(|n| n.checked_mul(convert_factor))
+                        .and_then(|n| n.checked_mul(factor as i64))
+                } else {
+                    None
+                };
+
+                if let Some(num_base) = exact {
                     unit = if ty == Type::Filesize {
                         Unit::Filesize(FilesizeUnit::B)
                     } else {
                         Unit::Nanosecond
                     };
-                    num_base as i64
+                    num_base
                 } else {
-                    // not safe to convert, because of the overflow
-                    num_float as i64
+                    let num_base = num_float * factor;
+                    if i64::MIN as f64 <= num_base && num_base <= i64::MAX as f64 {
+                        unit = if ty == Type::Filesize {
+                            Unit::Filesize(FilesizeUnit::B)
+                        } else {
+                            Unit::Nanosecond
+                        };
+                        num_base as i64
+                    } else {
+                        // not safe to convert, because of the overflow
+                        num_float as i64
+                    }
                 }
             }
-            None => num_float as i64,
+            None => lhs_int.unwrap_or(num_float as i64),
         };
 
         trace!("-- found {num} {unit:?}");

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -321,6 +321,30 @@ pub fn parse_filesize_integer_is_exact() {
 }
 
 #[test]
+pub fn parse_duration_integer_is_exact() {
+    // Duration literals use the same unit parser as filesize literals and must
+    // preserve whole nanosecond values without an `f64` round-trip.
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"6504534684301572998ns", true);
+
+    assert!(working_set.parse_errors.is_empty());
+    assert_eq!(block.len(), 1);
+    let pipeline = &block.pipelines[0];
+    assert_eq!(pipeline.len(), 1);
+    let element = &pipeline.elements[0];
+    assert!(element.redirection.is_none());
+
+    let Expr::ValueWithUnit(value) = &element.expr.expr else {
+        panic!("should be a ValueWithUnit");
+    };
+
+    assert_eq!(value.expr.expr, Expr::Int(6504534684301572998));
+    assert_eq!(value.unit.item, Unit::Nanosecond);
+}
+
+#[test]
 pub fn parse_non_utf8_fails() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -295,6 +295,32 @@ pub fn parse_filesize() {
 }
 
 #[test]
+pub fn parse_filesize_integer_is_exact() {
+    // A whole number of bytes must round-trip exactly (see issue #10612).
+    // `Filesize` is backed by an `i64`, but the literal used to be parsed through an
+    // `f64`, which silently rounded large values (e.g. this one became
+    // `6504534684301573120`).
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let block = parse(&mut working_set, None, b"6504534684301572998b", true);
+
+    assert!(working_set.parse_errors.is_empty());
+    assert_eq!(block.len(), 1);
+    let pipeline = &block.pipelines[0];
+    assert_eq!(pipeline.len(), 1);
+    let element = &pipeline.elements[0];
+    assert!(element.redirection.is_none());
+
+    let Expr::ValueWithUnit(value) = &element.expr.expr else {
+        panic!("should be a ValueWithUnit");
+    };
+
+    assert_eq!(value.expr.expr, Expr::Int(6504534684301572998));
+    assert_eq!(value.unit.item, Unit::Filesize(FilesizeUnit::B));
+}
+
+#[test]
 pub fn parse_non_utf8_fails() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);


### PR DESCRIPTION
## Description

Filesize and duration literals lose precision because `parse_unit_value` parses the numeric part through an `f64`. `Filesize` is backed by an `i64`, so large exact integers get silently rounded — e.g. `6504534684301572998b` parses as `6504534684301573120b`, off by 122 bytes (#10612).

This parses the numeric part as an `i64` when it's a whole number and computes the base-unit value (bytes / nanoseconds) with checked integer arithmetic. Fractional literals, and anything that would overflow `i64`, fall back to the existing `f64` path, so everything that already worked is unchanged. The unit factors are all whole numbers, so the integer conversion is lossless.

## User-facing changes (Release notes)

- Fixed large whole-number filesize and duration literals (e.g. `6504534684301572998b`) losing precision when parsed.

## Additional notes

Fixes #10612
