### PR TITLE
when config changes invalidate cache

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -293,8 +293,9 @@ fn is_completion_boundary(c: char) -> bool {
 
 /// The environment a cached completion was computed against.
 ///
-/// Results depend on cwd, `PATH`, and known declarations, which change between prompts
-/// while the query text does not — so the query alone is not a sound cache key.
+/// Results depend on cwd, `PATH`, known declarations, and `$env.config`, which
+/// change between prompts while the query text does not — so the query alone is
+/// not a sound cache key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CacheEnv(u64);
 
@@ -316,6 +317,8 @@ impl CacheEnv {
             .and_then(|cwd| std::fs::metadata(cwd).ok()?.modified().ok())
             .hash(&mut hasher);
         cwd.hash(&mut hasher);
+
+        engine_state.config_epoch().hash(&mut hasher);
 
         Self(hasher.finish())
     }
@@ -2124,26 +2127,33 @@ mod completer_tests {
         assert!(!engine.should_complete_on_repl_thread(&q("ls | c")));
     }
 
-    fn engine_with_external_completer() -> Arc<EngineState> {
+    fn apply_source(engine: &mut EngineState, stack: &mut Stack, source: &[u8]) {
         use nu_engine::eval_block;
         use nu_protocol::{PipelineData, debugger::WithoutDebug};
 
-        let mut engine = (*test_engine()).clone();
-        let mut stack = Stack::new();
-        let mut working_set = StateWorkingSet::new(&engine);
-        let block = parse(
-            &mut working_set,
-            None,
-            b"$env.config.completions.external.completer = {|spans| $spans}",
-            false,
+        let mut working_set = StateWorkingSet::new(engine);
+        let block = parse(&mut working_set, None, source, false);
+        assert!(
+            working_set.parse_errors.is_empty(),
+            "{:?}",
+            working_set.parse_errors
         );
-        assert!(working_set.parse_errors.is_empty());
         engine
             .merge_delta(working_set.render())
             .expect("merge_delta");
-        eval_block::<WithoutDebug>(&engine, &mut stack, &block, PipelineData::empty())
-            .expect("eval completer config");
-        engine.merge_env(&mut stack).expect("merge_env");
+        eval_block::<WithoutDebug>(engine, stack, &block, PipelineData::empty())
+            .expect("eval source");
+        engine.merge_env(stack).expect("merge_env");
+    }
+
+    fn engine_with_external_completer() -> Arc<EngineState> {
+        let mut engine = (*test_engine()).clone();
+        let mut stack = Stack::new();
+        apply_source(
+            &mut engine,
+            &mut stack,
+            b"$env.config.completions.external.completer = {|spans| $spans}",
+        );
         Arc::new(engine)
     }
 
@@ -2321,14 +2331,68 @@ mod completer_tests {
         );
     }
 
+    /// Any `$env.config` assignment, including ones that are not completion
+    /// settings, must not keep serving the previous prompt's suggestions.
+    #[rstest::rstest]
+    #[case::external_completer(
+        b"$env.config.completions.external.completer = {|spans| [from-second]}",
+        Some("from-second")
+    )]
+    #[case::unrelated_config(b"$env.config.float_precision = 5", None)]
+    fn cache_is_not_reused_after_config_changes(
+        #[case] later: &[u8],
+        #[case] expected_external: Option<&str>,
+    ) {
+        let mut engine = (*test_engine()).clone();
+        let mut stack = Stack::new();
+        apply_source(
+            &mut engine,
+            &mut stack,
+            b"$env.config.completions.external.completer = {|spans| [from-first]}",
+        );
+        let first_env = CacheEnv::of(&engine, &stack);
+        let engine = Arc::new(engine);
+        let stack = Arc::new(stack);
+        let cache = NarrowingCache::default();
+
+        let mut filling_prompt =
+            NuCompleter::with_cache(engine.clone(), stack.clone(), cache.clone());
+        assert!(!filling_prompt.complete_blocking("ls | c", 6).is_empty());
+        drop(filling_prompt);
+
+        let mut engine = (*engine).clone();
+        let mut stack = (*stack).clone();
+        apply_source(&mut engine, &mut stack, later);
+        let second_env = CacheEnv::of(&engine, &stack);
+        assert_ne!(
+            first_env, second_env,
+            "a config assignment must change the cache fingerprint"
+        );
+
+        let mut next_prompt = NuCompleter::with_cache(Arc::new(engine), Arc::new(stack), cache);
+        assert!(
+            next_prompt.complete("ls | c", 6).is_pending(),
+            "entries computed under a previous config must not answer"
+        );
+
+        if let Some(expected) = expected_external {
+            let values: Vec<_> = next_prompt
+                .complete_blocking("extcommand x", 12)
+                .iter()
+                .map(|s| s.value.clone())
+                .collect();
+            assert_eq!(values, [expected], "the newly assigned completer must run");
+        }
+    }
+
     /// `cache_size = 0` must disable the cache entirely, even a carried-over one.
     #[test]
     fn cache_size_zero_disables_the_cache() {
-        let mut engine = test_engine();
-        {
-            let state = Arc::make_mut(&mut engine);
-            Arc::make_mut(&mut state.config).completions.cache_size = 0;
-        }
+        let mut engine = (*test_engine()).clone();
+        let mut config = engine.get_config().as_ref().clone();
+        config.completions.cache_size = 0;
+        engine.set_config(config);
+        let engine = Arc::new(engine);
         let cache = NarrowingCache::default();
 
         let mut filling_prompt =

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -10,7 +10,6 @@ use nu_protocol::{
     report_parse_error, report_parse_warning,
     shell_error::generic::GenericError,
 };
-use std::sync::Arc;
 
 use crate::util::print_pipeline;
 
@@ -40,7 +39,9 @@ pub fn evaluate_commands(
     if let Some(e_style) = error_style {
         match e_style.coerce_str()?.parse() {
             Ok(e_style) => {
-                Arc::make_mut(&mut engine_state.config).error_style = e_style;
+                let mut config = engine_state.get_config().as_ref().clone();
+                config.error_style = e_style;
+                engine_state.set_config(config);
             }
             Err(err) => {
                 return Err(ShellError::Generic(GenericError::new(
@@ -55,8 +56,9 @@ pub fn evaluate_commands(
     // Parse the source code
     let (block, delta) = {
         if let Some(ref t_mode) = table_mode {
-            Arc::make_mut(&mut engine_state.config).table.mode =
-                t_mode.coerce_str()?.parse().unwrap_or_default();
+            let mut config = engine_state.get_config().as_ref().clone();
+            config.table.mode = t_mode.coerce_str()?.parse().unwrap_or_default();
+            engine_state.set_config(config);
         }
 
         let mut working_set = StateWorkingSet::new(engine_state);
@@ -107,8 +109,9 @@ pub fn evaluate_commands(
     }
 
     if let Some(t_mode) = table_mode {
-        Arc::make_mut(&mut engine_state.config).table.mode =
-            t_mode.coerce_str()?.parse().unwrap_or_default();
+        let mut config = engine_state.get_config().as_ref().clone();
+        config.table.mode = t_mode.coerce_str()?.parse().unwrap_or_default();
+        engine_state.set_config(config);
     }
 
     print_pipeline(engine_state, stack, pipeline_data, no_newline)?;

--- a/crates/nu-cli/tests/last_result.rs
+++ b/crates/nu-cli/tests/last_result.rs
@@ -63,7 +63,7 @@ impl Interactive {
     fn with_max_last_result_size(mut self, size: Filesize) -> Self {
         let mut cfg = self.engine_state.get_config().as_ref().clone();
         cfg.max_last_result_size = size;
-        self.engine_state.config = Arc::new(cfg);
+        self.engine_state.set_config(cfg);
         self
     }
 
@@ -650,7 +650,7 @@ fn snapshot_with_zero_budget_drops_last_keeps_metadata() -> Result {
 
     let mut cfg = session.engine_state.get_config().as_ref().clone();
     cfg.max_last_result_size = Filesize::ZERO;
-    session.engine_state.config = Arc::new(cfg);
+    session.engine_state.set_config(cfg);
 
     session.stack.set_last_exit_code(3, Span::test_data());
     session.snapshot_metadata(Duration::from_millis(5));

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -18,7 +18,6 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::Stdio,
-    sync::Arc,
     thread,
 };
 
@@ -515,7 +514,9 @@ fn write_pipeline_data(
         stack.start_collect_value();
 
         // Turn off color as we pass data through
-        Arc::make_mut(&mut engine_state.config).use_ansi_coloring = UseAnsiColoring::False;
+        let mut config = engine_state.get_config().as_ref().clone();
+        config.use_ansi_coloring = UseAnsiColoring::False;
+        engine_state.set_config(config);
 
         // Invoke the `table` command.
         let output =

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -919,9 +919,9 @@ mod tests {
         let mut stack = Stack::new();
 
         // force coloring on for test
-        let mut config = (*engine_state.config).clone();
+        let mut config = engine_state.get_config().as_ref().clone();
         config.use_ansi_coloring = UseAnsiColoring::True;
-        engine_state.config = Arc::new(config);
+        engine_state.set_config(config);
 
         // using Cow::Owned here to mean a match, since the content changed,
         // and borrowed to mean not a match, since the content didn't change

--- a/crates/nu-mcp/src/server.rs
+++ b/crates/nu-mcp/src/server.rs
@@ -9,7 +9,6 @@ use rmcp::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 pub struct NushellMcpServer {
     #[allow(dead_code)]
@@ -21,10 +20,10 @@ pub struct NushellMcpServer {
 impl NushellMcpServer {
     pub fn new(mut engine_state: EngineState) -> Self {
         // Configure the engine state for MCP
-        if let Some(config) = Arc::get_mut(&mut engine_state.config) {
-            config.use_ansi_coloring = UseAnsiColoring::False;
-            config.color_config.clear();
-        }
+        let mut config = engine_state.get_config().as_ref().clone();
+        config.use_ansi_coloring = UseAnsiColoring::False;
+        config.color_config.clear();
+        engine_state.set_config(config);
         NushellMcpServer {
             tool_router: Self::tool_router(),
             evaluator: Evaluator::new(engine_state),

--- a/crates/nu-protocol/src/config/ansi_coloring.rs
+++ b/crates/nu-protocol/src/config/ansi_coloring.rs
@@ -135,11 +135,10 @@ mod tests {
     #[test]
     fn test_use_ansi_coloring_true() {
         let mut engine_state = EngineState::new();
-        engine_state.config = Config {
+        engine_state.set_config(Config {
             use_ansi_coloring: UseAnsiColoring::True,
             ..Default::default()
-        }
-        .into();
+        });
 
         // explicit `True` ignores environment variables
         assert!(
@@ -182,11 +181,10 @@ mod tests {
     #[test]
     fn test_use_ansi_coloring_false() {
         let mut engine_state = EngineState::new();
-        engine_state.config = Config {
+        engine_state.set_config(Config {
             use_ansi_coloring: UseAnsiColoring::False,
             ..Default::default()
-        }
-        .into();
+        });
 
         // explicit `False` ignores environment variables
         assert!(
@@ -229,11 +227,10 @@ mod tests {
     #[test]
     fn test_use_ansi_coloring_auto() {
         let mut engine_state = EngineState::new();
-        engine_state.config = Config {
+        engine_state.set_config(Config {
             use_ansi_coloring: UseAnsiColoring::Auto,
             ..Default::default()
-        }
-        .into();
+        });
 
         // no environment variables, behavior depends on terminal state
         let is_terminal = std::io::stdout().is_terminal();
@@ -284,11 +281,10 @@ mod tests {
     #[test]
     fn test_use_ansi_coloring_auto_term_dumb() {
         let mut engine_state = EngineState::new();
-        engine_state.config = Config {
+        engine_state.set_config(Config {
             use_ansi_coloring: UseAnsiColoring::Auto,
             ..Default::default()
-        }
-        .into();
+        });
 
         // `term` set to "dumb" disables ANSI colors
         engine_state.add_env_var("term".to_string(), Value::test_string("dumb"));

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -110,7 +110,10 @@ pub struct EngineState {
     pub signal_handlers: Option<Handlers>,
     pub env_vars: Arc<EnvVars>,
     pub previous_env_vars: Arc<HashMap<EnvName, Value>>,
+    /// Live config. Replace it with [`Self::set_config`] so [`Self::config_epoch`] stays in sync.
     pub config: Arc<Config>,
+    /// Incremented when [`Self::config`] is replaced (`set_config`, `merge_env`).
+    config_epoch: u64,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_state: Arc<Mutex<ReplState>>,
     /// Shared source of truth for the interactive prompt's rendered content. The
@@ -239,6 +242,7 @@ impl EngineState {
             ),
             previous_env_vars: Arc::new(HashMap::new()),
             config: Arc::new(Config::default()),
+            config_epoch: 0,
             pipeline_externals_state: Arc::new((AtomicU32::new(0), AtomicU32::new(0))),
             repl_state: Arc::new(Mutex::new(ReplState {
                 buffer: "".to_string(),
@@ -445,7 +449,7 @@ impl EngineState {
 
         if let Some(config) = stack.config.take() {
             // If config was updated in the stack, replace it.
-            self.config = config;
+            self.replace_config(config);
 
             // Make plugin GC config changes take effect immediately.
             #[cfg(feature = "plugin")]
@@ -881,6 +885,16 @@ impl EngineState {
         &self.config
     }
 
+    /// Identity of the current config object. Changes when `$env.config` is rewritten.
+    pub fn config_epoch(&self) -> u64 {
+        self.config_epoch
+    }
+
+    fn replace_config(&mut self, conf: Arc<Config>) {
+        self.config_epoch = self.config_epoch.wrapping_add(1);
+        self.config = conf;
+    }
+
     pub fn set_config(&mut self, conf: impl Into<Arc<Config>>) {
         let conf = conf.into();
 
@@ -890,7 +904,7 @@ impl EngineState {
             self.update_plugin_gc_configs(&conf.plugin_gc);
         }
 
-        self.config = conf;
+        self.replace_config(conf);
     }
 
     /// Fetch the configuration for a plugin

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -17,7 +17,6 @@ use std::{
     io::{Result, Write},
     panic::{AssertUnwindSafe, catch_unwind},
     path::Path,
-    sync::Arc,
 };
 
 const LOGINSHELL_FILE: &str = "login.nu";
@@ -353,6 +352,6 @@ pub(crate) fn setup_config(
         eprintln!(
             "A panic occurred while reading configuration files, using default configuration."
         );
-        engine_state.config = Arc::new(Config::default())
+        engine_state.set_config(Config::default())
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -14,7 +14,6 @@ use nu_protocol::{
 };
 use nu_utils::perf;
 use nu_utils::time::Instant;
-use std::sync::Arc;
 
 pub(crate) fn run_commands(
     engine_state: &mut EngineState,
@@ -190,7 +189,9 @@ pub(crate) fn run_file(
         && let Ok(s) = t_mode.coerce_str()
         && let Ok(mode) = s.parse()
     {
-        Arc::make_mut(&mut engine_state.config).table.mode = mode;
+        let mut config = engine_state.get_config().as_ref().clone();
+        config.table.mode = mode;
+        engine_state.set_config(config);
     }
 
     let start_time = Instant::now();
@@ -241,7 +242,9 @@ pub(crate) fn run_repl(
         && let Ok(s) = t_mode.coerce_str()
         && let Ok(mode) = s.parse()
     {
-        Arc::make_mut(&mut engine_state.config).table.mode = mode;
+        let mut config = engine_state.get_config().as_ref().clone();
+        config.table.mode = mode;
+        engine_state.set_config(config);
     }
 
     let start_time = Instant::now();

--- a/tests/repl/test_custom_commands.rs
+++ b/tests/repl/test_custom_commands.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use nu_protocol::{ParseError, ShellError, Type};
 use nu_test_support::prelude::*;
 use pretty_assertions::assert_matches;
@@ -254,8 +252,9 @@ fn override_table_eval_file() -> Result {
 #[test]
 fn infinite_recursion_does_not_panic() -> Result {
     let mut tester = test();
-    let config = Arc::make_mut(&mut tester.engine_state.config);
+    let mut config = tester.engine_state.get_config().as_ref().clone();
     config.recursion_limit = 5;
+    tester.engine_state.set_config(config);
     let err = tester
         .run("def bang [] { bang }; bang")
         .expect_shell_error()?;
@@ -272,8 +271,9 @@ fn infinite_recursion_does_not_panic() -> Result {
 #[test]
 fn infinite_mutual_recursion_does_not_panic() -> Result {
     let mut tester = test();
-    let config = Arc::make_mut(&mut tester.engine_state.config);
+    let mut config = tester.engine_state.get_config().as_ref().clone();
     config.recursion_limit = 5;
+    tester.engine_state.set_config(config);
     let err = tester
         .run("def bang [] { def boom [] { bang }; boom }; bang")
         .expect_shell_error()?;


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
We noticed that when changing the completer, it seemed to accept the change but use the cached version.
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->

## User-facing changes (Release notes)
Invalidate the config any time anything changes under $env.config
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->