### PR TITLE
Revert "Remove most `fs` helpers from `nu-test-support` (#18910)"

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -15,8 +15,7 @@ use nu_protocol::{
     Config, ParseError, PipelineData, Value, debugger::WithoutDebug, engine::StateWorkingSet,
 };
 use nu_std::load_standard_library;
-
-use nu_test_support::prelude::*;
+use nu_test_support::fs;
 use reedline::{Completer, CompletionResult, Span, Suggestion, Suggestions};
 use rstest::{fixture, rstest};
 use support::{
@@ -1300,10 +1299,7 @@ fn external_completer_fallback() {
     let suggestions = run_external_completion_within_pwd(
         block,
         input,
-        FIXTURES
-            .join("external_completions")
-            .try_into()
-            .expect("fixtures is absolute"),
+        fs::fixtures().join("external_completions"),
     );
     match_suggestions(&expected, &suggestions);
 
@@ -1313,10 +1309,7 @@ fn external_completer_fallback() {
     let suggestions = run_external_completion_within_pwd(
         block,
         input,
-        FIXTURES
-            .join("external_completions")
-            .try_into()
-            .expect("fixtures is absolute"),
+        fs::fixtures().join("external_completions"),
     );
     match_suggestions(&expected, &suggestions);
 }
@@ -1471,7 +1464,7 @@ fn command_wide_completion_wrapped_untyped_equals_flag_value() {
 )]
 fn command_wide_completion_fallback(#[case] code: &str) {
     // Create a new engine with PWD
-    let pwd = AbsolutePathBuf::try_from(FIXTURES.as_path()).expect("fixtures is absolute");
+    let pwd = fs::fixtures();
     let (_, _, mut engine, mut stack) = new_engine_helper(pwd.clone());
 
     let config_code = format!(
@@ -3219,14 +3212,7 @@ fn run_external_completion_within_pwd(
 }
 
 fn run_external_completion(completer: &str, input: &str) -> Suggestions {
-    run_external_completion_within_pwd(
-        completer,
-        input,
-        FIXTURES
-            .join("completions")
-            .try_into()
-            .expect("fixtures is absolute"),
-    )
+    run_external_completion_within_pwd(completer, input, fs::fixtures().join("completions"))
 }
 
 #[test]
@@ -3304,12 +3290,7 @@ fn filecompletions_triggers_after_cursor() {
 
 #[test]
 fn filecompletions_for_redirection_target() {
-    let (_, _, engine, stack) = new_engine_helper(
-        FIXTURES
-            .join("external_completions")
-            .try_into()
-            .expect("fixtures is absolute"),
-    );
+    let (_, _, engine, stack) = new_engine_helper(fs::fixtures().join("external_completions"));
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
 
     let expected = vec!["`dir with space/bar baz`", "`dir with space/foo`"];

--- a/crates/nu-cli/tests/completions/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/completions/support/completions_helpers.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{ArgType, Command, EngineState, Stack, StateWorkingSet},
 };
-use nu_test_support::prelude::*;
+use nu_test_support::fs;
 use reedline::Suggestion;
 use std::path::MAIN_SEPARATOR;
 
@@ -175,18 +175,13 @@ pub fn new_engine_helper(pwd: AbsolutePathBuf) -> (AbsolutePathBuf, String, Engi
 
 /// creates a new engine with the current path in the completions fixtures folder
 pub fn new_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    new_engine_helper(
-        FIXTURES
-            .join("completions")
-            .try_into()
-            .expect("fixtures is absolute"),
-    )
+    new_engine_helper(fs::fixtures().join("completions"))
 }
 
 /// Adds pseudo PATH env for external completion tests
 pub fn new_external_engine() -> EngineState {
     let mut engine = create_default_context();
-    let dir = FIXTURES.join("external_completions").join("path");
+    let dir = fs::fixtures().join("external_completions").join("path");
     let dir_str = dir.to_string_lossy().to_string();
     let span = nu_protocol::Span::new(0, dir_str.len());
     engine.add_env_var(
@@ -199,10 +194,7 @@ pub fn new_external_engine() -> EngineState {
 /// creates a new engine with the current path in the dotnu_completions fixtures folder
 pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
     // Target folder inside assets
-    let dir = FIXTURES
-        .join("dotnu_completions")
-        .try_into()
-        .expect("fixtures is absolute");
+    let dir = fs::fixtures().join("dotnu_completions");
     let (dir, dir_str, mut engine_state, mut stack) = new_engine_helper(dir);
     let dir_span = nu_protocol::Span::new(0, dir_str.len());
 
@@ -239,21 +231,11 @@ pub fn new_dotnu_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
 }
 
 pub fn new_quote_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    new_engine_helper(
-        FIXTURES
-            .join("quoted_completions")
-            .try_into()
-            .expect("fixtures is absolute"),
-    )
+    new_engine_helper(fs::fixtures().join("quoted_completions"))
 }
 
 pub fn new_partial_engine() -> (AbsolutePathBuf, String, EngineState, Stack) {
-    new_engine_helper(
-        FIXTURES
-            .join("partial_completions")
-            .try_into()
-            .expect("fixtures is absolute"),
-    )
+    new_engine_helper(fs::fixtures().join("partial_completions"))
 }
 
 /// match a list of suggestions with the expected values

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -1,4 +1,6 @@
 use nu_protocol::shell_error;
+#[cfg(unix)]
+use nu_protocol::test_record;
 use nu_test_support::{fs::Stub::EmptyFile, prelude::*};
 
 #[test]
@@ -267,10 +269,9 @@ fn cd_permission_denied_folder() -> Result {
 }
 
 #[test]
-#[deps(NU)]
 #[cfg(unix)]
 fn pwd_recovery() -> Result {
-    let nu = NU.path().display().to_string();
+    let nu = nu_test_support::fs::executable_path().display().to_string();
     let unique = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_nanos())

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -1,5 +1,5 @@
 use nu_protocol::test_record;
-use nu_test_support::prelude::*;
+use nu_test_support::{fs::fixtures, prelude::*};
 
 #[test]
 fn all() -> Result {
@@ -30,7 +30,7 @@ fn compute_sum_of_individual_row() -> Result {
         ("mem", 3032375296.),
         ("virtual", 102579965952.),
     ];
-    let mut tester = test().cwd(FIXTURES.join("formats"));
+    let mut tester = test().cwd(fixtures().join("formats"));
     for (column_name, expected_value) in answers_for_columns {
         let () = tester.run_with_data("let column = into cell-path", [column_name])?;
         let code = "
@@ -61,7 +61,7 @@ fn compute_sum_of_table() -> Result {
     };
 
     test()
-        .cwd(FIXTURES.join("formats"))
+        .cwd(fixtures().join("formats"))
         .run(code)
         .expect_value_eq(expected)
 }
@@ -69,7 +69,7 @@ fn compute_sum_of_table() -> Result {
 #[test]
 fn sum_of_a_row_containing_a_table_is_an_error() -> Result {
     let outcome = test()
-        .cwd(FIXTURES.join("formats"))
+        .cwd(fixtures().join("formats"))
         .run("open sample-sys-output.json | math sum")
         .expect_shell_error()?;
     match outcome {

--- a/crates/nu-command/tests/commands/peek.rs
+++ b/crates/nu-command/tests/commands/peek.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{ByteStreamType, PipelineData, Span};
-use nu_test_support::prelude::*;
+use nu_test_support::{fs::fixtures, prelude::*};
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 
@@ -102,7 +102,7 @@ fn peek_with_byte_streams(
     #[case] expected_peek_record: PeekRecord,
 ) -> Result {
     let outcome = test()
-        .cwd(FIXTURES.as_path())
+        .cwd(fixtures())
         .run_raw_with_data(code, PipelineData::Empty)?;
 
     let PipelineData::ByteStream(stream, Some(metadata)) = outcome.body else {

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -1,7 +1,10 @@
 mod into_string;
 mod join;
 
-use nu_test_support::{fs::Stub::FileWithContent, prelude::*};
+use nu_test_support::{
+    fs::{Stub::FileWithContent, fixtures},
+    prelude::*,
+};
 
 #[test]
 fn trims() -> Result {
@@ -438,7 +441,7 @@ fn substring_drops_content_type() -> Result {
         | metadata
         | $in.content_type?
     ";
-    test().cwd(FIXTURES.as_path()).run(code).expect_value_eq(())
+    test().cwd(fixtures()).run(code).expect_value_eq(())
 }
 
 #[test]

--- a/crates/nu-command/tests/format_conversions/msgpack.rs
+++ b/crates/nu-command/tests/format_conversions/msgpack.rs
@@ -4,8 +4,13 @@ use chrono::DateTime;
 use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 
-static GENERATE: LazyLock<PathBuf> =
-    LazyLock::new(|| FIXTURES.join("formats").join("msgpack").join("generate.nu"));
+static GENERATE: LazyLock<PathBuf> = LazyLock::new(|| {
+    nu_test_support::fs::fixtures()
+        .join("formats")
+        .join("msgpack")
+        .join("generate.nu")
+        .into()
+});
 
 fn msgpack_test<T: FromValue>(fixture_name: impl AsRef<str>) -> Result<T> {
     msgpack_test_with_opts(fixture_name, "")
@@ -114,7 +119,10 @@ fn sample() -> Result {
 
 #[test]
 fn sample_roundtrip() -> Result {
-    let path_to_sample_nuon = FIXTURES.join("formats").join("msgpack").join("sample.nuon");
+    let path_to_sample_nuon = nu_test_support::fs::fixtures()
+        .join("formats")
+        .join("msgpack")
+        .join("sample.nuon");
 
     let sample_nuon =
         std::fs::read_to_string(&path_to_sample_nuon).expect("failed to open sample.nuon");

--- a/crates/nu-command/tests/format_conversions/msgpackz.rs
+++ b/crates/nu-command/tests/format_conversions/msgpackz.rs
@@ -3,7 +3,10 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn sample_roundtrip() -> Result {
-    let path_to_sample_nuon = FIXTURES.join("formats").join("msgpack").join("sample.nuon");
+    let path_to_sample_nuon = nu_test_support::fs::fixtures()
+        .join("formats")
+        .join("msgpack")
+        .join("sample.nuon");
 
     let sample_nuon =
         std::fs::read_to_string(&path_to_sample_nuon).expect("failed to open sample.nuon");

--- a/crates/nu-json/tests/main.rs
+++ b/crates/nu-json/tests/main.rs
@@ -1,5 +1,4 @@
 use nu_json::Value;
-use nu_test_support::prelude::*;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 use std::fs;
@@ -39,7 +38,7 @@ fn assert_rstest_finds_assets(#[files("../../tests/assets/nu_json/*")] rstest_su
 
     assert_eq!(
         fs::canonicalize(supplied_dir).unwrap(),
-        fs::canonicalize(ASSETS.join("nu_json")).unwrap()
+        fs::canonicalize(nu_test_support::fs::assets().join("nu_json")).unwrap()
     );
 }
 

--- a/crates/nu-lsp/src/completion.rs
+++ b/crates/nu-lsp/src/completion.rs
@@ -208,7 +208,7 @@ mod tests {
         TextDocumentPositionParams, Uri, WorkDoneProgressParams,
         request::{Completion, Request},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     fn send_complete_request(
@@ -569,7 +569,7 @@ mod tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(config, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/completion");
         script.push(filename);
         let script = path_to_uri(&script);

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::path_to_uri;
     use crate::tests::{initialize_language_server, open_unchecked, update};
     use assert_json_diff::assert_json_eq;
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     #[rstest]
@@ -87,7 +87,7 @@ mod tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/diagnostics");
         script.push(filename);
         let script = path_to_uri(&script);

--- a/crates/nu-lsp/src/goto.rs
+++ b/crates/nu-lsp/src/goto.rs
@@ -116,7 +116,7 @@ mod tests {
         TextDocumentPositionParams, Uri, WorkDoneProgressParams,
         request::{GotoDefinition, Request},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::{fixtures, root};
     use rstest::rstest;
 
     fn send_goto_definition_request(
@@ -152,7 +152,7 @@ mod tests {
     fn goto_definition_for_none_existing_file() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut none_existent_path = WORKSPACE_ROOT.clone();
+        let mut none_existent_path = root();
         none_existent_path.push("none-existent.nu");
         let script = path_to_uri(&none_existent_path);
         let resp = send_goto_definition_request(&client_connection, script, 0, 0);
@@ -185,7 +185,7 @@ mod tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp");
         script.push(filename);
         let script = path_to_uri(&script);
@@ -219,7 +219,7 @@ mod tests {
     fn goto_definition_in_new_file() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/no_such_file.nu");
         let script = path_to_uri(&script);
 
@@ -253,7 +253,7 @@ mod tests {
     fn goto_definition_on_stdlib_should_not_panic() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/goto/use_module.nu");
         let script = path_to_uri(&script);
 

--- a/crates/nu-lsp/src/hints.rs
+++ b/crates/nu-lsp/src/hints.rs
@@ -164,7 +164,7 @@ mod tests {
         InlayHintParams, Position, Range, TextDocumentIdentifier, Uri, WorkDoneProgressParams,
         request::{InlayHintRequest, Request},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     fn send_inlay_hint_request(client_connection: &Connection, uri: Uri) -> Message {
@@ -291,7 +291,7 @@ mod tests {
         #[case] source_self: bool,
         #[case] expected: serde_json::Value,
     ) {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/hints");
         script.push(filename);
 

--- a/crates/nu-lsp/src/hover.rs
+++ b/crates/nu-lsp/src/hover.rs
@@ -236,7 +236,7 @@ mod hover_tests {
         },
     };
     use assert_json_diff::assert_json_eq;
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     #[rstest]
@@ -266,7 +266,7 @@ mod hover_tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/hover");
         script.push(filename);
         let script = path_to_uri(&script);
@@ -286,7 +286,7 @@ mod hover_tests {
     fn hover_on_external_command() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/hover/command.nu");
         let script = path_to_uri(&script);
 
@@ -314,7 +314,7 @@ mod hover_tests {
         #[case] expected_prefix: &str,
         #[case] use_config: bool,
     ) {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp");
         script.push(filename);
         let script_uri = path_to_uri(&script);

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -152,7 +152,7 @@ mod tests {
     };
     use assert_json_diff::assert_json_eq;
     use lsp_types::Range;
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     #[rstest]
@@ -179,7 +179,7 @@ hello",
     fn hover_on_command_after_content_change(#[case] text: String, #[case] range: Option<Range>) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/hover/command.nu");
         let script = path_to_uri(&script);
 
@@ -202,7 +202,7 @@ hello",
     fn open_document_with_utf_char() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/notifications/issue_11522.nu");
         let script = path_to_uri(&script);
 

--- a/crates/nu-lsp/src/semantic_tokens.rs
+++ b/crates/nu-lsp/src/semantic_tokens.rs
@@ -101,7 +101,7 @@ mod tests {
         TextDocumentIdentifier, Uri, WorkDoneProgressParams,
         request::{Request, SemanticTokensFullRequest},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
 
     fn send_semantic_token_request(client_connection: &Connection, uri: Uri) -> Message {
         client_connection
@@ -127,7 +127,7 @@ mod tests {
     fn semantic_token_internals() {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/semantic_tokens/internals.nu");
         let script = path_to_uri(&script);
 

--- a/crates/nu-lsp/src/signature.rs
+++ b/crates/nu-lsp/src/signature.rs
@@ -249,7 +249,7 @@ mod tests {
         TextDocumentIdentifier, Uri, WorkDoneProgressParams,
         request::{Request, SignatureHelpRequest},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     fn send_signature_help_request(
@@ -382,7 +382,7 @@ mod tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(config, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/hints/signature.nu");
         let script = path_to_uri(&script);
 

--- a/crates/nu-lsp/src/symbols.rs
+++ b/crates/nu-lsp/src/symbols.rs
@@ -310,7 +310,7 @@ mod tests {
         WorkDoneProgressParams, WorkspaceSymbolParams,
         request::{DocumentSymbolRequest, Request, WorkspaceSymbolRequest},
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     fn create_position(line: u32, character: u32) -> serde_json::Value {
@@ -428,7 +428,7 @@ mod tests {
     ) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/symbols");
         script.push(filename);
         let script = path_to_uri(&script);
@@ -465,11 +465,11 @@ mod tests {
     fn workspace_symbol_request(#[case] query: &str, #[case] mut expected: serde_json::Value) {
         let (client_connection, _recv) = initialize_language_server(None, None);
 
-        let mut script_foo = FIXTURES.clone();
+        let mut script_foo = fixtures();
         script_foo.push("lsp/symbols/foo.nu");
         let script_foo = path_to_uri(&script_foo);
 
-        let mut script_bar = FIXTURES.clone();
+        let mut script_bar = fixtures();
         script_bar.push("lsp/symbols/bar.nu");
         let script_bar = path_to_uri(&script_bar);
 

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -570,7 +570,7 @@ mod tests {
         ReferenceParams, RenameParams, TextDocumentIdentifier, TextDocumentPositionParams, Uri,
         WorkDoneProgressParams, WorkspaceFolder, request, request::Request,
     };
-    use nu_test_support::prelude::*;
+    use nu_test_support::fs::fixtures;
     use rstest::rstest;
 
     // Helper functions to reduce JSON duplication
@@ -761,7 +761,7 @@ mod tests {
             None,
             Some(serde_json::json!({ "workspaceFolders": serde_json::Value::Null })),
         );
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/workspace/foo.nu");
         let script = path_to_uri(&script);
 
@@ -809,7 +809,7 @@ mod tests {
         #[case] with_workspace_folder: bool,
         #[case] expected_refs: Vec<serde_json::Value>,
     ) {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/workspace");
         let (client_connection, _recv) = initialize_language_server(
             None,
@@ -910,7 +910,7 @@ mod tests {
         #[case] expected_prepare: serde_json::Value,
         #[case] expected_changes: Vec<(&str, Vec<serde_json::Value>)>,
     ) {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/workspace");
         let (client_connection, _recv) = initialize_language_server(
             None,
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn rename_cancelled() {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp/workspace");
         let (client_connection, _recv) = initialize_language_server(
             None,
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[test]
     fn existence_of_module_block() {
-        let mut script_path = FIXTURES.clone();
+        let mut script_path = fixtures();
         script_path.push("lsp");
         script_path.push("workspace");
         let mut engine_state = nu_cmd_lang::create_default_context();
@@ -1122,10 +1122,10 @@ mod tests {
         #[case] cursor_position: (u32, u32),
         #[case] expected: serde_json::Value,
     ) {
-        let mut script = FIXTURES.clone();
+        let mut script = fixtures();
         script.push("lsp");
         script.push(filename);
-        let script = path_to_uri(script);
+        let script = path_to_uri(&script);
 
         let (client_connection, _recv) = initialize_language_server(None, None);
         open_unchecked(&client_connection, script.clone());

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -1,4 +1,5 @@
-use nu_path::{AbsolutePath, Path};
+use nu_path::{AbsolutePath, AbsolutePathBuf, Path};
+use std::io::Read;
 
 pub enum Stub<'a> {
     FileWithContent(&'a str, &'a str),
@@ -7,7 +8,96 @@ pub enum Stub<'a> {
     FileWithPermission(&'a str, bool),
 }
 
+pub fn file_contents(full_path: impl AsRef<AbsolutePath>) -> String {
+    let mut file = std::fs::File::open(full_path.as_ref()).expect("can not open file");
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .expect("can not read file");
+    contents
+}
+
+pub fn file_contents_binary(full_path: impl AsRef<AbsolutePath>) -> Vec<u8> {
+    let mut file = std::fs::File::open(full_path.as_ref()).expect("can not open file");
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents).expect("can not read file");
+    contents
+}
+
 pub fn files_exist_at(files: &[impl AsRef<Path>], path: impl AsRef<AbsolutePath>) -> bool {
     let path = path.as_ref();
     files.iter().all(|f| path.join(f.as_ref()).exists())
+}
+
+pub fn executable_path() -> AbsolutePathBuf {
+    let mut path = binaries();
+    path.push("nu");
+    path
+}
+
+pub fn installed_nu_path() -> AbsolutePathBuf {
+    let path = std::env::var_os(nu_utils::consts::NATIVE_PATH_ENV_VAR);
+    if let Ok(path) = which::which_in("nu", path, ".") {
+        AbsolutePathBuf::try_from(path).expect("installed nushell path is absolute")
+    } else {
+        executable_path()
+    }
+}
+
+pub fn root() -> AbsolutePathBuf {
+    let manifest_dir = if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        AbsolutePathBuf::try_from(manifest_dir).expect("CARGO_MANIFEST_DIR is not an absolute path")
+    } else {
+        AbsolutePathBuf::try_from(env!("CARGO_MANIFEST_DIR"))
+            .expect("CARGO_MANIFEST_DIR is not an absolute path")
+    };
+
+    let test_path = manifest_dir.join("Cargo.lock");
+    if test_path.exists() {
+        manifest_dir
+    } else {
+        manifest_dir
+            .parent()
+            .expect("Couldn't find the debug binaries directory")
+            .parent()
+            .expect("Couldn't find the debug binaries directory")
+            .into()
+    }
+}
+
+pub fn binaries() -> AbsolutePathBuf {
+    let build_target = std::env::var("CARGO_BUILD_TARGET").unwrap_or_default();
+
+    let profile = if let Ok(env_profile) = std::env::var("NUSHELL_CARGO_PROFILE") {
+        env_profile
+    } else if cfg!(debug_assertions) {
+        "debug".into()
+    } else {
+        "release".into()
+    };
+
+    std::env::var("CARGO_TARGET_DIR")
+        .or_else(|_| std::env::var("CARGO_BUILD_TARGET_DIR"))
+        .ok()
+        .and_then(|p| AbsolutePathBuf::try_from(p).ok())
+        .unwrap_or_else(|| root().join("target"))
+        .join(build_target)
+        .join(profile)
+}
+
+pub fn fixtures() -> AbsolutePathBuf {
+    let mut path = root();
+    path.push("tests");
+    path.push("fixtures");
+    path
+}
+
+pub fn assets() -> AbsolutePathBuf {
+    let mut path = root();
+    path.push("tests");
+    path.push("assets");
+    path
+}
+
+pub fn in_directory(path: impl AsRef<nu_path::Path>) -> AbsolutePathBuf {
+    root().join(path)
 }

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -614,10 +614,7 @@ pub mod prelude {
         assertions::*,
         harness::deps::*,
         playground::Playground,
-        tester::{
-            ASSETS, FIXTURES, Result, ShellErrorExt, TestError as Error, TestResultExt,
-            WORKSPACE_ROOT, test,
-        },
+        tester::{Result, ShellErrorExt, TestError as Error, TestResultExt, WORKSPACE_ROOT, test},
         value_types::*,
     };
 

--- a/crates/nu-test-support/src/playground/nu_process.rs
+++ b/crates/nu-test-support/src/playground/nu_process.rs
@@ -1,5 +1,5 @@
 use super::EnvironmentVariable;
-use crate::harness::deps::NU;
+use crate::fs::{binaries as test_bins_path, executable_path};
 use std::{
     ffi::{OsStr, OsString},
     fmt,
@@ -69,7 +69,7 @@ impl NuProcess {
     }
 
     pub fn construct(&self) -> Command {
-        let mut command = Command::new(NU.path());
+        let mut command = Command::new(executable_path());
 
         if let Some(cwd) = &self.cwd {
             command.current_dir(cwd);
@@ -77,7 +77,7 @@ impl NuProcess {
 
         command.env_clear();
 
-        let paths = [NU.bin_dir()];
+        let paths = [test_bins_path()];
 
         let paths_joined = match std::env::join_paths(paths) {
             Ok(all) => all,

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -1,9 +1,9 @@
 use super::Director;
-use crate::{fs::Stub, tester::FIXTURES};
+use crate::fs::{self, Stub};
 #[cfg(not(target_arch = "wasm32"))]
 use nu_path::Path;
 use nu_path::{AbsolutePath, AbsolutePathBuf};
-use std::{ops::Deref, str};
+use std::str;
 use tempfile::{TempDir, tempdir};
 
 #[derive(Default, Clone, Debug)]
@@ -86,15 +86,14 @@ impl Playground<'_> {
             .canonicalize()
             .expect("Could not canonicalize test path");
 
-        let fixtures = FIXTURES
-            .deref()
-            .try_into()
-            .expect("fixtures is absolute path");
+        let fixtures = fs::fixtures()
+            .canonicalize()
+            .expect("Could not canonicalize fixtures path");
 
         let dirs = Dirs {
             root: root.into(),
             test: test.as_path().into(),
-            fixtures,
+            fixtures: fixtures.into(),
         };
 
         let mut playground = Playground {

--- a/crates/nu-test-support/src/tester/mod.rs
+++ b/crates/nu-test-support/src/tester/mod.rs
@@ -36,14 +36,6 @@ pub static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
         .expect("could not absolutize root")
 });
 
-/// Test fixtures.
-pub static FIXTURES: LazyLock<PathBuf> =
-    LazyLock::new(|| WORKSPACE_ROOT.join("tests").join("fixtures"));
-
-/// Test assets.
-pub static ASSETS: LazyLock<PathBuf> =
-    LazyLock::new(|| WORKSPACE_ROOT.join("tests").join("assets"));
-
 // By using different engine states depending on the group key, we can ensure that behavior from
 // experimental options or environment variables take proper effect in the setup of an engine state.
 static INITIAL_ENGINE_STATES: KeyedLazyLock<GroupKey, EngineState> = KeyedLazyLock::new(|_| {
@@ -431,6 +423,25 @@ impl NuTester {
             .inherit_env_if_set("http_proxy")
             .inherit_env_if_set("https_proxy")
             .inherit_env_if_set("no_proxy")
+    }
+
+    /// Adds the "nu" binary for testing to the path.
+    ///
+    /// Calling [`inherit_path`](Self::inherit_path) after this methods removes the path entry.
+    #[deprecated(note = "use `#[deps(NU)]` instead")]
+    pub fn add_nu_to_path(self) -> Self {
+        let nu_home = crate::fs::binaries();
+        let path = self.engine_state.get_env_var("PATH");
+        let path = match path {
+            None => nu_home.display().to_string(),
+            Some(path) => format!(
+                "{nu}{sep}{prev}",
+                nu = nu_home.display(),
+                sep = ENV_PATH_SEPARATOR_CHAR,
+                prev = path.as_str().expect("PATH should always be a string")
+            ),
+        };
+        self.env("PATH", path)
     }
 
     /// Add a custom environment variable to the engine state.


### PR DESCRIPTION
## Description
This reverts commit baaba71de9dd58fe8b6a396d3ef106e093ee6149.

It looks strange to me because CI in https://github.com/nushell/nushell/pull/18910 passed, this pr is created to see if it breaks the CI

## User-facing changes (Release notes)
NaN

## Additional notes
NaN