### PR TITLE
each while: preserve errors instead of silently stopping

### DIFF
--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -85,7 +85,7 @@ impl Command for EachWhile {
                             .and_then(|data| data.into_value(head))
                         {
                             Ok(value) => (!value.is_nothing()).then_some(value),
-                            Err(_) => None,
+                            Err(error) => Some(Value::error(error, head)),
                         }
                     })
                     .fuse()
@@ -96,15 +96,15 @@ impl Command for EachWhile {
                 if let Some(chunks) = stream.chunks() {
                     let mut closure = ClosureEval::new(engine_state, stack, closure);
                     Ok(chunks
-                        .map_while(move |value| {
-                            let value = value.ok()?;
-                            match closure
+                        .map_while(move |value| match value {
+                            Ok(value) => match closure
                                 .run_with_value(value)
                                 .and_then(|data| data.into_value(span))
                             {
                                 Ok(value) => (!value.is_nothing()).then_some(value),
-                                Err(_) => None,
-                            }
+                                Err(error) => Some(Value::error(error, span)),
+                            },
+                            Err(error) => Some(Value::error(error, span)),
                         })
                         .fuse()
                         .into_pipeline_data(head, engine_state.signals().clone()))

--- a/crates/nu-cmd-extra/tests/commands/filters/each_while.rs
+++ b/crates/nu-cmd-extra/tests/commands/filters/each_while.rs
@@ -1,0 +1,15 @@
+use nu_test_support::prelude::*;
+
+#[test]
+fn each_while_preserves_closure_errors() -> Result {
+    let err = test()
+        .run(
+            r#"[1 2 3] | each while {|x|
+                if $x == 2 { error make {msg: "boom"} } else { $x }
+            }"#,
+        )
+        .expect_shell_error()?;
+
+    assert_contains("boom", format!("{err:?}"));
+    Ok(())
+}

--- a/crates/nu-cmd-extra/tests/commands/filters/mod.rs
+++ b/crates/nu-cmd-extra/tests/commands/filters/mod.rs
@@ -1,0 +1,1 @@
+mod each_while;

--- a/crates/nu-cmd-extra/tests/commands/mod.rs
+++ b/crates/nu-cmd-extra/tests/commands/mod.rs
@@ -1,2 +1,3 @@
 mod bits;
 mod bytes;
+mod filters;


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
<!--
Explain what this PR does and why.

This section is intentionally flexible:
- Describe the problem
- Explain your approach
- Include technical details if relevant

Good examples:
- "In this PR, I fixed..."
- "In this PR, I added support for..."
- "This change improves X by..."

Write as much or as little as needed for reviewers to understand your changes.
-->



In this PR, I fixed an issue where `each while` silently treated closure and ByteStream errors as the end of iteration.

`each while` uses `map_while`, where returning `None` means that iteration has finished. The previous implementation converted both closure errors and ByteStream chunk errors into `None`, causing errors to be lost and output to be silently truncated.

The implementation now preserves these errors as `Value::error`. Only `Value::Nothing` stops iteration.

A regression test covers closure errors:

```nushell
[1 2 3] | each while {|x|
    if $x == 2 {
        error make {msg: "boom"}
    } else {
        $x
    }
}
```




## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

Fixed an issue where each while silently stopped when the closure or input ByteStream produced an error. These errors are now preserved and reported.


## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->

Added a regression test for closure error handling.