### PR TITLE
Add `commandline get-selection` command

### DIFF
--- a/crates/nu-cli/src/commands/commandline/edit.rs
+++ b/crates/nu-cli/src/commands/commandline/edit.rs
@@ -68,6 +68,7 @@ impl Command for CommandlineEdit {
         }
 
         repl.accept = call.has_flag(engine_state, stack, "accept")?;
+        repl.selection = None;
 
         Ok(Value::nothing(call.head).into_pipeline_data())
     }

--- a/crates/nu-cli/src/commands/commandline/get_selection.rs
+++ b/crates/nu-cli/src/commands/commandline/get_selection.rs
@@ -1,0 +1,83 @@
+use nu_engine::command_prelude::*;
+use nu_protocol::shell_error::generic::GenericError;
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Clone)]
+pub struct CommandlineGetSelection;
+
+impl Command for CommandlineGetSelection {
+    fn name(&self) -> &str {
+        "commandline get-selection"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![
+                (Type::Nothing, Type::record()),
+                (Type::Nothing, Type::Nothing),
+            ])
+            .category(Category::Core)
+    }
+
+    fn description(&self) -> &str {
+        "Get the current selection positions."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["repl", "interactive"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let repl = engine_state.repl_state.lock().expect("repl state mutex");
+
+        match repl.selection {
+            None => Ok(Value::nothing(call.head).into_pipeline_data()),
+            Some((from, to)) => {
+                let char_pos_start = repl
+                    .buffer
+                    .grapheme_indices(true)
+                    .chain(std::iter::once((repl.buffer.len(), "")))
+                    .position(|(i, _c)| i == from)
+                    .expect("Selection start isn't on a grapheme boundary");
+                let char_pos_end = repl
+                    .buffer
+                    .grapheme_indices(true)
+                    .chain(std::iter::once((repl.buffer.len(), "")))
+                    .position(|(i, _c)| i == to)
+                    .expect("Selection end isn't on a grapheme boundary");
+                match (i64::try_from(char_pos_start), i64::try_from(char_pos_end)) {
+                    (Ok(pos_start), Ok(pos_end)) => Ok(Value::record(
+                        record! {
+                            "start" => Value::int(pos_start, call.head),
+                            "end" => Value::int(pos_end, call.head),
+                        },
+                        call.head,
+                    )
+                    .into_pipeline_data()),
+                    (Err(e), _) => Err(ShellError::Generic(GenericError::new_internal(
+                        "Failed to convert selection start to int",
+                        e.to_string(),
+                    ))),
+                    (_, Err(e)) => Err(ShellError::Generic(GenericError::new_internal(
+                        "Failed to convert selection end to int",
+                        e.to_string(),
+                    ))),
+                }
+            }
+        }
+    }
+
+    fn examples(&self) -> Vec<Example<'_>> {
+        vec![Example {
+            example: r#"let s = commandline get-selection; commandline | str substring ($s.start?)..<($s.end?)"#,
+            description: "Get the current selection content, or the full command line if none.",
+            result: None,
+        }]
+    }
+}

--- a/crates/nu-cli/src/commands/commandline/mod.rs
+++ b/crates/nu-cli/src/commands/commandline/mod.rs
@@ -2,6 +2,7 @@ mod commandline_;
 mod complete;
 mod edit;
 mod get_cursor;
+mod get_selection;
 mod set_cursor;
 mod set_prompt;
 
@@ -9,5 +10,6 @@ pub use commandline_::Commandline;
 pub use complete::CommandlineComplete;
 pub use edit::CommandlineEdit;
 pub use get_cursor::CommandlineGetCursor;
+pub use get_selection::CommandlineGetSelection;
 pub use set_cursor::CommandlineSetCursor;
 pub use set_prompt::CommandlineSetPrompt;

--- a/crates/nu-cli/src/commands/default_context.rs
+++ b/crates/nu-cli/src/commands/default_context.rs
@@ -18,6 +18,7 @@ pub fn add_cli_context(mut engine_state: EngineState) -> EngineState {
             CommandlineComplete,
             CommandlineEdit,
             CommandlineGetCursor,
+            CommandlineGetSelection,
             CommandlineSetCursor,
             CommandlineSetPrompt,
             History,

--- a/crates/nu-cli/src/commands/mod.rs
+++ b/crates/nu-cli/src/commands/mod.rs
@@ -13,8 +13,8 @@ mod print;
 pub use abbr::Abbreviations;
 pub use abbr_list::AbbreviationsList;
 pub use commandline::{
-    Commandline, CommandlineComplete, CommandlineEdit, CommandlineGetCursor, CommandlineSetCursor,
-    CommandlineSetPrompt,
+    Commandline, CommandlineComplete, CommandlineEdit, CommandlineGetCursor,
+    CommandlineGetSelection, CommandlineSetCursor, CommandlineSetPrompt,
 };
 pub use history::*;
 pub use keybindings::Keybindings;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -409,6 +409,7 @@ fn run_command(ctx: RunContext) -> Reedline {
     let mut repl = engine_state.repl_state.lock().expect("repl state mutex");
     repl.cursor_pos = line_editor.current_insertion_point();
     repl.buffer = line_editor.current_buffer_contents().to_string();
+    repl.selection = line_editor.current_selection();
     drop(repl);
 
     if shell_integration.osc633 {
@@ -577,6 +578,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
     let mut repl = engine_state.repl_state.lock().expect("repl state mutex");
     repl.cursor_pos = line_editor.current_insertion_point();
     repl.buffer = line_editor.current_buffer_contents().to_string();
+    repl.selection = line_editor.current_selection();
     drop(repl);
 
     // Check all the environment variables they ask for
@@ -1300,6 +1302,7 @@ fn flush_engine_state_repl_buffer(
     repl.accept = false;
     repl.buffer = "".to_string();
     repl.cursor_pos = 0;
+    repl.selection = None;
     line_editor
 }
 

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -3210,6 +3210,7 @@ fn run_external_completion_within_pwd(
         let mut repl = engine_state.repl_state.lock().expect("repl state");
         repl.buffer = input.to_string();
         repl.cursor_pos = input.len();
+        repl.selection = None;
     }
 
     // Instantiate a new completer

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -55,6 +55,7 @@ pub struct ReplState {
     pub cursor_pos: usize,
     /// Immediately accept the buffer on the next loop.
     pub accept: bool,
+    pub selection: Option<(usize, usize)>,
 }
 
 #[derive(Debug)]
@@ -244,6 +245,7 @@ impl EngineState {
                 buffer: "".to_string(),
                 cursor_pos: 0,
                 accept: false,
+                selection: None,
             })),
             prompt_state: Arc::new(PromptState::new()),
             table_decl_id: None,
@@ -1161,6 +1163,7 @@ impl EngineState {
                 buffer: "".to_string(),
                 cursor_pos: 0,
                 accept: false,
+                selection: None,
             }));
         }
         if Mutex::is_poisoned(&self.jobs) {


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->
This PR adds a command to retrieve the current selection bounds.

Knowing the current selection adds the possibility to add custom edition of the command line and to create user-defined ctrl+c without the system-clipboard feature.

Requires https://github.com/nushell/reedline/pull/1200

Asked in [nushell's discord](https://discord.com/channels/601130461678272522/1534693483615621391)

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

### Tested keybindings
`{ name: copy_selection modifier: control keycode: char_c mode: [emacs vi_insert] event: { ... } }`

#### Copy the selection to the system clipboard
`{ send: ExecuteHostCommand cmd: "let s = commandline get-selection; commandline | str substring ($s.start?)..<($s.end?) | copy" }`
`copy` could be `clipboard copy`. I use `if $nu.os-info.family == 'windows' { nircmd clipboard set $in } else { wl-copy }`.
The entire buffer is sent to the clipboard if there is no selection.

#### Make the selection uppercase
`{ send: ExecuteHostCommand cmd: "let s = commandline get-selection; if ($s | is-empty) { return; }; let cu = (commandline get-cursor); commandline edit (commandline | split indices $s.start $s.end | update 1 {str uppercase} | str join ''); commandline set-cursor $cu" }`
Where `split indices` can be:
```nushell
# Split a string at specified indices (credits: Bahex)
def "split indices" [...indices: int]: string -> list<string> {
    let IN
    $indices
    | prepend 0
    | window 2
    | each { ($in.0)..<($in.1) }
    | append [($indices | last -s)..]
    | each {|r| $IN | str substring $r }
}
```
