### PR TITLE
`group-by --to-table` keep original types

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -3,6 +3,7 @@ use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
     FromValue, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
 };
+use std::hash::{Hash, Hasher};
 
 #[derive(Clone)]
 pub struct GroupBy;
@@ -42,12 +43,14 @@ impl Command for GroupBy {
     }
 
     fn extra_description(&self) -> &str {
-        r#"the group-by command makes some assumptions:
-    - if the input data is not a string, the grouper will convert the key to string but the values will remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
+        r#"The default record output uses display-string keys because record keys must be strings:
+    - if the input data is not a string, the grouper converts the key to a string but the values remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
     - datetime is formatted based on your configuration setting. use `format date` to change the format.
     - filesize is formatted based on your configuration setting. use `format filesize` to change the format.
     - some nushell values are not supported, such as closures.
-    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null."#
+    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+
+With --to-table, group keys keep their original types and grouping uses typed value identity (same type and payload). Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups. null group keys are included as null values."#
     }
 
     fn run(
@@ -99,6 +102,25 @@ impl Command for GroupBy {
                     ]),
                     "2" => Value::test_list(vec![Value::test_string("2")]),
                 })),
+            },
+            Example {
+                description: "Group by a non-string column and keep the original key type.",
+                example: "[{n: 1} {n: 2} {n: 1}] | group-by n --to-table",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "n" => Value::test_int(1),
+                        "items" => Value::test_list(vec![
+                            Value::test_record(record! { "n" => Value::test_int(1) }),
+                            Value::test_record(record! { "n" => Value::test_int(1) }),
+                        ]),
+                    }),
+                    Value::test_record(record! {
+                        "n" => Value::test_int(2),
+                        "items" => Value::test_list(vec![
+                            Value::test_record(record! { "n" => Value::test_int(2) }),
+                        ]),
+                    }),
+                ])),
             },
             Example {
                 description: "You can also output a table instead of a record.",
@@ -281,14 +303,28 @@ pub fn group_by(
 
     let grouped = match &groupers[..] {
         [first, rest @ ..] => {
-            let mut grouped =
-                Grouped::new(first.as_ref(), prune, values, config, engine_state, stack)?;
+            let mut grouped = Grouped::new(
+                first.as_ref(),
+                prune,
+                values,
+                config,
+                to_table,
+                engine_state,
+                stack,
+            )?;
             for grouper in rest {
-                grouped.subgroup(grouper.as_ref(), prune, config, engine_state, stack)?;
+                grouped.subgroup(
+                    grouper.as_ref(),
+                    prune,
+                    config,
+                    to_table,
+                    engine_state,
+                    stack,
+                )?;
             }
             grouped
         }
-        [] => Grouped::empty(values, config),
+        [] => Grouped::empty(values, config, to_table),
     };
 
     let value = if to_table {
@@ -363,26 +399,177 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
 /// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+///
+/// Default record output groups by display string (`Display`). `--to-table` keeps the
+/// original value and groups by typed identity (`Preserved`).
+#[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
-    String(String),
+    Display(String),
+    Preserved(Value),
 }
 
 impl GroupKey {
-    fn from_value(value: &Value, config: &nu_protocol::Config) -> Self {
+    fn from_value(value: &Value, config: &nu_protocol::Config, preserve_values: bool) -> Self {
         if value.is_nothing() {
             Self::Nothing
+        } else if preserve_values {
+            Self::Preserved(value.clone())
         } else {
-            Self::String(value.to_expanded_string(", ", config))
+            Self::Display(value.to_expanded_string(", ", config))
         }
     }
 
     fn into_value(self, span: Span) -> Value {
         match self {
             Self::Nothing => Value::nothing(span),
-            Self::String(s) => Value::string(s, span),
+            Self::Display(s) => Value::string(s, span),
+            Self::Preserved(v) => v,
         }
+    }
+}
+
+impl PartialEq for GroupKey {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Nothing, Self::Nothing) => true,
+            (Self::Display(a), Self::Display(b)) => a == b,
+            (Self::Preserved(a), Self::Preserved(b)) => group_values_eq(a, b),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for GroupKey {}
+
+impl Hash for GroupKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Nothing => {}
+            Self::Display(s) => s.hash(state),
+            Self::Preserved(v) => hash_group_value(v, state),
+        }
+    }
+}
+
+fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
+    std::mem::discriminant(value).hash(state);
+    match value {
+        Value::Bool { val, .. } => val.hash(state),
+        Value::Int { val, .. } => val.hash(state),
+        Value::Float { val, .. } => val.to_bits().hash(state),
+        Value::String { val, .. } => val.hash(state),
+        Value::Glob { val, no_expand, .. } => {
+            val.hash(state);
+            no_expand.hash(state);
+        }
+        Value::Filesize { val, .. } => val.hash(state),
+        Value::Duration { val, .. } => val.hash(state),
+        Value::Date { val, .. } => val.hash(state),
+        Value::Range { val, .. } => val.to_string().hash(state),
+        Value::Record { val, .. } => {
+            let mut pairs: Vec<_> = val.iter().collect();
+            pairs.sort_unstable_by_key(|(a, _)| *a);
+            pairs.len().hash(state);
+            for (key, child) in pairs {
+                key.hash(state);
+                hash_group_value(child, state);
+            }
+        }
+        Value::List { vals, .. } => {
+            vals.len().hash(state);
+            for child in vals.iter() {
+                hash_group_value(child, state);
+            }
+        }
+        Value::Closure { val, .. } => val.block_id.hash(state),
+        Value::Error { .. } => {}
+        Value::Binary { val, .. } => val.hash(state),
+        Value::CellPath { val, .. } => {
+            val.members.len().hash(state);
+            for member in &val.members {
+                match member {
+                    PathMember::String { val, optional, .. } => {
+                        0u8.hash(state);
+                        val.hash(state);
+                        optional.hash(state);
+                    }
+                    PathMember::Int { val, optional, .. } => {
+                        1u8.hash(state);
+                        val.hash(state);
+                        optional.hash(state);
+                    }
+                }
+            }
+        }
+        Value::Custom { val, .. } => {
+            val.type_name().hash(state);
+            if let Ok(base) = val.to_base_value(value.span()) {
+                hash_group_value(&base, state);
+            }
+        }
+        Value::Nothing { .. } => {}
+    }
+}
+
+fn group_values_eq(left: &Value, right: &Value) -> bool {
+    match (left, right) {
+        (Value::Bool { val: a, .. }, Value::Bool { val: b, .. }) => a == b,
+        (Value::Int { val: a, .. }, Value::Int { val: b, .. }) => a == b,
+        (Value::Float { val: a, .. }, Value::Float { val: b, .. }) => a.to_bits() == b.to_bits(),
+        (Value::String { val: a, .. }, Value::String { val: b, .. }) => a == b,
+        (
+            Value::Glob {
+                val: a,
+                no_expand: a_no_expand,
+                ..
+            },
+            Value::Glob {
+                val: b,
+                no_expand: b_no_expand,
+                ..
+            },
+        ) => a == b && a_no_expand == b_no_expand,
+        (Value::Filesize { val: a, .. }, Value::Filesize { val: b, .. }) => a == b,
+        (Value::Duration { val: a, .. }, Value::Duration { val: b, .. }) => a == b,
+        (Value::Date { val: a, .. }, Value::Date { val: b, .. }) => a == b,
+        // Typed identity: do not use Range::eq, which treats int and float ranges as equal.
+        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => {
+            a.to_string() == b.to_string()
+        }
+        (Value::Record { val: a, .. }, Value::Record { val: b, .. }) => {
+            if a.len() != b.len() {
+                return false;
+            }
+            let mut left_pairs: Vec<_> = a.iter().collect();
+            let mut right_pairs: Vec<_> = b.iter().collect();
+            left_pairs.sort_unstable_by_key(|(x, _)| *x);
+            right_pairs.sort_unstable_by_key(|(x, _)| *x);
+            left_pairs
+                .iter()
+                .zip(right_pairs)
+                .all(|((ak, av), (bk, bv))| *ak == bk && group_values_eq(av, bv))
+        }
+        (Value::List { vals: a, .. }, Value::List { vals: b, .. }) => {
+            a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| group_values_eq(x, y))
+        }
+        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => a.block_id == b.block_id,
+        (Value::Error { .. }, Value::Error { .. }) => true,
+        (Value::Binary { val: a, .. }, Value::Binary { val: b, .. }) => a == b,
+        (Value::CellPath { val: a, .. }, Value::CellPath { val: b, .. }) => a == b,
+        (Value::Custom { val: a, .. }, Value::Custom { val: b, .. }) => {
+            if a.type_name() != b.type_name() {
+                return false;
+            }
+            match (a.to_base_value(left.span()), b.to_base_value(right.span())) {
+                (Ok(a_base), Ok(b_base)) => group_values_eq(&a_base, &b_base),
+                (Err(_), Err(_)) => true,
+                _ => false,
+            }
+        }
+        (Value::Nothing { .. }, Value::Nothing { .. }) => true,
+        _ => false,
     }
 }
 
@@ -398,6 +585,7 @@ fn group_cell_path(
     prune: bool,
     values: Vec<Value>,
     config: &nu_protocol::Config,
+    preserve_values: bool,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let optional_path = path_has_optional_member(column_name);
@@ -411,7 +599,7 @@ fn group_cell_path(
             continue;
         }
 
-        let key = GroupKey::from_value(key_val.as_ref(), config);
+        let key = GroupKey::from_value(key_val.as_ref(), config, preserve_values);
 
         if prune {
             // it's okay if this fails since pruning is best-effort
@@ -438,6 +626,7 @@ fn group_closure(
     values: Vec<Value>,
     span: Span,
     closure: Closure,
+    preserve_values: bool,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
@@ -447,7 +636,7 @@ fn group_closure(
 
     for value in values {
         let key_val = closure.run_with_value(value.clone())?.into_value(span)?;
-        let key = GroupKey::from_value(&key_val, config);
+        let key = GroupKey::from_value(&key_val, config, preserve_values);
 
         groups.entry(key).or_default().push(value);
     }
@@ -483,11 +672,11 @@ enum Tree {
 }
 
 impl Grouped {
-    fn empty(values: Vec<Value>, config: &nu_protocol::Config) -> Self {
+    fn empty(values: Vec<Value>, config: &nu_protocol::Config, preserve_values: bool) -> Self {
         let mut groups = IndexMap::<_, Vec<_>>::new();
 
         for value in values.into_iter() {
-            let key = GroupKey::from_value(&value, config);
+            let key = GroupKey::from_value(&value, config, preserve_values);
             groups.entry(key).or_default().push(value);
         }
 
@@ -501,15 +690,19 @@ impl Grouped {
         prune: bool,
         values: Vec<Value>,
         config: &nu_protocol::Config,
+        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
         let groups = match grouper.item {
-            Grouper::CellPath { val } => group_cell_path(val, prune, values, config)?,
+            Grouper::CellPath { val } => {
+                group_cell_path(val, prune, values, config, preserve_values)?
+            }
             Grouper::Closure { val } => group_closure(
                 values,
                 grouper.span,
                 Closure::clone(val),
+                preserve_values,
                 engine_state,
                 stack,
             )?,
@@ -524,6 +717,7 @@ impl Grouped {
         grouper: Spanned<&Grouper>,
         prune: bool,
         config: &nu_protocol::Config,
+        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<(), ShellError> {
@@ -531,14 +725,22 @@ impl Grouped {
             Tree::Leaf(groups) => std::mem::take(groups)
                 .into_iter()
                 .map(|(key, values)| -> Result<_, ShellError> {
-                    let leaf = Self::new(grouper, prune, values, config, engine_state, stack)?;
+                    let leaf = Self::new(
+                        grouper,
+                        prune,
+                        values,
+                        config,
+                        preserve_values,
+                        engine_state,
+                        stack,
+                    )?;
                     Ok((key, leaf))
                 })
                 .collect::<Result<IndexMap<_, _>, ShellError>>()?,
             Tree::Branch(nested_groups) => {
                 let mut nested_groups = std::mem::take(nested_groups);
                 for v in nested_groups.values_mut() {
-                    v.subgroup(grouper, prune, config, engine_state, stack)?;
+                    v.subgroup(grouper, prune, config, preserve_values, engine_state, stack)?;
                 }
                 nested_groups
             }
@@ -589,8 +791,8 @@ impl Grouped {
                     // Records cannot use null as a key; omit null groups rather than
                     // mapping them to the empty string (which collides with "").
                     .filter_map(|(k, v)| match k {
-                        GroupKey::String(key) => Some((key, v.into_value(head))),
-                        GroupKey::Nothing => None,
+                        GroupKey::Display(key) => Some((key, v.into_value(head))),
+                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
                     })
                     .collect(),
                 head,
@@ -599,8 +801,8 @@ impl Grouped {
                 let values = branch
                     .into_iter()
                     .filter_map(|(k, v)| match k {
-                        GroupKey::String(key) => Some((key, v.into_record(head))),
-                        GroupKey::Nothing => None,
+                        GroupKey::Display(key) => Some((key, v.into_record(head))),
+                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
                     })
                     .collect();
                 Value::record(values, head)

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -21,7 +21,7 @@ impl Command for GroupBy {
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Any)])
             .switch(
                 "to-table",
-                "Return a table with \"groups\" and \"items\" columns.",
+                "Always return a table. Key columns keep their original types (column name \"group\" when no grouper is given).",
                 None,
             )
             .switch(
@@ -50,9 +50,9 @@ impl Command for GroupBy {
 
 The default output is a record when every group key is a string. Those record keys are the original strings; they are not reformatted. null group keys are omitted (records cannot use null as a key). Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
 
-If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table.
+If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table. Table output uses the same column-name rules as --to-table: a grouper named `items` is rejected (use `{ get items }` or rename the column), and duplicate grouper names are rejected.
 
---to-table always returns a table. Group columns keep their original types. null group keys are included as null values."#
+--to-table always returns a table. The group column is named `group` when no grouper is given; otherwise the grouper names. Group columns keep their original types. null group keys are included as null values."#
     }
 
     fn run(
@@ -481,8 +481,15 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
                 hash_group_value(child, state);
             }
         }
-        Value::Closure { val, .. } => val.block_id.hash(state),
-        Value::Error { .. } => {}
+        Value::Closure { val, .. } => {
+            val.block_id.hash(state);
+            val.captures.len().hash(state);
+            for (var_id, captured) in &val.captures {
+                var_id.hash(state);
+                hash_group_value(captured, state);
+            }
+        }
+        Value::Error { error, .. } => format!("{error:?}").hash(state),
         Value::Binary { val, .. } => val.hash(state),
         Value::CellPath { val, .. } => {
             val.members.len().hash(state);
@@ -593,8 +600,17 @@ fn group_values_eq(left: &Value, right: &Value) -> bool {
         (Value::List { vals: a, .. }, Value::List { vals: b, .. }) => {
             a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| group_values_eq(x, y))
         }
-        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => a.block_id == b.block_id,
-        (Value::Error { .. }, Value::Error { .. }) => true,
+        (Value::Closure { val: a, .. }, Value::Closure { val: b, .. }) => {
+            a.block_id == b.block_id
+                && a.captures.len() == b.captures.len()
+                && a.captures
+                    .iter()
+                    .zip(&b.captures)
+                    .all(|((id_a, val_a), (id_b, val_b))| {
+                        *id_a == *id_b && group_values_eq(val_a, val_b)
+                    })
+        }
+        (Value::Error { error: a, .. }, Value::Error { error: b, .. }) => a == b,
         (Value::Binary { val: a, .. }, Value::Binary { val: b, .. }) => a == b,
         (Value::CellPath { val: a, .. }, Value::CellPath { val: b, .. }) => a == b,
         (Value::Custom { val: a, .. }, Value::Custom { val: b, .. }) => {
@@ -844,9 +860,54 @@ impl Grouped {
 #[cfg(test)]
 mod test {
     use super::*;
+    use nu_protocol::{BlockId, ShellError, Span, VarId};
+    use std::hash::Hasher;
 
     #[test]
     fn test_examples() -> nu_test_support::Result {
         nu_test_support::test().examples(GroupBy)
+    }
+
+    fn hash_of(value: &Value) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        hash_group_value(value, &mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn group_identity_includes_error_payload_and_closure_captures() {
+        let block = BlockId::new(1);
+        let var = VarId::new(0);
+        let c1 = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(1))],
+        });
+        let c1_again = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(1))],
+        });
+        let c2 = Value::test_closure(Closure {
+            block_id: block,
+            captures: vec![(var, Value::test_int(2))],
+        });
+        assert!(group_values_eq(&c1, &c1_again));
+        assert_eq!(hash_of(&c1), hash_of(&c1_again));
+        assert!(!group_values_eq(&c1, &c2));
+
+        let e1 = Value::error(
+            ShellError::Generic(GenericError::new("a", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        let e1_again = Value::error(
+            ShellError::Generic(GenericError::new("a", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        let e2 = Value::error(
+            ShellError::Generic(GenericError::new("b", "here", Span::test_data())),
+            Span::test_data(),
+        );
+        assert!(group_values_eq(&e1, &e1_again));
+        assert_eq!(hash_of(&e1), hash_of(&e1_again));
+        assert!(!group_values_eq(&e1, &e2));
     }
 }

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -42,18 +42,17 @@ impl Command for GroupBy {
     }
 
     fn description(&self) -> &str {
-        "Splits a list or table into groups, and returns a record containing those groups."
+        "Splits a list or table into groups. Returns a record when the group keys are strings, otherwise a table."
     }
 
     fn extra_description(&self) -> &str {
-        r#"The default record output uses display-string keys because record keys must be strings:
-    - if the input data is not a string, the grouper converts the key to a string but the values remain in their original format. e.g. with bools, "true" and true would be in the same group (see example).
-    - datetime is formatted based on your configuration setting. use `format date` to change the format.
-    - filesize is formatted based on your configuration setting. use `format filesize` to change the format.
-    - some nushell values are not supported, such as closures.
-    - null group keys are never mapped to the empty string. The default record output omits null groups (records cannot use null as a key); use --to-table to include them as null values. Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+        r#"Grouping uses typed value identity (same type and payload), not display strings. Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups.
 
-With --to-table, group keys keep their original types and grouping uses typed value identity (same type and payload). Distinct filesizes that render the same (for example 1MB and 1.001MB) stay in separate groups. "true" and true are separate groups. null group keys are included as null values."#
+The default output is a record when every group key is a string. Those record keys are the original strings; they are not reformatted. null group keys are omitted (records cannot use null as a key). Optional cell paths (e.g. `foo?`) still ignore rows where access yields null.
+
+If any group key is not a string, the default output is a table with the original key types — the same shape as --to-table.
+
+--to-table always returns a table. Group columns keep their original types. null group keys are included as null values."#
     }
 
     fn run(
@@ -107,8 +106,8 @@ With --to-table, group keys keep their original types and grouping uses typed va
                 })),
             },
             Example {
-                description: "Group by a non-string column and keep the original key type.",
-                example: "[{n: 1} {n: 2} {n: 1}] | group-by n --to-table",
+                description: "Group by a non-string column. The result is a table so the keys keep their original type.",
+                example: "[{n: 1} {n: 2} {n: 1}] | group-by n",
                 result: Some(Value::test_list(vec![
                     Value::test_record(record! {
                         "n" => Value::test_int(1),
@@ -152,18 +151,26 @@ With --to-table, group keys keep their original types and grouping uses typed va
                 ])),
             },
             Example {
-                description: "Group bools, whether they are strings or actual bools.",
+                description: "Bools and strings are different keys, so the result is a table.",
                 example: r#"[true "true" false "false"] | group-by"#,
-                result: Some(Value::test_record(record! {
-                    "true" => Value::test_list(vec![
-                        Value::test_bool(true),
-                        Value::test_string("true"),
-                    ]),
-                    "false" => Value::test_list(vec![
-                        Value::test_bool(false),
-                        Value::test_string("false"),
-                    ]),
-                })),
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "group" => Value::test_bool(true),
+                        "items" => Value::test_list(vec![Value::test_bool(true)]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_string("true"),
+                        "items" => Value::test_list(vec![Value::test_string("true")]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_bool(false),
+                        "items" => Value::test_list(vec![Value::test_bool(false)]),
+                    }),
+                    Value::test_record(record! {
+                        "group" => Value::test_string("false"),
+                        "items" => Value::test_list(vec![Value::test_string("false")]),
+                    }),
+                ])),
             },
             Example {
                 description: "Group items by multiple columns' values.",
@@ -292,7 +299,6 @@ pub fn group_by(
     let groupers: Vec<Spanned<Grouper>> = call.rest(engine_state, stack, 0)?;
     let to_table = call.has_flag(engine_state, stack, "to-table")?;
     let prune = call.has_flag(engine_state, stack, "prune")?;
-    let config = &stack.get_config(engine_state);
 
     let values: Vec<Value> = input.into_iter().collect();
     if values.is_empty() {
@@ -306,31 +312,18 @@ pub fn group_by(
 
     let grouped = match &groupers[..] {
         [first, rest @ ..] => {
-            let mut grouped = Grouped::new(
-                first.as_ref(),
-                prune,
-                values,
-                config,
-                to_table,
-                engine_state,
-                stack,
-            )?;
+            let mut grouped = Grouped::new(first.as_ref(), prune, values, engine_state, stack)?;
             for grouper in rest {
-                grouped.subgroup(
-                    grouper.as_ref(),
-                    prune,
-                    config,
-                    to_table,
-                    engine_state,
-                    stack,
-                )?;
+                grouped.subgroup(grouper.as_ref(), prune, engine_state, stack)?;
             }
             grouped
         }
-        [] => Grouped::empty(values, config, to_table),
+        [] => Grouped::empty(values),
     };
 
-    let value = if to_table {
+    // Records can only use string keys. Non-string group keys keep their type
+    // by emitting the same table --to-table would.
+    let value = if to_table || grouped.has_non_string_key() {
         let column_names = groupers_to_column_names(&groupers)?;
         grouped.into_table(&column_names, head)
     } else {
@@ -401,31 +394,38 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 }
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
-/// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
+/// do not collapse. Record output omits `Nothing` keys; table output emits them as null.
 #[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
-    Display(String),
     Preserved(Value),
 }
 
 impl GroupKey {
-    fn from_value(value: &Value, config: &nu_protocol::Config, preserve_values: bool) -> Self {
+    fn from_value(value: &Value) -> Self {
         if value.is_nothing() {
             Self::Nothing
-        } else if preserve_values {
-            Self::Preserved(value.clone())
         } else {
-            Self::Display(value.to_expanded_string(", ", config))
+            Self::Preserved(value.clone())
         }
     }
 
     fn into_value(self, span: Span) -> Value {
         match self {
             Self::Nothing => Value::nothing(span),
-            Self::Display(s) => Value::string(s, span),
             Self::Preserved(v) => v,
         }
+    }
+
+    fn as_record_key(&self) -> Option<&str> {
+        match self {
+            Self::Preserved(Value::String { val, .. }) => Some(val.as_str()),
+            Self::Nothing | Self::Preserved(_) => None,
+        }
+    }
+
+    fn is_non_string(&self) -> bool {
+        !matches!(self, Self::Nothing | Self::Preserved(Value::String { .. }))
     }
 }
 
@@ -433,7 +433,6 @@ impl PartialEq for GroupKey {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Nothing, Self::Nothing) => true,
-            (Self::Display(a), Self::Display(b)) => a == b,
             (Self::Preserved(a), Self::Preserved(b)) => group_values_eq(a, b),
             _ => false,
         }
@@ -447,7 +446,6 @@ impl Hash for GroupKey {
         std::mem::discriminant(self).hash(state);
         match self {
             Self::Nothing => {}
-            Self::Display(s) => s.hash(state),
             Self::Preserved(v) => hash_group_value(v, state),
         }
     }
@@ -625,8 +623,6 @@ fn group_cell_path(
     column_name: &CellPath,
     prune: bool,
     values: Vec<Value>,
-    config: &nu_protocol::Config,
-    preserve_values: bool,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let optional_path = path_has_optional_member(column_name);
@@ -640,7 +636,7 @@ fn group_cell_path(
             continue;
         }
 
-        let key = GroupKey::from_value(key_val.as_ref(), config, preserve_values);
+        let key = GroupKey::from_value(key_val.as_ref());
 
         if prune {
             // it's okay if this fails since pruning is best-effort
@@ -667,17 +663,15 @@ fn group_closure(
     values: Vec<Value>,
     span: Span,
     closure: Closure,
-    preserve_values: bool,
     engine_state: &EngineState,
     stack: &mut Stack,
 ) -> Result<IndexMap<GroupKey, Vec<Value>>, ShellError> {
     let mut groups = IndexMap::<_, Vec<_>>::new();
     let mut closure = ClosureEval::new(engine_state, stack, closure);
-    let config = &stack.get_config(engine_state);
 
     for value in values {
         let key_val = closure.run_with_value(value.clone())?.into_value(span)?;
-        let key = GroupKey::from_value(&key_val, config, preserve_values);
+        let key = GroupKey::from_value(&key_val);
 
         groups.entry(key).or_default().push(value);
     }
@@ -713,11 +707,11 @@ enum Tree {
 }
 
 impl Grouped {
-    fn empty(values: Vec<Value>, config: &nu_protocol::Config, preserve_values: bool) -> Self {
+    fn empty(values: Vec<Value>) -> Self {
         let mut groups = IndexMap::<_, Vec<_>>::new();
 
         for value in values.into_iter() {
-            let key = GroupKey::from_value(&value, config, preserve_values);
+            let key = GroupKey::from_value(&value);
             groups.entry(key).or_default().push(value);
         }
 
@@ -730,20 +724,15 @@ impl Grouped {
         grouper: Spanned<&Grouper>,
         prune: bool,
         values: Vec<Value>,
-        config: &nu_protocol::Config,
-        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<Self, ShellError> {
         let groups = match grouper.item {
-            Grouper::CellPath { val } => {
-                group_cell_path(val, prune, values, config, preserve_values)?
-            }
+            Grouper::CellPath { val } => group_cell_path(val, prune, values)?,
             Grouper::Closure { val } => group_closure(
                 values,
                 grouper.span,
                 Closure::clone(val),
-                preserve_values,
                 engine_state,
                 stack,
             )?,
@@ -757,8 +746,6 @@ impl Grouped {
         &mut self,
         grouper: Spanned<&Grouper>,
         prune: bool,
-        config: &nu_protocol::Config,
-        preserve_values: bool,
         engine_state: &EngineState,
         stack: &mut Stack,
     ) -> Result<(), ShellError> {
@@ -766,28 +753,30 @@ impl Grouped {
             Tree::Leaf(groups) => std::mem::take(groups)
                 .into_iter()
                 .map(|(key, values)| -> Result<_, ShellError> {
-                    let leaf = Self::new(
-                        grouper,
-                        prune,
-                        values,
-                        config,
-                        preserve_values,
-                        engine_state,
-                        stack,
-                    )?;
+                    let leaf = Self::new(grouper, prune, values, engine_state, stack)?;
                     Ok((key, leaf))
                 })
                 .collect::<Result<IndexMap<_, _>, ShellError>>()?,
             Tree::Branch(nested_groups) => {
                 let mut nested_groups = std::mem::take(nested_groups);
                 for v in nested_groups.values_mut() {
-                    v.subgroup(grouper, prune, config, preserve_values, engine_state, stack)?;
+                    v.subgroup(grouper, prune, engine_state, stack)?;
                 }
                 nested_groups
             }
         };
         self.groups = Tree::Branch(groups);
         Ok(())
+    }
+
+    fn has_non_string_key(&self) -> bool {
+        match &self.groups {
+            Tree::Leaf(leaf) => leaf.keys().any(GroupKey::is_non_string),
+            Tree::Branch(branch) => {
+                branch.keys().any(GroupKey::is_non_string)
+                    || branch.values().any(Self::has_non_string_key)
+            }
+        }
     }
 
     fn into_table(self, column_names: &[String], head: Span) -> Value {
@@ -831,9 +820,9 @@ impl Grouped {
                 leaf.into_iter()
                     // Records cannot use null as a key; omit null groups rather than
                     // mapping them to the empty string (which collides with "").
-                    .filter_map(|(k, v)| match k {
-                        GroupKey::Display(key) => Some((key, v.into_value(head))),
-                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
+                    .filter_map(|(k, v)| {
+                        k.as_record_key()
+                            .map(|key| (key.to_string(), v.into_value(head)))
                     })
                     .collect(),
                 head,
@@ -841,9 +830,9 @@ impl Grouped {
             Tree::Branch(branch) => {
                 let values = branch
                     .into_iter()
-                    .filter_map(|(k, v)| match k {
-                        GroupKey::Display(key) => Some((key, v.into_record(head))),
-                        GroupKey::Nothing | GroupKey::Preserved(_) => None,
+                    .filter_map(|(k, v)| {
+                        k.as_record_key()
+                            .map(|key| (key.to_string(), v.into_record(head)))
                     })
                     .collect();
                 Value::record(values, head)

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -1,9 +1,12 @@
 use indexmap::IndexMap;
 use nu_engine::{ClosureEval, command_prelude::*};
 use nu_protocol::{
-    FromValue, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
+    FromValue, Range, ast::PathMember, engine::Closure, shell_error::generic::GenericError,
 };
-use std::hash::{Hash, Hasher};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Bound,
+};
 
 #[derive(Clone)]
 pub struct GroupBy;
@@ -399,9 +402,6 @@ fn groupers_to_column_names(groupers: &[Spanned<Grouper>]) -> Result<Vec<String>
 
 /// Internal group key. `Nothing` is distinct from the empty string so null and `""`
 /// do not collapse. Record output omits `Nothing` keys; `--to-table` emits them as null.
-///
-/// Default record output groups by display string (`Display`). `--to-table` keeps the
-/// original value and groups by typed identity (`Preserved`).
 #[derive(Debug, Clone)]
 enum GroupKey {
     Nothing,
@@ -467,7 +467,7 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
         Value::Filesize { val, .. } => val.hash(state),
         Value::Duration { val, .. } => val.hash(state),
         Value::Date { val, .. } => val.hash(state),
-        Value::Range { val, .. } => val.to_string().hash(state),
+        Value::Range { val, .. } => hash_range(val, state),
         Value::Record { val, .. } => {
             let mut pairs: Vec<_> = val.iter().collect();
             pairs.sort_unstable_by_key(|(a, _)| *a);
@@ -513,6 +513,50 @@ fn hash_group_value<H: Hasher>(value: &Value, state: &mut H) {
     }
 }
 
+fn hash_range<H: Hasher>(range: &Range, state: &mut H) {
+    match range {
+        Range::IntRange(r) => {
+            0u8.hash(state);
+            r.start().hash(state);
+            r.step().hash(state);
+            r.end().hash(state);
+        }
+        Range::FloatRange(r) => {
+            1u8.hash(state);
+            r.start().to_bits().hash(state);
+            r.step().to_bits().hash(state);
+            match r.end() {
+                Bound::Unbounded => 0u8.hash(state),
+                Bound::Included(v) => {
+                    1u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+                Bound::Excluded(v) => {
+                    2u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+            }
+        }
+    }
+}
+
+fn ranges_eq(left: &Range, right: &Range) -> bool {
+    match (left, right) {
+        (Range::IntRange(a), Range::IntRange(b)) => a == b,
+        (Range::FloatRange(a), Range::FloatRange(b)) => {
+            a.start().to_bits() == b.start().to_bits()
+                && a.step().to_bits() == b.step().to_bits()
+                && match (a.end(), b.end()) {
+                    (Bound::Unbounded, Bound::Unbounded) => true,
+                    (Bound::Included(x), Bound::Included(y))
+                    | (Bound::Excluded(x), Bound::Excluded(y)) => x.to_bits() == y.to_bits(),
+                    _ => false,
+                }
+        }
+        _ => false,
+    }
+}
+
 fn group_values_eq(left: &Value, right: &Value) -> bool {
     match (left, right) {
         (Value::Bool { val: a, .. }, Value::Bool { val: b, .. }) => a == b,
@@ -534,10 +578,7 @@ fn group_values_eq(left: &Value, right: &Value) -> bool {
         (Value::Filesize { val: a, .. }, Value::Filesize { val: b, .. }) => a == b,
         (Value::Duration { val: a, .. }, Value::Duration { val: b, .. }) => a == b,
         (Value::Date { val: a, .. }, Value::Date { val: b, .. }) => a == b,
-        // Typed identity: do not use Range::eq, which treats int and float ranges as equal.
-        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => {
-            a.to_string() == b.to_string()
-        }
+        (Value::Range { val: a, .. }, Value::Range { val: b, .. }) => ranges_eq(a, b),
         (Value::Record { val: a, .. }, Value::Record { val: b, .. }) => {
             if a.len() != b.len() {
                 return false;

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -91,34 +91,26 @@ fn group_by_to_table_on_empty_list_returns_empty_list() -> Result {
 
 #[test]
 fn optional_cell_path_works() -> Result {
+    // Int keys are not strings, so the default output is a table.
     test()
         .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
-        .expect_value_eq(test_value!({
-            "123": [{foo: 123}],
-            "234": [{foo: 234}],
-        }))
+        .expect_value_eq(test_value!([
+            {foo: 123, items: [{foo: 123}]},
+            {foo: 234, items: [{foo: 234}]},
+        ]))
 }
 
 #[test]
 fn group_by_compound_values_are_grouped_distinctly() -> Result {
-    // Regression test for grouping by list values.
-    let code = "
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
-        $data | group-by v | columns | length
-    ";
-    test().run(code).expect_value_eq(4)?;
-
-    // Every distinct list value should produce a separate group with exactly 1 row.
-    let code = "
-        let data = [[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]]
-        $data
-        | group-by v
-        | values
-        | each {|items| $items | length }
-        | uniq
-        | first
-    ";
-    test().run(code).expect_value_eq(1)
+    // List keys force table output. Distinct lists stay distinct.
+    test()
+        .run("[[k v]; [a [2 1]] [b [1 2]] [c [3]] [d [2]]] | group-by v")
+        .expect_value_eq(test_value!([
+            {v: [2, 1], items: [{k: "a", v: [2, 1]}]},
+            {v: [1, 2], items: [{k: "b", v: [1, 2]}]},
+            {v: [3], items: [{k: "c", v: [3]}]},
+            {v: [2], items: [{k: "d", v: [2]}]},
+        ]))
 }
 
 // --- null key consistency (#18707) ---
@@ -193,10 +185,10 @@ fn optional_cell_path_still_skips_nothing() -> Result {
     // Missing optional column is still ignored (historical #9020 behavior).
     test()
         .run("[{foo: 123}, {foo: 234}, {bar: 345}] | group-by foo?")
-        .expect_value_eq(test_value!({
-            "123": [{foo: 123}],
-            "234": [{foo: 234}],
-        }))?;
+        .expect_value_eq(test_value!([
+            {foo: 123, items: [{foo: 123}]},
+            {foo: 234, items: [{foo: 234}]},
+        ]))?;
 
     // Optional path with explicit null is also skipped (cannot distinguish from missing).
     test()
@@ -225,14 +217,13 @@ fn multi_grouper_null_key_in_to_table() -> Result {
             {a: 2, b: 1, items: [{a: 2, b: 1}]},
         ]))?;
 
-    // Record mode drops the null branch entirely.
+    // Non-string keys (and null) force table output; null is kept as nothing.
     test()
         .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b")
-        .expect_value_eq(test_value!({
-            "2": {
-                "1": [{a: 2, b: 1}],
-            },
-        }))
+        .expect_value_eq(test_value!([
+            {a: (), b: 1, items: [{a: (), b: 1}]},
+            {a: 2, b: 1, items: [{a: 2, b: 1}]},
+        ]))
 }
 
 #[test]
@@ -277,10 +268,52 @@ fn to_table_keeps_int_keys() -> Result {
 }
 
 #[test]
-fn record_mode_still_groups_filesizes_by_display_string() -> Result {
+fn non_string_keys_emit_a_table_without_to_table_flag() -> Result {
     test()
-        .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
-        .expect_value_eq(1)
+        .run("[[size]; [1MB] [1.001MB]] | group-by size | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[[size]; [1MB]] | group-by size | get 0.size | describe")
+        .expect_value_eq("filesize")?;
+
+    test()
+        .run("[{n: 1} {n: 1} {n: 2}] | group-by n")
+        .expect_value_eq(test_value!([
+            {n: 1, items: [{n: 1}, {n: 1}]},
+            {n: 2, items: [{n: 2}]},
+        ]))?;
+
+    test()
+        .run("[1 2 1] | group-by")
+        .expect_value_eq(test_value!([
+            {group: 1, items: [1, 1]},
+            {group: 2, items: [2]},
+        ]))?;
+
+    test()
+        .run(r#"[true "true"] | group-by"#)
+        .expect_value_eq(test_value!([
+            {group: true, items: [true]},
+            {group: "true", items: ["true"]},
+        ]))?;
+
+    test()
+        .run(r#"["a" 1] | group-by"#)
+        .expect_value_eq(test_value!([
+            {group: "a", items: ["a"]},
+            {group: 1, items: [1]},
+        ]))
+}
+
+#[test]
+fn string_keys_still_emit_a_record() -> Result {
+    test()
+        .run("['a' 'b' 'a'] | group-by")
+        .expect_value_eq(test_value!({
+            a: ["a", "a"],
+            b: ["b"],
+        }))
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -317,6 +317,37 @@ fn string_keys_still_emit_a_record() -> Result {
 }
 
 #[test]
+fn items_grouper_errors_when_output_is_a_table() -> Result {
+    // String keys still emit a record, so a column named `items` is fine.
+    test()
+        .run(r#"[{items: "a"} {items: "a"}] | group-by items"#)
+        .expect_value_eq(test_value!({
+            a: [{items: "a"}, {items: "a"}],
+        }))?;
+
+    // Non-string keys emit a table, which cannot have two `items` columns.
+    let err = test()
+        .run("[{items: 1} {items: 2}] | group-by items")
+        .expect_shell_error()?;
+    match err {
+        ShellError::Generic(generic) => {
+            assert_contains("items", generic.error.as_ref());
+            Ok(())
+        }
+        err => Err(err.into()),
+    }
+}
+
+#[test]
+fn closures_with_different_captures_are_distinct_groups() -> Result {
+    let code = "
+        let make = {|n| {|| $n }}
+        [(do $make 1) (do $make 1) (do $make 2)] | group-by --to-table | length
+    ";
+    test().run(code).expect_value_eq(2)
+}
+
+#[test]
 fn to_table_does_not_merge_int_and_float_ranges() -> Result {
     // `1..3 == 1.0..3.0` is true, but --to-table groups by typed identity.
     test()

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -217,12 +217,12 @@ fn all_nulls_record_is_empty_table_has_null_group() -> Result {
 
 #[test]
 fn multi_grouper_null_key_in_to_table() -> Result {
-    // Non-null keys are still stringified for grouping; null is preserved as nothing.
+    // --to-table keeps original key types; null is preserved as nothing.
     test()
         .run("[ { a: null, b: 1 } { a: 2, b: 1 } ] | group-by a b --to-table")
         .expect_value_eq(test_value!([
-            {a: (), b: "1", items: [{a: (), b: 1}]},
-            {a: "2", b: "1", items: [{a: 2, b: 1}]},
+            {a: (), b: 1, items: [{a: (), b: 1}]},
+            {a: 2, b: 1, items: [{a: 2, b: 1}]},
         ]))?;
 
     // Record mode drops the null branch entirely.
@@ -233,4 +233,52 @@ fn multi_grouper_null_key_in_to_table() -> Result {
                 "1": [{a: 2, b: 1}],
             },
         }))
+}
+
+#[test]
+fn to_table_preserves_filesize_keys_and_does_not_collapse_display_collisions() -> Result {
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size --to-table | length")
+        .expect_value_eq(2)?;
+
+    let code = "
+        let data = [[size]; [1MB] [1.001MB]]
+        let grouped = $data | group-by size --to-table
+        $grouped.size == $data.size
+    ";
+    test().run(code).expect_value_eq(true)?;
+
+    test()
+        .run("[[size]; [1MB]] | group-by size --to-table | get 0.size | describe")
+        .expect_value_eq("filesize")?;
+
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size --to-table | get 0.size | into filesize")
+        .expect_value_eq(nu_protocol::Filesize::new(1_000_000))
+}
+
+#[test]
+fn to_table_groups_equal_lists_and_keeps_list_keys() -> Result {
+    test()
+        .run("[[k v]; [a [1]] [b [1]]] | group-by v --to-table")
+        .expect_value_eq(test_value!([
+            {v: [1], items: [{k: "a", v: [1]}, {k: "b", v: [1]}]},
+        ]))
+}
+
+#[test]
+fn to_table_keeps_int_keys() -> Result {
+    test()
+        .run("[{n: 1} {n: 1} {n: 2}] | group-by n --to-table")
+        .expect_value_eq(test_value!([
+            {n: 1, items: [{n: 1}, {n: 1}]},
+            {n: 2, items: [{n: 2}]},
+        ]))
+}
+
+#[test]
+fn record_mode_still_groups_filesizes_by_display_string() -> Result {
+    test()
+        .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
+        .expect_value_eq(1)
 }

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -282,3 +282,33 @@ fn record_mode_still_groups_filesizes_by_display_string() -> Result {
         .run("[[size]; [1MB] [1.001MB]] | group-by size | columns | length")
         .expect_value_eq(1)
 }
+
+#[test]
+fn to_table_does_not_merge_int_and_float_ranges() -> Result {
+    // `1..3 == 1.0..3.0` is true, but --to-table groups by typed identity.
+    test()
+        .run("[1..3, 1..3, 1.0..3.0] | group-by --to-table | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[1..3, 1..3] | group-by --to-table | length")
+        .expect_value_eq(1)?;
+
+    test()
+        .run("[1.0..3.0, 1.0..3.0] | group-by --to-table | length")
+        .expect_value_eq(1)?;
+
+    test()
+        .run("[1..3, 1..4] | group-by --to-table | length")
+        .expect_value_eq(2)?;
+
+    test()
+        .run("[1..3] | group-by --to-table | get 0.group | describe")
+        .expect_value_eq("range")?;
+
+    let code = "
+        let grouped = [1..3, 1..3, 1.0..3.0] | group-by --to-table
+        ($grouped.items.0 | length) == 2 and ($grouped.items.1 | length) == 1
+    ";
+    test().run(code).expect_value_eq(true)
+}

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -212,7 +212,7 @@ fn sqlite_database_operations(#[case] operation: &str, #[case] expected: impl In
 #[case::wrap("wrap wrapped | columns | first", "wrapped")]
 #[case::interleave("interleave { [{z: 999}] } | length", 6)]
 #[case::rotate("rotate --ccw | columns | first", "column0")]
-#[case::group_by("group-by z | columns | length", 4)]
+#[case::group_by("group-by z | length", 5)]
 #[case::get("get z.0", 1)]
 #[case::length("length", 5)]
 #[case::merge("first | merge {n: 1} | get n", 1)]

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -2,7 +2,7 @@ use super::Expression;
 use crate::{Span, casing::Casing};
 use nu_utils::{escape_quote_string, needs_quoting};
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Display, str::FromStr};
+use std::{cmp::Ordering, fmt::Display, hash::{Hash, Hasher}, str::FromStr};
 use winnow::Parser;
 
 /// One level of access of a [`CellPath`]
@@ -183,6 +183,23 @@ impl PartialOrd for PathMember {
     }
 }
 
+impl Hash for PathMember {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            PathMember::String { val, optional, .. } => {
+                0u8.hash(state);
+                val.hash(state);
+                optional.hash(state);
+            }
+            PathMember::Int { val, optional, .. } => {
+                1u8.hash(state);
+                val.hash(state);
+                optional.hash(state);
+            }
+        }
+    }
+}
+
 impl Display for PathMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -296,6 +313,15 @@ impl TestPathMember<usize> {
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct CellPath {
     pub members: Vec<PathMember>,
+}
+
+impl Hash for CellPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.members.len().hash(state);
+        for member in &self.members {
+            member.hash(state);
+        }
+    }
 }
 
 impl CellPath {

--- a/crates/nu-protocol/src/engine/closure.rs
+++ b/crates/nu-protocol/src/engine/closure.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     fmt::{self, Debug},
+    hash::{Hash, Hasher},
 };
 
 use crate::{BlockId, ShellError, Span, Value, VarId, engine::EngineState};
@@ -26,6 +27,14 @@ impl Debug for Closure {
                 }),
             )
             .finish()
+    }
+}
+
+impl Hash for Closure {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Only hash block_id to match PartialOrd which compares closures by
+        // block_id alone. Including captures would violate the hash contract.
+        self.block_id.hash(state);
     }
 }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -37,6 +37,7 @@ use std::{
     borrow::Cow,
     cmp::Ordering,
     fmt::{self, Debug, Display, Write},
+    hash::{Hash, Hasher},
     ops::{Bound, ControlFlow},
     path::PathBuf,
 };
@@ -2785,6 +2786,51 @@ impl PartialOrd for Value {
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
         self.partial_cmp(other).is_some_and(Ordering::is_eq)
+    }
+}
+
+impl Hash for Value {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Value::Bool { val, .. } => val.hash(state),
+            Value::Int { val, .. } => val.hash(state),
+            Value::Float { val, .. } => val.to_bits().hash(state),
+            Value::String { val, .. } => val.hash(state),
+            Value::Glob { val, no_expand, .. } => {
+                val.hash(state);
+                no_expand.hash(state);
+            }
+            Value::Filesize { val, .. } => val.hash(state),
+            Value::Duration { val, .. } => val.hash(state),
+            Value::Date { val, .. } => {
+                val.timestamp().hash(state);
+                val.offset().local_minus_utc().hash(state);
+            }
+            Value::Range { val, .. } => val.hash(state),
+            Value::Record { val, .. } => val.hash(state),
+            Value::List { vals, .. } => {
+                vals.len().hash(state);
+                for child in vals.iter() {
+                    child.hash(state);
+                }
+            }
+            Value::Closure { val, .. } => val.hash(state),
+            Value::Error { .. } => {
+                // PartialOrd considers all errors equal, so use a constant
+                // hash to satisfy the hash/equality contract.
+                0u8.hash(state);
+            }
+            Value::Binary { val, .. } => val.hash(state),
+            Value::CellPath { val, .. } => val.hash(state),
+            Value::Custom { val, .. } => {
+                val.type_name().hash(state);
+                if let Ok(base) = val.to_base_value(self.span()) {
+                    base.hash(state);
+                }
+            }
+            Value::Nothing { .. } => {}
+        }
     }
 }
 
@@ -5821,6 +5867,301 @@ mod tests {
             // Verify it's larger than a simple list
             let simple_list = Value::test_list(vec![Value::test_int(1)]);
             assert!(record_size > simple_list.memory_size());
+        }
+    }
+
+    mod hash {
+        use super::*;
+        use crate::ast::{CellPath, PathMember};
+        use crate::{BlockId, Filesize, Range, ShellError, Span, VarId, casing::Casing};
+        use crate::engine::Closure;
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        use std::ops::Bound;
+
+        fn hash_value(val: &Value) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            val.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        #[test]
+        fn same_value_same_hash() {
+            assert_eq!(hash_value(&Value::test_int(1)), hash_value(&Value::test_int(1)));
+            assert_eq!(
+                hash_value(&Value::test_string("hello")),
+                hash_value(&Value::test_string("hello"))
+            );
+            assert_eq!(
+                hash_value(&Value::test_bool(true)),
+                hash_value(&Value::test_bool(true))
+            );
+        }
+
+        #[test]
+        fn different_values_different_hash() {
+            assert_ne!(hash_value(&Value::test_int(1)), hash_value(&Value::test_int(2)));
+            assert_ne!(
+                hash_value(&Value::test_string("a")),
+                hash_value(&Value::test_string("b"))
+            );
+        }
+
+        #[test]
+        fn bool_and_string_true_are_different() {
+            assert_ne!(
+                hash_value(&Value::test_bool(true)),
+                hash_value(&Value::test_string("true"))
+            );
+        }
+
+        #[test]
+        fn nothing_and_empty_string_are_different() {
+            assert_ne!(
+                hash_value(&Value::nothing(Span::test_data())),
+                hash_value(&Value::test_string(""))
+            );
+        }
+
+        #[test]
+        fn int_and_float_with_same_value_are_different() {
+            assert_ne!(
+                hash_value(&Value::test_int(1)),
+                hash_value(&Value::test_float(1.0))
+            );
+        }
+
+        #[test]
+        fn float_hash_uses_bits() {
+            assert_eq!(
+                hash_value(&Value::test_float(1.0)),
+                hash_value(&Value::test_float(1.0))
+            );
+            assert_ne!(
+                hash_value(&Value::test_float(1.0)),
+                hash_value(&Value::test_float(2.0))
+            );
+        }
+
+        #[test]
+        fn filesize_same_hash() {
+            let a = Value::filesize(Filesize::new(1000), Span::test_data());
+            let b = Value::filesize(Filesize::new(1000), Span::test_data());
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn filesize_different_hash() {
+            let a = Value::filesize(Filesize::new(1000), Span::test_data());
+            let b = Value::filesize(Filesize::new(2000), Span::test_data());
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn duration_same_hash() {
+            let a = Value::duration(1_000_000, Span::test_data());
+            let b = Value::duration(1_000_000, Span::test_data());
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn range_int_same_hash() {
+            let a = Value::range(Range::new_int(1, Some(2), Some(Bound::Included(5))), Span::test_data());
+            let b = Value::range(Range::new_int(1, Some(2), Some(Bound::Included(5))), Span::test_data());
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn range_int_different_hash() {
+            let a = Value::range(Range::new_int(1, Some(2), Some(Bound::Included(5))), Span::test_data());
+            let b = Value::range(Range::new_int(1, Some(3), Some(Bound::Included(5))), Span::test_data());
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn range_int_and_float_different_hash() {
+            let a = Value::range(Range::new_int(1, Some(2), Some(Bound::Included(3))), Span::test_data());
+            let b = Value::range(Range::new_float(1.0, Some(2.0), Some(Bound::Included(3.0))), Span::test_data());
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn record_same_hash() {
+            let a = Value::test_record(record! {
+                "x" => Value::test_int(1),
+                "y" => Value::test_int(2),
+            });
+            let b = Value::test_record(record! {
+                "x" => Value::test_int(1),
+                "y" => Value::test_int(2),
+            });
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn record_different_keys_different_hash() {
+            let a = Value::test_record(record! {
+                "a" => Value::test_int(1),
+            });
+            let b = Value::test_record(record! {
+                "b" => Value::test_int(1),
+            });
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn record_key_order_does_not_affect_hash() {
+            let a = Value::test_record(record! {
+                "a" => Value::test_int(1),
+                "b" => Value::test_int(2),
+            });
+            let b = Value::test_record(record! {
+                "b" => Value::test_int(2),
+                "a" => Value::test_int(1),
+            });
+            // Record PartialOrd sorts columns before comparing, so these are
+            // equal. Hash must match.
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn list_same_hash() {
+            let a = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            let b = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn list_different_hash() {
+            let a = Value::test_list(vec![Value::test_int(1), Value::test_int(2)]);
+            let b = Value::test_list(vec![Value::test_int(1), Value::test_int(3)]);
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn cell_path_same_hash() {
+            let a = Value::cell_path(
+                CellPath {
+                    members: vec![PathMember::test_string("a", false, Casing::Sensitive)],
+                },
+                Span::test_data(),
+            );
+            let b = Value::cell_path(
+                CellPath {
+                    members: vec![PathMember::test_string("a", false, Casing::Sensitive)],
+                },
+                Span::test_data(),
+            );
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn cell_path_ignores_casing_in_hash() {
+            let a = Value::cell_path(
+                CellPath {
+                    members: vec![PathMember::test_string("a", false, Casing::Sensitive)],
+                },
+                Span::test_data(),
+            );
+            let b = Value::cell_path(
+                CellPath {
+                    members: vec![PathMember::test_string("a", false, Casing::Insensitive)],
+                },
+                Span::test_data(),
+            );
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn glob_same_hash() {
+            let a = Value::glob("*.txt", false, Span::test_data());
+            let b = Value::glob("*.txt", false, Span::test_data());
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn glob_different_hash() {
+            let a = Value::glob("*.txt", false, Span::test_data());
+            let b = Value::glob("*.rs", false, Span::test_data());
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn closures_different_block_ids_different_hash() {
+            let a = Value::closure(
+                Closure {
+                    block_id: BlockId::new(0),
+                    captures: vec![],
+                },
+                Span::test_data(),
+            );
+            let b = Value::closure(
+                Closure {
+                    block_id: BlockId::new(1),
+                    captures: vec![],
+                },
+                Span::test_data(),
+            );
+            assert_ne!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn errors_all_have_same_hash() {
+            let a = Value::error(
+                ShellError::CantConvert {
+                    to_type: "int".into(),
+                    from_type: "string".into(),
+                    span: Span::test_data(),
+                    help: None,
+                },
+                Span::test_data(),
+            );
+            let b = Value::error(
+                ShellError::CantConvert {
+                    to_type: "float".into(),
+                    from_type: "bool".into(),
+                    span: Span::test_data(),
+                    help: Some("different error".into()),
+                },
+                Span::test_data(),
+            );
+            // PartialOrd considers all errors equal, so hash must match.
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn closures_same_block_id_same_hash_regardless_of_captures() {
+            let a = Value::closure(
+                Closure {
+                    block_id: BlockId::new(0),
+                    captures: vec![(VarId::new(0), Value::test_int(1))],
+                },
+                Span::test_data(),
+            );
+            let b = Value::closure(
+                Closure {
+                    block_id: BlockId::new(0),
+                    captures: vec![(VarId::new(0), Value::test_int(2))],
+                },
+                Span::test_data(),
+            );
+            // PartialOrd compares closures by block_id only, so these are
+            // equal. Hash must match.
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn binary_same_hash() {
+            let a = Value::binary(vec![1, 2, 3], Span::test_data());
+            let b = Value::binary(vec![1, 2, 3], Span::test_data());
+            assert_eq!(hash_value(&a), hash_value(&b));
+        }
+
+        #[test]
+        fn binary_different_hash() {
+            let a = Value::binary(vec![1, 2, 3], Span::test_data());
+            let b = Value::binary(vec![1, 2, 4], Span::test_data());
+            assert_ne!(hash_value(&a), hash_value(&b));
         }
     }
 

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -3,13 +3,18 @@
 use crate::{ShellError, Signals, Span, Value, ast::RangeInclusion};
 use core::ops::Bound;
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Display, str::FromStr};
+use std::{
+    cmp::Ordering,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
 use winnow::Parser;
 
 mod int_range {
     use crate::{FromValue, ShellError, Signals, Span, Value, ast::RangeInclusion};
     use serde::{Deserialize, Serialize};
-    use std::{cmp::Ordering, fmt::Display, ops::Bound};
+    use std::{cmp::Ordering, fmt::Display, hash::{Hash, Hasher}, ops::Bound};
 
     use super::Range;
 
@@ -245,6 +250,14 @@ mod int_range {
 
     impl Eq for IntRange {}
 
+    impl Hash for IntRange {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.start.hash(state);
+            self.step.hash(state);
+            self.end.hash(state);
+        }
+    }
+
     impl Display for IntRange {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{}..", self.start)?;
@@ -311,7 +324,12 @@ mod float_range {
     use crate::{IntRange, Range, ShellError, Signals, Span, Value, ast::RangeInclusion};
     use nu_utils::ObviousFloat;
     use serde::{Deserialize, Serialize};
-    use std::{cmp::Ordering, fmt::Display, ops::Bound};
+    use std::{
+        cmp::Ordering,
+        fmt::Display,
+        hash::{Hash, Hasher},
+        ops::Bound,
+    };
 
     #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
     pub struct FloatRange {
@@ -529,6 +547,24 @@ mod float_range {
 
     impl Eq for FloatRange {}
 
+    impl Hash for FloatRange {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.start.to_bits().hash(state);
+            self.step.to_bits().hash(state);
+            match self.end {
+                Bound::Unbounded => 0u8.hash(state),
+                Bound::Included(v) => {
+                    1u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+                Bound::Excluded(v) => {
+                    2u8.hash(state);
+                    v.to_bits().hash(state);
+                }
+            }
+        }
+    }
+
     impl Display for FloatRange {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{}..", ObviousFloat(self.start))?;
@@ -742,6 +778,23 @@ impl PartialEq for Range {
 }
 
 impl Eq for Range {}
+
+impl Hash for Range {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Range::IntRange(r) => {
+                0u8.hash(state);
+                r.start().hash(state);
+                r.step().hash(state);
+                r.end().hash(state);
+            }
+            Range::FloatRange(r) => {
+                1u8.hash(state);
+                r.hash(state);
+            }
+        }
+    }
+}
 
 impl Display for Range {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -1,6 +1,7 @@
 //! Our insertion ordered map-type [`Record`]
 use std::{
     fmt::Debug,
+    hash::{Hash, Hasher},
     iter::FusedIterator,
     marker::PhantomData,
     ops::{Deref, DerefMut, Index, RangeBounds},
@@ -23,6 +24,21 @@ impl Debug for Record {
         f.debug_map()
             .entries(self.inner.iter().map(|(k, v)| (k, v)))
             .finish()
+    }
+}
+
+impl Hash for Record {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Sort by key before hashing to match PartialOrd semantics which sorts
+        // columns before comparing, ensuring records with the same content but
+        // different insertion orders hash identically.
+        let mut pairs: Vec<_> = self.inner.iter().collect();
+        pairs.sort_by_key(|(k, _)| k.clone());
+        pairs.len().hash(state);
+        for (key, value) in pairs {
+            key.hash(state);
+            value.hash(state);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
This PR implements hash for Value. This should later allow Value to be used as a key in group-by.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->