### PR TITLE
fix parsing performance regression

### DIFF
--- a/crates/nu-parser/src/parse_captures_compile.rs
+++ b/crates/nu-parser/src/parse_captures_compile.rs
@@ -526,9 +526,9 @@ pub fn parse(
 
 /// Like [`parse`], but never returns a span-matched cached block.
 ///
-/// Required for `source` / `source-env`: free variables rebind to new VarIds
-/// when `let`/`mut` are re-declared, so a block cached by span alone is stale.
-/// See https://github.com/nushell/nushell/issues/18515
+/// `source` / `source-env` use [`parse`], which reuses a cached block only when
+/// every free-variable capture still resolves to the current `VarId`. Use this
+/// when a caller must re-lex and re-bind regardless.
 pub fn parse_fresh(
     working_set: &mut StateWorkingSet,
     fname: Option<&str>,
@@ -536,6 +536,38 @@ pub fn parse_fresh(
     scoped: bool,
 ) -> Arc<Block> {
     parse_with_block_cache(working_set, fname, contents, scoped, false)
+}
+
+/// Whether every free-variable capture on `block` still names the same `VarId`.
+///
+/// File-level `block.captures` includes vars used inside nested `def` bodies
+/// (`discover_captures_in_expr` bubbles those up). That is the #18515 set:
+/// outer `let`/`mut` re-declarations change the `VarId` and must not reuse.
+/// Files with no free vars (libraries of `def`s) return true immediately.
+fn cached_block_captures_still_valid(working_set: &StateWorkingSet, block: &Block) -> bool {
+    block
+        .captures
+        .iter()
+        .all(|(var_id, span)| capture_binding_is_current(working_set, *var_id, *span))
+}
+
+fn capture_binding_is_current(working_set: &StateWorkingSet, var_id: VarId, span: Span) -> bool {
+    // Specials (`$nu`, `$env`, `$in`, …) are not rebound by `let`/`mut`.
+    if var_id <= LAST_VARIABLE_ID {
+        return true;
+    }
+
+    let from_var = working_set
+        .get_variable_if_possible(var_id)
+        .and_then(|variable| variable.name.as_deref());
+    let name = match from_var {
+        Some(name) if !name.is_empty() => name,
+        _ => working_set.get_span_contents(span),
+    };
+    if name.is_empty() {
+        return false;
+    }
+    working_set.find_variable(name) == Some(var_id)
 }
 
 fn parse_with_block_cache(
@@ -556,11 +588,22 @@ fn parse_with_block_cache(
 
     let new_span = working_set.get_span_for_file(file_id);
 
-    // Reuse a previously-parsed block with the same span when safe (e.g. LSP).
-    // Callers that need fresh free-variable bindings use `parse_fresh`.
-    if use_block_cache && let Some(block) = working_set.find_block_by_span(new_span) {
-        return block;
+    // Reuse a previously-parsed block with the same span when its free
+    // variables still bind to the current VarIds. Stale captures (REPL
+    // `let`/`mut` re-declaration, #18515) fall through and re-parse.
+    if use_block_cache {
+        for cached in working_set.blocks_with_span_newest_first(new_span) {
+            if cached_block_captures_still_valid(working_set, &cached) {
+                return cached;
+            }
+        }
     }
+
+    // Capture discovery below should only consider blocks created by this parse.
+    // Walking the whole delta is O(historical blocks) per source and made
+    // repeated `source` of the same file quadratic after parse_fresh.
+    let first_new_delta_block = working_set.delta.blocks.len();
+
     let mut output = {
         let (output, err) = lex(contents, new_span.start, &[], &[], false);
         if let Some(err) = err {
@@ -600,18 +643,19 @@ fn parse_with_block_cache(
         Err(err) => working_set.error(err),
     }
 
-    // Also check other blocks that might have been imported
+    // Also check other blocks that might have been imported during this parse
     let mut errors = vec![];
-    for (block_idx, block) in working_set.delta.blocks.iter().enumerate() {
-        let block_id = block_idx + working_set.permanent_state.num_blocks();
-        let block_id = BlockId::new(block_id);
+    let permanent_blocks = working_set.permanent_state.num_blocks();
+    for block_idx in first_new_delta_block..working_set.delta.blocks.len() {
+        let block_id = BlockId::new(permanent_blocks + block_idx);
 
         if !seen_blocks.contains_key(&block_id) {
             let mut captures = vec![];
+            let block = working_set.delta.blocks[block_idx].clone();
 
             match discover_captures_in_closure(
                 working_set,
-                block,
+                &block,
                 &mut seen,
                 &mut seen_blocks,
                 &mut captures,

--- a/crates/nu-parser/src/parse_captures_compile.rs
+++ b/crates/nu-parser/src/parse_captures_compile.rs
@@ -6,7 +6,10 @@ use nu_protocol::{
     BlockId, IN_VARIABLE_ID, LAST_VARIABLE_ID, ParseError, Span, Type, VarId, ast::*,
     engine::StateWorkingSet,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 pub fn compile_block(working_set: &mut StateWorkingSet<'_>, block: &mut Block) {
     if !working_set.parse_errors.is_empty() {
@@ -78,6 +81,66 @@ pub fn discover_captures_in_closure(
     }
 
     Ok(())
+}
+
+fn parser_info_block_id(call: &Call) -> Option<BlockId> {
+    match &call.get_parser_info("block_id")?.expr {
+        Expr::Int(id) if *id >= 0 => Some(BlockId::new(*id as usize)),
+        _ => None,
+    }
+}
+
+fn bubble_captures_from_block_id(
+    working_set: &StateWorkingSet,
+    block_id: BlockId,
+    seen: &mut [VarId],
+    seen_blocks: &mut HashMap<BlockId, Vec<(VarId, Span)>>,
+    output: &mut Vec<(VarId, Span)>,
+) -> Result<(), ParseError> {
+    match seen_blocks.get(&block_id) {
+        Some(capture_list) => {
+            for capture in capture_list {
+                if !seen.contains(&capture.0) {
+                    output.push(*capture);
+                }
+            }
+            Ok(())
+        }
+        None => {
+            let block = working_set.get_block(block_id);
+            if !block.captures.is_empty() {
+                for (capture, span) in &block.captures {
+                    if !seen.contains(capture) {
+                        output.push((*capture, *span));
+                    }
+                }
+                Ok(())
+            } else {
+                let result = {
+                    let mut inner_seen = vec![];
+                    seen_blocks.insert(block_id, vec![]);
+
+                    let mut result = vec![];
+                    discover_captures_in_closure(
+                        working_set,
+                        block,
+                        &mut inner_seen,
+                        seen_blocks,
+                        &mut result,
+                    )?;
+
+                    result
+                };
+                for capture in &result {
+                    if !seen.contains(&capture.0) {
+                        output.push(*capture);
+                    }
+                }
+                seen_blocks.insert(block_id, result);
+                Ok(())
+            }
+        }
+    }
 }
 
 fn discover_captures_in_pipeline(
@@ -232,50 +295,24 @@ pub fn discover_captures_in_expr(
             } else {
                 let decl = working_set.get_decl(call.decl_id);
                 if let Some(block_id) = decl.block_id() {
-                    match seen_blocks.get(&block_id) {
-                        Some(capture_list) => {
-                            // Push captures onto the outer closure that aren't created by that outer closure
-                            for capture in capture_list {
-                                if !seen.contains(&capture.0) {
-                                    output.push(*capture);
-                                }
-                            }
-                        }
-                        None => {
-                            let block = working_set.get_block(block_id);
-                            if !block.captures.is_empty() {
-                                for (capture, span) in &block.captures {
-                                    if !seen.contains(capture) {
-                                        output.push((*capture, *span));
-                                    }
-                                }
-                            } else {
-                                let result = {
-                                    let mut seen = vec![];
-                                    seen_blocks.insert(block_id, vec![]);
-
-                                    let mut result = vec![];
-                                    discover_captures_in_closure(
-                                        working_set,
-                                        block,
-                                        &mut seen,
-                                        seen_blocks,
-                                        &mut result,
-                                    )?;
-
-                                    result
-                                };
-                                // Push captures onto the outer closure that aren't created by that outer closure
-                                for capture in &result {
-                                    if !seen.contains(&capture.0) {
-                                        output.push(*capture);
-                                    }
-                                }
-
-                                seen_blocks.insert(block_id, result);
-                            }
-                        }
-                    }
+                    bubble_captures_from_block_id(
+                        working_set,
+                        block_id,
+                        seen,
+                        seen_blocks,
+                        output,
+                    )?;
+                }
+                // `source` / `source-env` store the sourced file as parser_info
+                // `block_id` (Expr::Int), not as decl.block_id() or a call argument.
+                if let Some(block_id) = parser_info_block_id(call) {
+                    bubble_captures_from_block_id(
+                        working_set,
+                        block_id,
+                        seen,
+                        seen_blocks,
+                        output,
+                    )?;
                 }
             }
 
@@ -538,17 +575,96 @@ pub fn parse_fresh(
     parse_with_block_cache(working_set, fname, contents, scoped, false)
 }
 
-/// Whether every free-variable capture on `block` still names the same `VarId`.
-///
-/// File-level `block.captures` includes vars used inside nested `def` bodies
-/// (`discover_captures_in_expr` bubbles those up). That is the #18515 set:
-/// outer `let`/`mut` re-declarations change the `VarId` and must not reuse.
-/// Files with no free vars (libraries of `def`s) return true immediately.
+fn cached_block_reusable(working_set: &StateWorkingSet, block: &Block, scoped: bool) -> bool {
+    block.parsed_scoped == scoped && cached_block_captures_still_valid(working_set, block)
+}
+
+/// Child sourced blocks can hold captures that are not on this block yet.
 fn cached_block_captures_still_valid(working_set: &StateWorkingSet, block: &Block) -> bool {
-    block
+    if !block
         .captures
         .iter()
         .all(|(var_id, span)| capture_binding_is_current(working_set, *var_id, *span))
+    {
+        return false;
+    }
+    nested_source_blocks_still_valid(working_set, block, &mut HashSet::new())
+}
+
+fn nested_source_blocks_still_valid(
+    working_set: &StateWorkingSet,
+    block: &Block,
+    visited: &mut HashSet<BlockId>,
+) -> bool {
+    for pipeline in &block.pipelines {
+        for element in &pipeline.elements {
+            if !expr_nested_source_blocks_still_valid(working_set, &element.expr, visited) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn expr_nested_source_blocks_still_valid(
+    working_set: &StateWorkingSet,
+    expr: &Expression,
+    visited: &mut HashSet<BlockId>,
+) -> bool {
+    match &expr.expr {
+        Expr::Call(call) => {
+            if let Some(block_id) = parser_info_block_id(call)
+                && visited.insert(block_id)
+            {
+                let nested = working_set.get_block(block_id);
+                if !nested
+                    .captures
+                    .iter()
+                    .all(|(var_id, span)| capture_binding_is_current(working_set, *var_id, *span))
+                {
+                    return false;
+                }
+                if !nested_source_blocks_still_valid(working_set, nested, visited) {
+                    return false;
+                }
+            }
+            for arg in &call.arguments {
+                let inner = match arg {
+                    Argument::Named(named) => named.2.as_ref(),
+                    Argument::Positional(expr)
+                    | Argument::Unknown(expr)
+                    | Argument::Spread(expr) => Some(expr),
+                };
+                if let Some(inner) = inner
+                    && !expr_nested_source_blocks_still_valid(working_set, inner, visited)
+                {
+                    return false;
+                }
+            }
+            true
+        }
+        Expr::Closure(block_id)
+        | Expr::Block(block_id)
+        | Expr::Subexpression(block_id)
+        | Expr::RowCondition(block_id) => {
+            if visited.insert(*block_id) {
+                nested_source_blocks_still_valid(
+                    working_set,
+                    working_set.get_block(*block_id),
+                    visited,
+                )
+            } else {
+                true
+            }
+        }
+        Expr::AttributeBlock(ab) => {
+            expr_nested_source_blocks_still_valid(working_set, &ab.item, visited)
+        }
+        Expr::Collect(_, inner) => {
+            expr_nested_source_blocks_still_valid(working_set, inner, visited)
+        }
+        _ => true,
+    }
 }
 
 fn capture_binding_is_current(working_set: &StateWorkingSet, var_id: VarId, span: Span) -> bool {
@@ -588,20 +704,16 @@ fn parse_with_block_cache(
 
     let new_span = working_set.get_span_for_file(file_id);
 
-    // Reuse a previously-parsed block with the same span when its free
-    // variables still bind to the current VarIds. Stale captures (REPL
-    // `let`/`mut` re-declaration, #18515) fall through and re-parse.
+    // Reuse when scoped-ness matches and free vars still bind to these VarIds.
     if use_block_cache {
         for cached in working_set.blocks_with_span_newest_first(new_span) {
-            if cached_block_captures_still_valid(working_set, &cached) {
+            if cached_block_reusable(working_set, &cached, scoped) {
                 return cached;
             }
         }
     }
 
-    // Capture discovery below should only consider blocks created by this parse.
-    // Walking the whole delta is O(historical blocks) per source and made
-    // repeated `source` of the same file quadratic after parse_fresh.
+    // Only blocks created by this parse. Older delta entries already have captures.
     let first_new_delta_block = working_set.delta.blocks.len();
 
     let mut output = {
@@ -651,11 +763,11 @@ fn parse_with_block_cache(
 
         if !seen_blocks.contains_key(&block_id) {
             let mut captures = vec![];
-            let block = working_set.delta.blocks[block_idx].clone();
+            let block = &working_set.delta.blocks[block_idx];
 
             match discover_captures_in_closure(
                 working_set,
-                &block,
+                block,
                 &mut seen,
                 &mut seen_blocks,
                 &mut captures,

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -155,6 +155,7 @@ pub fn parse_block(
 
     let mut block = Block::new_with_capacity(lite_block.block.len());
     block.span = Some(span);
+    block.parsed_scoped = scoped;
 
     if let [first, rest @ ..] = lite_block.block.as_slice() {
         // only the first pipeline receives the block's pipeline input
@@ -179,6 +180,7 @@ pub fn parse_block(
         // Move the block out to prepare it to become a subexpression
         let inner_block = std::mem::take(&mut block);
         block.span = inner_block.span;
+        block.parsed_scoped = scoped;
         let ty = inner_block.output_type();
         let block_id = working_set.add_block(Arc::new(inner_block));
 

--- a/crates/nu-parser/src/parse_source.rs
+++ b/crates/nu-parser/src/parse_source.rs
@@ -5,7 +5,7 @@ use crate::{
     parse_keywords::find_keyword_decl,
     parse_pipelines::{parse_redirection, redirecting_builtin_error},
     parser::{
-        ArgumentParsingLevel, CallKind, ParsedInternalCall, compile_block, parse, parse_fresh,
+        ArgumentParsingLevel, CallKind, ParsedInternalCall, compile_block, parse,
         parse_internal_call,
     },
 };
@@ -150,9 +150,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                             return garbage_pipeline(working_set, spans);
                         }
 
-                        // Re-parse so free vars bind to current VarIds, not a
-                        // span-cached block from an earlier parse (#18515).
-                        let mut block = parse_fresh(
+                        // Parse with capture-valid span reuse. Files with no
+                        // free vars reuse the cached block (0.114 behavior).
+                        // Redeclared outer `let`/`mut` invalidates the cache so
+                        // sourced files see the new VarIds (#18515 / #18538).
+                        let mut block = parse(
                             working_set,
                             Some(&path.path().to_string_lossy()),
                             &contents,

--- a/crates/nu-parser/src/parse_source.rs
+++ b/crates/nu-parser/src/parse_source.rs
@@ -150,10 +150,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                             return garbage_pipeline(working_set, spans);
                         }
 
-                        // Parse with capture-valid span reuse. Files with no
-                        // free vars reuse the cached block (0.114 behavior).
-                        // Redeclared outer `let`/`mut` invalidates the cache so
-                        // sourced files see the new VarIds (#18515 / #18538).
+                        // Reuse the cached parse only when VarIds still match.
                         let mut block = parse(
                             working_set,
                             Some(&path.path().to_string_lossy()),
@@ -167,7 +164,9 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
 
                         working_set.files.pop();
 
-                        let block_id = working_set.add_block(block);
+                        let block_id = working_set
+                            .find_block_id_of(&block)
+                            .unwrap_or_else(|| working_set.add_block(block));
 
                         let mut call_with_block = call;
 

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -24,6 +24,12 @@ pub struct Block {
     /// Not serialized: only meaningful within the process that parsed the block.
     #[serde(skip)]
     pub scope_bindings: Option<Arc<ScopeBindings>>,
+    /// Whether `parse_block` ran with `scoped = true` (`enter_scope`).
+    ///
+    /// Distinct from `scope_bindings`: a scoped parse of a let-only file still
+    /// snapshots as `None`. Needed so `source` does not reuse a `source-env` parse.
+    #[serde(skip)]
+    pub parsed_scoped: bool,
 }
 
 impl Block {
@@ -63,6 +69,7 @@ impl Block {
             ir_block: None,
             span: None,
             scope_bindings: None,
+            parsed_scoped: false,
         }
     }
 
@@ -75,6 +82,7 @@ impl Block {
             ir_block: None,
             span: None,
             scope_bindings: None,
+            parsed_scoped: false,
         }
     }
 
@@ -113,6 +121,7 @@ where
             ir_block: None,
             span: None,
             scope_bindings: None,
+            parsed_scoped: false,
         }
     }
 }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1070,10 +1070,6 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     /// Blocks covering `span`, newest first (delta before permanent).
-    ///
-    /// The parser uses this to reuse a sourced file when free-variable captures
-    /// still resolve to the current `VarId`s. Newest first so a re-parsed block
-    /// (same span, new bindings) is preferred over a stale one.
     pub fn blocks_with_span_newest_first(&self, span: Span) -> Vec<Arc<Block>> {
         let mut blocks = Vec::new();
         for block in self.delta.blocks.iter().rev() {
@@ -1087,6 +1083,21 @@ impl<'a> StateWorkingSet<'a> {
             }
         }
         blocks
+    }
+
+    /// Identity lookup so a cache hit can keep the existing `BlockId`.
+    pub fn find_block_id_of(&self, block: &Arc<Block>) -> Option<BlockId> {
+        for (idx, existing) in self.delta.blocks.iter().enumerate() {
+            if Arc::ptr_eq(existing, block) {
+                return Some(BlockId::new(self.permanent_state.num_blocks() + idx));
+            }
+        }
+        for (idx, existing) in self.permanent_state.blocks.iter().enumerate() {
+            if Arc::ptr_eq(existing, block) {
+                return Some(BlockId::new(idx));
+            }
+        }
+        None
     }
 
     pub fn find_module_by_span(&self, span: Span) -> Option<ModuleId> {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1069,6 +1069,26 @@ impl<'a> StateWorkingSet<'a> {
         None
     }
 
+    /// Blocks covering `span`, newest first (delta before permanent).
+    ///
+    /// The parser uses this to reuse a sourced file when free-variable captures
+    /// still resolve to the current `VarId`s. Newest first so a re-parsed block
+    /// (same span, new bindings) is preferred over a stale one.
+    pub fn blocks_with_span_newest_first(&self, span: Span) -> Vec<Arc<Block>> {
+        let mut blocks = Vec::new();
+        for block in self.delta.blocks.iter().rev() {
+            if block.span == Some(span) {
+                blocks.push(block.clone());
+            }
+        }
+        for block in self.permanent_state.blocks.iter().rev() {
+            if block.span == Some(span) {
+                blocks.push(block.clone());
+            }
+        }
+        blocks
+    }
+
     pub fn find_module_by_span(&self, span: Span) -> Option<ModuleId> {
         for (id, module) in self.delta.modules.iter().enumerate() {
             if Some(span) == module.span {

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -645,6 +645,102 @@ fn source_same_file_does_not_multiply_decls() -> Result {
 }
 
 #[test]
+fn source_redeclared_let_visible_through_nested_source() -> Result {
+    // Wrapper files that only `source` a child with free vars must not reuse a
+    // stale child block after `let` is redeclared.
+    Playground::setup(
+        "source_redeclared_nested_source",
+        |dirs, sandbox| -> Result {
+            sandbox.with_files(&[
+                FileWithContent("b.nu", "$xxx"),
+                FileWithContent("a.nu", "source b.nu"),
+            ]);
+
+            let mut tester = test().cwd(dirs.test());
+
+            let out1: String = tester.run("let xxx = 'first'; source a.nu")?;
+            assert_eq!(out1, "first");
+
+            let out2: String = tester.run("let xxx = 'second'; source a.nu")?;
+            assert_eq!(out2, "second");
+
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn source_redeclared_let_visible_through_def_wrapping_source() -> Result {
+    Playground::setup(
+        "source_redeclared_def_wraps_source",
+        |dirs, sandbox| -> Result {
+            sandbox.with_files(&[
+                FileWithContent("b.nu", "$xxx"),
+                FileWithContent("a.nu", "def foo [] { source b.nu }"),
+            ]);
+
+            let mut tester = test().cwd(dirs.test());
+
+            let out1: String = tester.run("let xxx = 'first'; source a.nu; foo")?;
+            assert_eq!(out1, "first");
+
+            let out2: String = tester.run("let xxx = 'second'; source a.nu; foo")?;
+            assert_eq!(out2, "second");
+
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn source_after_source_env_still_registers_defs() -> Result {
+    // `source` is unscoped; `source-env` is scoped. Reuse must not share those
+    // parses, or `source` after `source-env` would skip overlay registration.
+    Playground::setup("source_after_source_env_defs", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[FileWithContent("lib.nu", "def from_lib [] { 7 }")]);
+
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source-env lib.nu")?;
+        tester
+            .run("from_lib")
+            .expect_error_code_eq("nu::shell::external_command")?;
+
+        let () = tester.run("source lib.nu")?;
+        tester.run("from_lib").expect_value_eq(7)?;
+        Ok(())
+    })
+}
+
+#[test]
+fn source_after_source_env_still_registers_lets() -> Result {
+    // Scoped let-only files snapshot `scope_bindings` as None. Reuse must still
+    // distinguish `source` from `source-env` so overlay vars get registered.
+    Playground::setup("source_after_source_env_lets", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[
+            FileWithContent("lets.nu", "let foo = 1"),
+            FileWithContent("consts.nu", "const bar = 2"),
+        ]);
+
+        let mut tester = test().cwd(dirs.test());
+
+        let () = tester.run("source-env lets.nu")?;
+        tester
+            .run("$foo")
+            .expect_error_code_eq("nu::parser::variable_not_found")?;
+        let () = tester.run("source lets.nu")?;
+        tester.run("$foo").expect_value_eq(1)?;
+
+        let () = tester.run("source-env consts.nu")?;
+        tester
+            .run("$bar")
+            .expect_error_code_eq("nu::parser::variable_not_found")?;
+        let () = tester.run("source consts.nu")?;
+        tester.run("$bar").expect_value_eq(2)?;
+        Ok(())
+    })
+}
+
+#[test]
 fn source_use_file_named_null() -> Result {
     Playground::setup("source_file_named_null", |dirs, sandbox| -> Result {
         sandbox.with_files(&[FileWithContent(

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -583,6 +583,68 @@ fn source_env_redeclared_let_variable() -> Result {
 }
 
 #[test]
+fn source_redeclared_let_visible_inside_sourced_def() -> Result {
+    // Nested `def` bodies capture outer vars. File-level captures must include
+    // those (or the span cache would reuse a stale `foo` after `let` redeclare).
+    // See https://github.com/nushell/nushell/issues/18515
+    Playground::setup("source_redeclared_let_in_def", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[FileWithContent("foo.nu", "def foo [] { $xxx }")]);
+
+        let mut tester = test().cwd(dirs.test());
+
+        let out1: String = tester.run("let xxx = 'first'; source foo.nu; foo")?;
+        assert_eq!(out1, "first");
+
+        let out2: String = tester.run("let xxx = 'second'; source foo.nu; foo")?;
+        assert_eq!(out2, "second");
+
+        Ok(())
+    })
+}
+
+#[test]
+#[deps(NU)]
+fn source_script_def_sees_outer_let() -> Result {
+    Playground::setup("source_script_def_outer_let", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[
+            FileWithContent("foo.nu", "def foo [] { $xxx }"),
+            FileWithContent("app.nu", "let xxx = 'from-script'\nsource foo.nu\nfoo"),
+        ]);
+
+        let out: String = test().cwd(dirs.test()).run("nu app.nu | to text")?;
+        assert_eq!(out, "from-script");
+        Ok(())
+    })
+}
+
+#[test]
+fn source_same_file_does_not_multiply_decls() -> Result {
+    // Capture-free sourced files must reuse the cached block so repeated
+    // `source` does not add another `def` for the same name each time.
+    Playground::setup("source_same_file_no_multiply", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[FileWithContent(
+            "lib.nu",
+            "def shared_a [] { 0 }\ndef shared_b [] { 0 }\ndef shared_c [] { 0 }",
+        )]);
+
+        let mut tester = test().cwd(dirs.test());
+        let () = tester.run("source lib.nu")?;
+        let after_first: i64 = tester.run("scope engine-stats | get num_decls")?;
+
+        let () = tester.run("source lib.nu")?;
+        let () = tester.run("source lib.nu")?;
+        let after_more: i64 = tester.run("scope engine-stats | get num_decls")?;
+
+        assert_eq!(
+            after_first, after_more,
+            "re-sourcing a capture-free file should reuse decls, not add new ones"
+        );
+        tester.run("shared_a").expect_value_eq(0)?;
+        Ok(())
+    })
+}
+
+#[test]
 fn source_use_file_named_null() -> Result {
     Playground::setup("source_file_named_null", |dirs, sandbox| -> Result {
         sandbox.with_files(&[FileWithContent(


### PR DESCRIPTION
## Description
When running this script (below), there was a significant slowdown in parsing due to changes from #18538. The fix switched `source` / `source-env` to `parse_fresh`, which never consults the span cache. That is correct for files that close over outer `let`/`mut`. It is wasteful for files that do not, which is most library `def` files.

```nushell
# ❯ source nu115-slowdown.nu
# nu version: 0.114.1
# ╭───┬───────┬──────────────────┬──────────────────╮
# │ # │ files │      total       │     per_file     │
# ├───┼───────┼──────────────────┼──────────────────┤
# │ 0 │     1 │ 14ms 705µs 131ns │ 14ms 705µs 131ns │
# │ 1 │    10 │ 15ms 911µs 958ns │  1ms 591µs 195ns │
# │ 2 │    20 │ 19ms 861µs 105ns │       993µs 55ns │
# │ 3 │    33 │ 26ms 750µs 384ns │      810µs 617ns │
# │ 4 │    50 │ 38ms 724µs 925ns │      774µs 498ns │
# │ 5 │    63 │ 51ms 904µs 669ns │      823µs 883ns │
# ╰───┴───────┴──────────────────┴──────────────────╯

# ❯ source nu115-slowdown.nu
# nu version: 0.115.1
# ╭───┬───────┬───────────────────┬──────────────────╮
# │ # │ files │       total       │     per_file     │
# ├───┼───────┼───────────────────┼──────────────────┤
# │ 0 │     1 │  11ms 711µs 291ns │ 11ms 711µs 291ns │
# │ 1 │    10 │  38ms 981µs 814ns │  3ms 898µs 181ns │
# │ 2 │    20 │  82ms 885µs 427ns │  4ms 144µs 271ns │
# │ 3 │    33 │  191ms 51µs 643ns │  5ms 789µs 443ns │
# │ 4 │    50 │ 396ms 705µs 337ns │  7ms 934µs 106ns │
# │ 5 │    63 │ 630ms 736µs 252ns │  10ms 11µs 686ns │
# ╰───┴───────┴───────────────────┴──────────────────╯

let exe = $nu.current-exe
print $"nu version: (version | get version)"

1..300 | each {|i| $"def shared($i) [] { 0 }" } | str join (char nl) | save -f common.nu
1..63  | each {|i| $"def outer($i) [] { 0 }(char nl)source common.nu" | save -f $"f($i).nu" } | ignore

[1 10 20 33 50 63] | each {|n|
  1..$n | each {|i| $"source f($i).nu" } | str join (char nl) | save -f loader.nu
  let t = (timeit { ^$exe --no-config-file -c "source loader.nu; exit" })
  {files: $n, total: $t, per_file: ($t / $n)}
}
```

After this PR `source` / `source-env` go through `parse()` again. A cached block is reused only when it is safe. Stale captures fall through and parse fresh. That is the #18515 path. Empty-capture libraries hit the cache. That is the 0.114 path.

## User-facing changes (Release notes)

### Faster repeated `source` of the same file

0.115 started re-parsing every `source` / `source-env` of a file that had already been parsed, so configs and libraries that `source` the same helpers many times got slower as more files were loaded. A 63-file case that stayed around 50ms in 0.114 grew to hundreds of milliseconds.

After this PR `source` / `source-env` go through `parse()` again. A cached block is reused only when it is safe. Stale captures fall through and parse fresh. That is the #18515 path. Empty-capture libraries hit the cache. That is the 0.114 path.

## Additional notes
Fixes an issue reported on Discord
closes https://github.com/nushell/nushell/issues/18926