### PR TITLE
fix(hash): hash byte streams without collecting them into memory

### DIFF
--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -1,6 +1,10 @@
 use nu_cmd_base::input_handler::{CmdArgument, operate};
 use nu_engine::command_prelude::*;
-use std::{fmt::Write, marker::PhantomData};
+use std::{
+    fmt::Write as _,
+    io::{self, Write},
+    marker::PhantomData,
+};
 
 pub trait HashDigest: digest::Digest + Clone {
     fn name() -> &'static str;
@@ -32,6 +36,24 @@ pub(super) struct Arguments {
 impl CmdArgument for Arguments {
     fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
         self.cell_paths.take()
+    }
+}
+
+/// Feeds a byte stream into a digest one chunk at a time.
+///
+/// `digest` 0.11 dropped the `io::Write` impl on hash types, so hashing a
+/// [`ByteStream`](nu_protocol::ByteStream) needs this bridge onto `update` to
+/// stay within a fixed amount of memory.
+struct DigestWriter<'a, D: HashDigest>(&'a mut D);
+
+impl<D: HashDigest> Write for DigestWriter<'_, D> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -102,8 +124,9 @@ where
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
 
         if let PipelineData::ByteStream(stream, ..) = input {
-            let bytes = stream.into_bytes()?;
-            let digest = D::digest(&bytes);
+            let mut hasher = D::new();
+            stream.write_to(DigestWriter(&mut hasher))?;
+            let digest = hasher.finalize();
             if binary {
                 Ok(
                     Value::binary(<[u8]>::to_vec(AsRef::<[u8]>::as_ref(&digest)), head)
@@ -150,5 +173,24 @@ where
         Value::binary(<[u8]>::to_vec(AsRef::<[u8]>::as_ref(&digest)), span)
     } else {
         Value::string(hex_encode(AsRef::<[u8]>::as_ref(&digest)), span)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use digest::Digest;
+    use sha2::Sha256;
+
+    /// A stream must hash the same as the bytes it carries, whatever the
+    /// chunking — the digest is fed incrementally, never collected.
+    #[test]
+    fn chunked_writes_match_one_shot() {
+        let data: Vec<u8> = (0..=u8::MAX).cycle().take(300 * 1024).collect();
+
+        let mut hasher = Sha256::new();
+        io::copy(&mut data.as_slice(), &mut DigestWriter(&mut hasher)).unwrap();
+
+        assert_eq!(hasher.finalize(), Sha256::digest(&data));
     }
 }


### PR DESCRIPTION
## Description

`hash md5` and `hash sha256` stopped streaming their input in 0.115.0: the
`digest` 0.11 bump (#18678) dropped the `io::Write` impl the ByteStream branch
relied on, and `stream.write_to(&mut hasher)` was replaced with
`stream.into_bytes()`. `open --raw big-file | hash sha256` now holds the whole
file in memory again — the behavior of #8260, which was fixed in 0.79.0 and had
survived the ByteStream rewrite (#12774).

This adds a small `DigestWriter` adapter forwarding `io::Write` onto
`Digest::update`, restoring the `write_to` handoff. Nothing else changes: the
string, binary, list and cell-path paths are untouched.

Measured on macOS 15 / aarch64, release builds, `open --raw <file> | hash sha256`:

| input | peak RSS before | after | wall before | after |
|---|---|---|---|---|
| 512 MiB | 619 MB | 17 MB | 0.51 s | 0.27 s |
| 3 GiB | 3124 MB | 16 MB | 4.21 s | 1.60 s |

Collecting cost wall-clock as well as memory, so the fix is ~2.5x faster on
large inputs. Feeding the digest in chunks costs nothing on small inputs: over a
tree of 3000 small files, `each { open --raw $f | hash sha256 }` measures 133 ms
before and 134 ms after (medians of 5).

Affected released versions are 0.115.0 and 0.115.1; 0.114.1 and earlier stream
correctly. Digests are unchanged throughout and match `shasum -a 256` / `md5`.

## User-facing changes (Release notes)

`hash md5` and `hash sha256` hash byte streams incrementally again, so
`open --raw <file> | hash sha256` runs in constant memory instead of holding the
whole file. Hashing a 3 GiB file drops from ~3.1 GB peak memory to ~16 MB, and
is ~2.5x faster. This restores the behavior of 0.114.1 and earlier, which
regressed in 0.115.0.

## Tests + Formatting

- `cargo test -p nu-command --lib hash` — 17 passed, including a new
  `chunked_writes_match_one_shot` unit test covering the adapter
- `cargo fmt --all -- --check`
- `cargo clippy -p nu-command --lib -- -D warnings`
- Manually checked against 512 MiB and 3 GiB files, `^cat file | hash md5`
  (external stream), `--binary`, and string / list / cell-path inputs
