### PR TITLE
Inject `Playground` into tests

### DIFF
--- a/crates/nu-test-support-macros/src/test.rs
+++ b/crates/nu-test-support-macros/src/test.rs
@@ -1,8 +1,8 @@
 use quote::quote;
 use std::mem;
 use syn::{
-    Attribute, Expr, Ident, ItemFn, Lit, LitBool, LitStr, Meta, MetaNameValue, Path, Token,
-    parse::ParseStream, spanned::Spanned,
+    Attribute, Expr, FnArg, Ident, ItemFn, Lit, LitBool, LitStr, Meta, MetaNameValue, Pat, Path,
+    Token, parse::ParseStream, spanned::Spanned,
 };
 
 pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
@@ -13,7 +13,34 @@ pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
     let attr_rest = attrs.rest;
     let dependencies = attrs.dependencies;
 
+    let args = match TestArgs::try_from_iter(mem::take(&mut item_fn.sig.inputs).into_iter()) {
+        Ok(args) => args,
+        Err(err) => return err.to_compile_error(),
+    };
+
+    let arg_array = [args.playground.as_ref()];
+
+    // reorder arguments of test function to inject arguments in correct order
+    item_fn.sig.inputs = arg_array
+        .into_iter()
+        .flatten()
+        .map(|(arg, _)| arg)
+        .cloned()
+        .collect();
+
+    let playground = args.playground.as_ref().map(|(_, ident)| quote! {
+        let #ident = match ::nu_test_support::playground::Playground::new(
+            MODULE_PATH_WITHOUT_CRATE,
+            ::std::env!("CARGO_PKG_NAME"),
+            ::std::env!("CARGO_CRATE_NAME"),
+        ) {
+            ::std::result::Result::Err(err) => return ::nu_test_support::harness::IntoTestResult::into_test_result(Err(err)),
+            ::std::result::Result::Ok(ok) => ok,
+        };
+    }).into_iter();
+
     let fn_ident = &item_fn.sig.ident;
+    let fn_args = arg_array.into_iter().flatten().map(|(_, ident)| ident);
 
     let run_in_serial = match attrs.run_in_serial {
         Some(true) => true,
@@ -63,7 +90,8 @@ pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
             const MODULE_PATH_WITHOUT_CRATE: &str = ::nu_test_support::module_path_without_crate!();
 
             fn wrapper() -> TestResult {
-                ::nu_test_support::harness::IntoTestResult::into_test_result(#fn_ident())
+                #(#playground)*
+                ::nu_test_support::harness::IntoTestResult::into_test_result(#fn_ident(#(#fn_args),*))
             }
 
             #[::nu_test_support::collect_test(::nu_test_support::harness::TESTS)]
@@ -262,5 +290,47 @@ impl TryFrom<Vec<Attribute>> for TestAttributes {
         }
 
         Ok(test_attrs)
+    }
+}
+
+#[derive(Default)]
+pub struct TestArgs {
+    pub playground: Option<(FnArg, Ident)>,
+}
+
+impl TestArgs {
+    pub fn try_from_iter(iter: impl Iterator<Item = FnArg>) -> syn::Result<Self> {
+        let mut args = TestArgs::default();
+
+        for arg in iter {
+            let pat_type = match &arg {
+                FnArg::Receiver(_) => {
+                    return Err(syn::Error::new_spanned(arg, "unexpected self parameter"));
+                }
+                FnArg::Typed(pat_type) => pat_type,
+            };
+
+            let Pat::Ident(pat_ident) = &*pat_type.pat else {
+                return Err(syn::Error::new(
+                    pat_type.pat.span(),
+                    "expected single ident",
+                ));
+            };
+
+            let ident = pat_ident.ident.clone();
+            match ident.to_string().as_str() {
+                "playground" | "play" | "pg" | "_playground" => {
+                    args.playground = Some((arg, ident.clone()))
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        "unknown arg name for injection, expected `playground`",
+                    ));
+                }
+            }
+        }
+
+        Ok(args)
     }
 }

--- a/crates/nu-test-support-macros/src/test.rs
+++ b/crates/nu-test-support-macros/src/test.rs
@@ -13,34 +13,15 @@ pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
     let attr_rest = attrs.rest;
     let dependencies = attrs.dependencies;
 
-    let args = match TestArgs::try_from_iter(mem::take(&mut item_fn.sig.inputs).into_iter()) {
+    let args = match TestArgs::try_from_iter(item_fn.sig.inputs.iter()) {
         Ok(args) => args,
         Err(err) => return err.to_compile_error(),
     };
 
-    let arg_array = [args.playground.as_ref()];
-
-    // reorder arguments of test function to inject arguments in correct order
-    item_fn.sig.inputs = arg_array
-        .into_iter()
-        .flatten()
-        .map(|(arg, _)| arg)
-        .cloned()
-        .collect();
-
-    let playground = args.playground.as_ref().map(|(_, ident)| quote! {
-        let #ident = match ::nu_test_support::playground::Playground::new(
-            MODULE_PATH_WITHOUT_CRATE,
-            ::std::env!("CARGO_PKG_NAME"),
-            ::std::env!("CARGO_CRATE_NAME"),
-        ) {
-            ::std::result::Result::Err(err) => return ::nu_test_support::harness::IntoTestResult::into_test_result(Err(err)),
-            ::std::result::Result::Ok(ok) => ok,
-        };
-    }).into_iter();
+    let pre_test = args.0.iter().map(|(arg, ident)| arg.inject(ident));
 
     let fn_ident = &item_fn.sig.ident;
-    let fn_args = arg_array.into_iter().flatten().map(|(_, ident)| ident);
+    let fn_args = args.0.iter().map(|(_, ident)| ident);
 
     let run_in_serial = match attrs.run_in_serial {
         Some(true) => true,
@@ -90,7 +71,7 @@ pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
             const MODULE_PATH_WITHOUT_CRATE: &str = ::nu_test_support::module_path_without_crate!();
 
             fn wrapper() -> TestResult {
-                #(#playground)*
+                #(#pre_test)*
                 ::nu_test_support::harness::IntoTestResult::into_test_result(#fn_ident(#(#fn_args),*))
             }
 
@@ -294,16 +275,18 @@ impl TryFrom<Vec<Attribute>> for TestAttributes {
 }
 
 #[derive(Default)]
-pub struct TestArgs {
-    pub playground: Option<(FnArg, Ident)>,
+pub struct TestArgs(Vec<(TestArg, Ident)>);
+
+pub enum TestArg {
+    Playground,
 }
 
 impl TestArgs {
-    pub fn try_from_iter(iter: impl Iterator<Item = FnArg>) -> syn::Result<Self> {
+    pub fn try_from_iter<'a>(iter: impl Iterator<Item = &'a FnArg>) -> syn::Result<Self> {
         let mut args = TestArgs::default();
 
         for arg in iter {
-            let pat_type = match &arg {
+            let pat_type = match arg {
                 FnArg::Receiver(_) => {
                     return Err(syn::Error::new_spanned(arg, "unexpected self parameter"));
                 }
@@ -320,7 +303,7 @@ impl TestArgs {
             let ident = pat_ident.ident.clone();
             match ident.to_string().as_str() {
                 "playground" | "play" | "pg" | "_playground" => {
-                    args.playground = Some((arg, ident.clone()))
+                    args.0.push((TestArg::Playground, ident));
                 }
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -332,5 +315,22 @@ impl TestArgs {
         }
 
         Ok(args)
+    }
+}
+
+impl TestArg {
+    pub fn inject(&self, ident: &Ident) -> proc_macro2::TokenStream {
+        match self {
+            TestArg::Playground => quote! {
+                let #ident = match ::nu_test_support::playground::Playground::new(
+                    MODULE_PATH_WITHOUT_CRATE,
+                    ::std::env!("CARGO_PKG_NAME"),
+                    ::std::env!("CARGO_CRATE_NAME"),
+                ) {
+                    ::std::result::Result::Err(err) => return ::nu_test_support::harness::IntoTestResult::into_test_result(Err(err)),
+                    ::std::result::Result::Ok(ok) => ok,
+                };
+            },
+        }
     }
 }

--- a/crates/nu-test-support-macros/src/test.rs
+++ b/crates/nu-test-support-macros/src/test.rs
@@ -70,6 +70,7 @@ pub fn test(mut item_fn: ItemFn) -> proc_macro2::TokenStream {
 
             const MODULE_PATH_WITHOUT_CRATE: &str = ::nu_test_support::module_path_without_crate!();
 
+            #[allow(clippy::used_underscore_binding, reason = "renaming idents is tedious here")]
             fn wrapper() -> TestResult {
                 #(#pre_test)*
                 ::nu_test_support::harness::IntoTestResult::into_test_result(#fn_ident(#(#fn_args),*))

--- a/crates/nu-test-support-macros/src/test.rs
+++ b/crates/nu-test-support-macros/src/test.rs
@@ -277,6 +277,7 @@ impl TryFrom<Vec<Attribute>> for TestAttributes {
 #[derive(Default)]
 pub struct TestArgs(Vec<(TestArg, Ident)>);
 
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TestArg {
     Playground,
 }
@@ -303,6 +304,20 @@ impl TestArgs {
             let ident = pat_ident.ident.clone();
             match ident.to_string().as_str() {
                 "playground" | "play" | "pg" | "_playground" => {
+                    if let Some((_, first)) =
+                        args.0.iter().find(|(arg, _)| *arg == TestArg::Playground)
+                    {
+                        let mut err = syn::Error::new_spanned(
+                            ident,
+                            "duplicate `playground` injection",
+                        );
+                        err.combine(syn::Error::new_spanned(
+                            first,
+                            "first `playground` injection is here",
+                        ));
+                        return Err(err);
+                    }
+
                     args.0.push((TestArg::Playground, ident));
                 }
                 _ => {

--- a/crates/nu-test-support-macros/src/test.rs
+++ b/crates/nu-test-support-macros/src/test.rs
@@ -307,10 +307,8 @@ impl TestArgs {
                     if let Some((_, first)) =
                         args.0.iter().find(|(arg, _)| *arg == TestArg::Playground)
                     {
-                        let mut err = syn::Error::new_spanned(
-                            ident,
-                            "duplicate `playground` injection",
-                        );
+                        let mut err =
+                            syn::Error::new_spanned(ident, "duplicate `playground` injection");
                         err.combine(syn::Error::new_spanned(
                             first,
                             "first `playground` injection is here",

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -496,21 +496,26 @@
 //!
 //! ```
 //! # #[macro_use] extern crate nu_test_support;
-//! use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
+//! use nu_test_support::prelude::*;
 //!
 //! #[test]
-//! fn rm_in_playground() -> Result {
+//! fn rm_in_playground(playground: Playground) -> Result {
+//! #     let _ = playground;
 //! #     unimplemented!()
 //! # }
 //! #
 //! # fn main() -> Result {
-//!     Playground::setup("rm_in_doctest", |dirs, sandbox| {
-//!         sandbox.with_files(&[EmptyFile("i_will_be_deleted.txt")]);
-//!         test()
-//!             .cwd(dirs.test())
-//!             .run("rm i_will_be_deleted.txt")
-//!             .expect_value_eq(())
-//!     })
+//! #     let playground = Playground::new(
+//! #         "crate::tests::rm_in_doctest",
+//! #         env!("CARGO_PKG_NAME"),
+//! #         env!("CARGO_CRATE_NAME"),
+//! #     )?;
+//!     playground.empty_file("i_will_be_deleted.txt")?;
+//!
+//!     test()
+//!         .cwd(playground.path())
+//!         .run("rm i_will_be_deleted.txt")
+//!         .expect_value_eq(())
 //! }
 //! ```
 //!
@@ -590,6 +595,39 @@
 //!     test()
 //!         .run_with_data("$in | math abs", input)
 //!         .expect_value_eq(1)
+//! }
+//! ```
+//!
+//! A [`Playground`](playground::Playground) can also be used in parameterized `rstest`
+//! cases. Mark the playground argument with `#[ignore]` so `rstest` leaves it for the
+//! Nushell test harness to inject.
+//!
+//! ```
+//! # #[macro_use] extern crate nu_test_support;
+//! use nu_test_support::prelude::*;
+//! use rstest::rstest;
+//!
+//! #[rstest]
+//! #[case::a("a")]
+//! #[case::b("b")]
+//! fn cased_playground(
+//!     #[case] value: &str,
+//!     #[ignore] playground: Playground, // keep this argument out of rstest's fixture handling
+//! ) -> Result {
+//! #     let _ = playground;
+//! #     unimplemented!()
+//! # }
+//! #
+//! # fn main() -> Result {
+//! #     let playground = Playground::new(
+//! #         "crate::tests::cased_playground",
+//! #         env!("CARGO_PKG_NAME"),
+//! #         env!("CARGO_CRATE_NAME"),
+//! #     )?;
+//!     test()
+//!         .cwd(playground.path())
+//!         .run("$env.PWD | str contains 'cased_playground'")
+//!         .expect_value_eq(true)
 //! }
 //! ```
 


### PR DESCRIPTION
## Description

In this PR I modified the `#[test]` macro in a way that allows injecting a `Playground` into a test without manual construction. Just add `fn my_test(playground: Playground) -> Result` and you have your playground available in the test.

This should avoid the weird situation about naming playgrounds different names which some tests did more thoroughly than others. This also works with `rstest` as the `case` name is also part of the playground slug, you just have to tell `rstest` to `#[ignore]` the argument to make it work.

## User-facing changes (Release notes)

n/a

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>