### PR TITLE
fix(kill): decode taskkill output lossily instead of hard-erroring

### DIFF
--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -126,18 +126,18 @@ impl Command for Kill {
         if !quiet && !output.status.success() {
             return Err(ShellError::Generic(GenericError::new(
                 "process didn't terminate successfully",
-                String::from_utf8(output.stderr).unwrap_or_default(),
+                String::from_utf8_lossy(&output.stderr).into_owned(),
                 call.head,
             )));
         }
 
-        let mut output = String::from_utf8(output.stdout).map_err(|e| {
-            ShellError::Generic(GenericError::new(
-                "failed to convert output to string",
-                e.to_string(),
-                call.head,
-            ))
-        })?;
+        // The underlying kill command's (e.g. `taskkill` on Windows) output is
+        // encoded using the system's active codepage, not necessarily UTF-8, so a
+        // non-English locale (e.g. Shift-JIS/932 on Japanese Windows) can produce
+        // bytes that aren't valid UTF-8. Decode lossily instead of hard-erroring:
+        // the process was still killed successfully, so failing to report its
+        // (informational-only) output isn't worth surfacing as a command error.
+        let mut output = String::from_utf8_lossy(&output.stdout).into_owned();
 
         output.truncate(output.trim_end().len());
 
@@ -200,5 +200,26 @@ mod tests {
         assert_eq!(inferred_signal_number(b"-9", -9), Some(9));
         assert_eq!(inferred_signal_number(b"0", 0), None);
         assert_eq!(inferred_signal_number(b"9", 9), None);
+    }
+
+    /// Regression test for https://github.com/nushell/nushell/issues/13476: on a
+    /// non-English Windows codepage (e.g. Shift-JIS/932), `taskkill`'s stdout is
+    /// encoded in that codepage rather than UTF-8, and can contain byte sequences
+    /// that are outright invalid UTF-8 -- `String::from_utf8` hard-errors on
+    /// these ("invalid utf-8 sequence of 1 bytes from index 0" was the exact
+    /// error reported), even though the process was killed successfully.
+    /// `String::from_utf8_lossy` never errors, by contract of the standard
+    /// library API, so this can no longer regress -- this test exists to pin
+    /// down the exact byte shape that used to trip `String::from_utf8`.
+    #[test]
+    fn decodes_non_utf8_taskkill_output_without_erroring() {
+        // 0x82 is a lone Shift-JIS lead byte with no following byte: on its own
+        // it is not valid UTF-8 in any position, which is exactly what produced
+        // "invalid utf-8 sequence of 1 bytes from index 0" in the original report.
+        let stdout: Vec<u8> = vec![b'O', b'K', 0x82];
+        assert!(String::from_utf8(stdout.clone()).is_err());
+
+        let decoded = String::from_utf8_lossy(&stdout).into_owned();
+        assert!(decoded.starts_with("OK"));
     }
 }


### PR DESCRIPTION
## Description

Fixes #13476.

On a non-English Windows codepage (e.g. Shift-JIS/932), `taskkill`'s stdout/stderr is encoded in that codepage rather than UTF-8, and can contain byte sequences that aren't valid UTF-8 at all. `String::from_utf8` hard-errors on these, so `kill <pid>` reported `failed to convert output to string` even though the process was actually killed successfully — the error was purely a decoding problem with the informational output text, not a real failure.

Switched both the stdout and stderr conversions in `kill.rs` to `String::from_utf8_lossy`, which never errors (invalid sequences become replacement characters). The stderr path was already tolerant of this in spirit (`unwrap_or_default()` on the same `from_utf8` error), just at the cost of silently discarding the whole message instead of preserving it lossily — so this also slightly improves error messages on non-UTF8 stderr, not just fixing the stdout crash.

## User-facing changes (Release notes)

- Fixed `kill` failing with a UTF-8 conversion error on non-English Windows codepages (e.g. Japanese Shift-JIS), even though the target process was successfully terminated.

## Additional notes

- Added a regression test (`decodes_non_utf8_taskkill_output_without_erroring`) that reproduces the exact byte shape from the report (a lone Shift-JIS lead byte, matching the "invalid utf-8 sequence of 1 bytes from index 0" error text) and confirms `String::from_utf8` errors on it while `String::from_utf8_lossy` does not.
- `cargo test -p nu-command --lib platform::kill::` (3/3 pass), `cargo fmt --check`, and `cargo clippy -p nu-command --lib -- -D warnings` are all clean.
- I don't have a non-English Windows codepage active by default in my dev environment, so I couldn't reproduce the exact original `chcp 932` repro end-to-end; I verified the fix at the byte level instead (see the added test) and via `cargo check`/`cargo clippy`/`cargo test` on Windows.