### PR TITLE
MCP: set default bind host to 127.0.0.1

### DIFF
--- a/crates/nu-mcp/src/lib.rs
+++ b/crates/nu-mcp/src/lib.rs
@@ -33,9 +33,21 @@ pub enum McpTransport {
     Stdio,
     /// HTTP transport with SSE streaming
     Http {
+        /// Address to bind to (default: 127.0.0.1)
+        bind_host: String,
         /// Port to listen on
-        port: u16,
+        bind_port: u16,
     },
+}
+
+impl McpTransport {
+    /// Create a new MCP transport configuration for HTTP
+    pub fn http(bind_address: Option<String>, port: Option<u16>) -> Self {
+        McpTransport::Http {
+            bind_host: bind_address.unwrap_or("127.0.0.1".into()),
+            bind_port: port.unwrap_or(8080),
+        }
+    }
 }
 
 pub fn initialize_mcp_server(
@@ -84,7 +96,13 @@ pub fn initialize_mcp_server(
     runtime.block_on(async {
         let result = match transport {
             McpTransport::Stdio => run_stdio_server(engine_state).await,
-            McpTransport::Http { port } => run_http_server(engine_state, port).await,
+            McpTransport::Http {
+                bind_host,
+                bind_port,
+            } => {
+                let addr = format!("{bind_host}:{bind_port}");
+                run_http_server(engine_state, &addr).await
+            }
         };
         if let Err(e) = result {
             tracing::error!("Error running MCP server: {:?}", e);
@@ -113,7 +131,7 @@ const SESSION_CHANNEL_CAPACITY: usize = 16;
 
 async fn run_http_server(
     engine_state: EngineState,
-    port: u16,
+    bind_address: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine_state = Arc::new(engine_state);
 
@@ -137,10 +155,9 @@ async fn run_http_server(
         StreamableHttpServerConfig::default(),
     ));
 
-    let addr = format!("0.0.0.0:{port}");
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    tracing::info!("MCP HTTP server listening on http://{addr}");
-    eprintln!("MCP HTTP server listening on http://{addr}");
+    let listener = tokio::net::TcpListener::bind(bind_address).await?;
+    tracing::info!("MCP HTTP server listening on http://{bind_address}");
+    eprintln!("MCP HTTP server listening on http://{bind_address}");
 
     loop {
         let io = tokio::select! {

--- a/src/command.rs
+++ b/src/command.rs
@@ -396,6 +396,15 @@ const CLI_FLAGS: &[CliFlag] = &[
         CliCategory::Startup,
         "nu --mcp --mcp-transport http --mcp-port 3000",
     ),
+    #[cfg(feature = "mcp")]
+    CliFlag::value(
+        "mcp-host",
+        None,
+        ValueHint::String,
+        "host for MCP HTTP transhost (default 127.0.0.1)",
+        CliCategory::Startup,
+        "nu --mcp --mcp-transhost http --mcp-host 0.0.0.0",
+    ),
 ];
 
 // Container for parsed CLI values before conversion to NushellCliArgs.
@@ -439,6 +448,8 @@ struct CliValues {
     mcp_transport: Option<Spanned<String>>,
     #[cfg(feature = "mcp")]
     mcp_port: Option<u16>,
+    #[cfg(feature = "mcp")]
+    mcp_host: Option<String>,
 }
 
 // Error type for CLI parsing with optional help text.
@@ -777,6 +788,8 @@ pub(crate) fn parse_cli_args(args: Vec<OsString>) -> Result<ParsedCli, CliError>
             mcp_transport: cli.mcp_transport,
             #[cfg(feature = "mcp")]
             mcp_port: cli.mcp_port,
+            #[cfg(feature = "mcp")]
+            mcp_host: cli.mcp_host,
         },
         script_name,
         args_to_script,
@@ -1447,6 +1460,8 @@ pub(crate) struct NushellCliArgs {
     pub(crate) mcp_transport: Option<Spanned<String>>,
     #[cfg(feature = "mcp")]
     pub(crate) mcp_port: Option<u16>,
+    #[cfg(feature = "mcp")]
+    pub(crate) mcp_host: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,10 +603,10 @@ fn main() -> Result<()> {
             );
         }
         let transport = match mcp_transport_kind {
-            Some("http") => {
-                let port = parsed_nu_cli_args.mcp_port.unwrap_or(8080);
-                nu_mcp::McpTransport::Http { port }
-            }
+            Some("http") => nu_mcp::McpTransport::http(
+                parsed_nu_cli_args.mcp_host.clone(),
+                parsed_nu_cli_args.mcp_port,
+            ),
             _ => nu_mcp::McpTransport::Stdio,
         };
         nu_mcp::initialize_mcp_server(engine_state, transport)?;


### PR DESCRIPTION
## Description

Previously when using the http transport the mcp server defaulted to binding to all interfaces (0.0.0.0). Changed the behavior to only bind to the local interface (127.0.0.1). This is to prevent other hosts on the network from binding to the mcp server and executing commands.

## User-facing changes (Release notes)

All interfaces aren't bound now
