### PR TITLE
Reject excessively nested input instead of overflowing the parser stack

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -483,6 +483,10 @@ struct Completed {
     cacheable: bool,
 }
 
+/// Stack for threads whose work is parsing The `MAX_PARSE_NESTING_DEPTH` limit alone is not
+/// enough compilation and capture discovery recurse over the same tree afterwards
+const PARSER_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
 struct CompletionWorker {
     request_tx: mpsc::Sender<CompletionQuery>,
     result_rx: mpsc::Receiver<Completed>,
@@ -1862,12 +1866,12 @@ impl NuCompleter {
             .narrowed_fallback(query, self.cache_env, self.engine.options())
     }
 
-    fn spawn_worker(engine: &CompletionEngine) -> CompletionWorker {
+    fn spawn_worker(engine: &CompletionEngine) -> Option<CompletionWorker> {
         let (request_tx, request_rx) = mpsc::channel::<CompletionQuery>();
         let (result_tx, result_rx) = mpsc::channel::<Completed>();
 
         let engine = engine.to_background();
-        thread::spawn(move || {
+        let complete = move || {
             while let Ok(mut query) = request_rx.recv() {
                 while let Ok(newer) = request_rx.try_recv() {
                     query = newer;
@@ -1883,14 +1887,18 @@ impl NuCompleter {
                     return;
                 }
             }
-        });
+        };
+        thread::Builder::new()
+            .stack_size(PARSER_WORKER_STACK_SIZE)
+            .spawn(complete)
+            .ok()?;
 
-        CompletionWorker {
+        Some(CompletionWorker {
             request_tx,
             result_rx,
             pending: None,
             latest: None,
-        }
+        })
     }
 
     fn fold_completed(&mut self, done: Completed) -> bool {
@@ -2020,11 +2028,13 @@ impl ReedlineCompleter for NuCompleter {
         let fallback = self.stale_fallback(&query);
         let partial = partial_of(line, &fallback);
 
-        let worker = self
-            .worker
-            .get_or_insert_with(|| Self::spawn_worker(&self.engine));
+        if self.worker.is_none() {
+            self.worker = Self::spawn_worker(&self.engine);
+        }
 
-        if worker.pending.as_ref() != Some(&query) {
+        if let Some(worker) = self.worker.as_mut()
+            && worker.pending.as_ref() != Some(&query)
+        {
             if worker.request_tx.send(query.clone()).is_ok() {
                 worker.pending = Some(query);
             } else {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod format_conversions;
+mod parser_nesting_lifecycle;
 mod requires_ast_for_arguments;
 
 #[macro_use]

--- a/crates/nu-command/tests/parser_nesting_lifecycle.rs
+++ b/crates/nu-command/tests/parser_nesting_lifecycle.rs
@@ -1,0 +1,103 @@
+//! Report-once state for `ParseError::NestingTooDeep` when `source` re-enters the parser through
+//! `parse_fresh` mid-parse Lives here rather than in `nu-parser` because a real `source` needs
+//! the shell command context
+
+use nu_protocol::{ParseError, Value, engine::StateWorkingSet};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn deep_parens() -> String {
+    format!("{}1{}", "(".repeat(200), ")".repeat(200))
+}
+
+fn deep_lists() -> String {
+    format!("{}{}", "[".repeat(200), "]".repeat(200))
+}
+
+/// Parses `parent` with `child.nu` beside it returning the opening delimiter of each nesting
+/// diagnostic `[` from the list-nested source `(` from the paren-nested one Runs on a worker
+/// with a production-sized parser stack since reaching the nesting limit costs more recursion
+/// than a default test thread holds in a debug build
+fn nesting_diagnostic_delimiters(parent: &str, child: &str) -> Vec<char> {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nu_nesting_lifecycle_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    std::fs::write(dir.join("child.nu"), child).expect("write child");
+
+    let parent = parent.to_string();
+    let scan_dir = dir.clone();
+    let delimiters = std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            let engine_state = nu_cmd_lang::create_default_context();
+            let mut engine_state = nu_command::add_shell_command_context(engine_state);
+            engine_state.add_env_var("PWD".into(), Value::test_string(scan_dir.to_string_lossy()));
+
+            let mut working_set = StateWorkingSet::new(&engine_state);
+            nu_parser::parse(
+                &mut working_set,
+                Some("parent.nu"),
+                parent.as_bytes(),
+                false,
+            );
+
+            working_set
+                .parse_errors
+                .iter()
+                .filter_map(|err| match err {
+                    ParseError::NestingTooDeep(span) => working_set
+                        .get_span_contents(*span)
+                        .first()
+                        .map(|byte| *byte as char),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+        .expect("spawn parser worker")
+        .join()
+        .expect("parser worker finished");
+
+    let _ = std::fs::remove_dir_all(&dir);
+    delimiters
+}
+
+/// The parent reports before sourcing the child and must not report a second time afterwards
+#[test]
+fn nested_source_keeps_parent_report_state() {
+    let parent = format!("{}\nsource child.nu\n{}", deep_lists(), deep_lists());
+    let delimiters = nesting_diagnostic_delimiters(&parent, &deep_parens());
+
+    assert_eq!(
+        delimiters,
+        vec!['[', '('],
+        "expected one diagnostic for the parent and one for the child"
+    );
+}
+
+#[test]
+fn nested_source_does_not_consume_parent_report_state() {
+    let parent = format!("source child.nu\n{}", deep_lists());
+    let delimiters = nesting_diagnostic_delimiters(&parent, &deep_parens());
+
+    assert_eq!(
+        delimiters,
+        vec!['(', '['],
+        "child reported first, then the parent reported its own"
+    );
+}
+
+/// A shallow child must not clear the parents report state and re-enable a second diagnostic
+#[test]
+fn shallow_child_does_not_reset_parent_report_state() {
+    let parent = format!("{}\nsource child.nu\n{}", deep_lists(), deep_lists());
+    let delimiters = nesting_diagnostic_delimiters(&parent, "[1 2 3] | length");
+
+    assert_eq!(
+        delimiters,
+        vec!['['],
+        "one diagnostic for the parent, none added by the shallow child"
+    );
+}

--- a/crates/nu-lsp/src/workspace.rs
+++ b/crates/nu-lsp/src/workspace.rs
@@ -22,6 +22,10 @@ use std::{
     sync::Arc,
 };
 
+/// Stack for threads whose work is parsing The `MAX_PARSE_NESTING_DEPTH` limit alone is not
+/// enough compilation and capture discovery recurse over the same tree afterwards
+const PARSER_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
 /// Message type indicating ranges of interest in each doc
 #[derive(Debug)]
 pub(crate) struct RangePerDoc {
@@ -449,7 +453,7 @@ impl LanguageServer {
         let text_documents = self.docs.clone();
         self.send_progress_begin(token.clone(), message)?;
 
-        std::thread::spawn(move || -> Result<()> {
+        let scan_workspace = move || -> Result<()> {
             let mut working_set = StateWorkingSet::new(&engine_state);
             let mut scripts: HashSet<_> = match find_nu_scripts_in_folder(&workspace_uri) {
                 Ok(it) => it,
@@ -544,7 +548,11 @@ impl LanguageServer {
             data_sender
                 .send(InternalMessage::Finished(token))
                 .into_diagnostic()
-        });
+        };
+        std::thread::Builder::new()
+            .stack_size(PARSER_WORKER_STACK_SIZE)
+            .spawn(scan_workspace)
+            .into_diagnostic()?;
         Ok((cancel_sender, Arc::new(data_receiver)))
     }
 
@@ -572,6 +580,40 @@ mod tests {
     };
     use nu_test_support::prelude::*;
     use rstest::rstest;
+
+    #[test]
+    fn parser_worker_stack_fits_the_nesting_limit() {
+        use nu_protocol::ParseError;
+        use nu_protocol::engine::{EngineState, StateWorkingSet};
+
+        fn parse_nested_on_worker(depth: usize) -> Vec<ParseError> {
+            let source = format!("{}{}", "[".repeat(depth), "]".repeat(depth));
+            std::thread::Builder::new()
+                .stack_size(super::PARSER_WORKER_STACK_SIZE)
+                .spawn(move || {
+                    let engine_state = EngineState::new();
+                    let mut working_set = StateWorkingSet::new(&engine_state);
+                    nu_parser::parse(&mut working_set, None, source.as_bytes(), false);
+                    working_set.parse_errors
+                })
+                .expect("spawn parser worker")
+                .join()
+                .expect("parser worker finished")
+        }
+
+        // Find the boundary by behaviour rather than reading the parsers limit
+        let mut refused = 1;
+        while parse_nested_on_worker(refused).is_empty() {
+            refused += 1;
+            assert!(refused < 1024, "parser accepted implausibly deep nesting");
+        }
+
+        assert!(parse_nested_on_worker(refused - 1).is_empty());
+        assert!(matches!(
+            parse_nested_on_worker(refused).as_slice(),
+            [ParseError::NestingTooDeep(_)]
+        ));
+    }
 
     // Helper functions to reduce JSON duplication
     fn make_range(

--- a/crates/nu-parser/src/parse_captures_compile.rs
+++ b/crates/nu-parser/src/parse_captures_compile.rs
@@ -713,6 +713,18 @@ fn parse_with_block_cache(
         }
     }
 
+    // `source` re-enters this function while its parent parse is still running
+    working_set.with_source_nesting_report(|working_set| {
+        parse_source_contents(working_set, contents, new_span, scoped)
+    })
+}
+
+fn parse_source_contents(
+    working_set: &mut StateWorkingSet,
+    contents: &[u8],
+    new_span: Span,
+    scoped: bool,
+) -> Arc<Block> {
     // Only blocks created by this parse. Older delta entries already have captures.
     let first_new_delta_block = working_set.delta.blocks.len();
 

--- a/crates/nu-parser/src/parse_expressions.rs
+++ b/crates/nu-parser/src/parse_expressions.rs
@@ -825,7 +825,23 @@ pub fn parse_closure_expression(
     Expression::new(working_set, Expr::Closure(block_id), span, Type::Closure)
 }
 
+/// Depth-guards the value recursion nested lists and records never reach [`parse_block`]s guard
 pub fn parse_value(
+    working_set: &mut StateWorkingSet,
+    span: Span,
+    shape: &SyntaxShape,
+    input_type: Option<&Type>,
+) -> Expression {
+    if !working_set.enter_nesting(span) {
+        return garbage(working_set, span);
+    }
+
+    let expression = parse_value_inner(working_set, span, shape, input_type);
+    working_set.exit_nesting();
+    expression
+}
+
+fn parse_value_inner(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,

--- a/crates/nu-parser/src/parse_pipelines.rs
+++ b/crates/nu-parser/src/parse_pipelines.rs
@@ -126,7 +126,33 @@ pub fn parse_pipeline(
     }
 }
 
+/// A root of the parsers mutual recursion so blocks closures and subexpressions are held to
+/// `MAX_PARSE_NESTING_DEPTH` here rather than at each recursive construct
 pub fn parse_block(
+    working_set: &mut StateWorkingSet,
+    tokens: &[Token],
+    span: Span,
+    scoped: bool,
+    is_subexpression: bool,
+    input_type: Option<&Type>,
+) -> Block {
+    if !working_set.enter_nesting(span) {
+        return Block::new();
+    }
+
+    let block = parse_block_inner(
+        working_set,
+        tokens,
+        span,
+        scoped,
+        is_subexpression,
+        input_type,
+    );
+    working_set.exit_nesting();
+    block
+}
+
+fn parse_block_inner(
     working_set: &mut StateWorkingSet,
     tokens: &[Token],
     span: Span,

--- a/crates/nu-parser/src/parse_shape_specs.rs
+++ b/crates/nu-parser/src/parse_shape_specs.rs
@@ -17,7 +17,23 @@ pub fn parse_type(working_set: &mut StateWorkingSet, bytes: &[u8], span: Span) -
 /// Parse the literals of [`Type`]-like [`SyntaxShape`]s including inner types.
 ///
 /// NOTE: Does not provide a mapping to every [`SyntaxShape`]
+///
+/// Depth-guards the shape recursion inner types of `list<...>` never reach `parse_block`s guard
 pub fn parse_shape_name(
+    working_set: &mut StateWorkingSet,
+    bytes: &[u8],
+    span: Span,
+) -> SyntaxShape {
+    if !working_set.enter_nesting(span) {
+        return SyntaxShape::Any;
+    }
+
+    let shape = parse_shape_name_inner(working_set, bytes, span);
+    working_set.exit_nesting();
+    shape
+}
+
+fn parse_shape_name_inner(
     working_set: &mut StateWorkingSet,
     bytes: &[u8],
     span: Span,

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -3792,3 +3792,90 @@ fn empty_and_complete_lines_error_kinds() {
         unclosed.parse_errors
     );
 }
+
+/// Parsing at the nesting limit needs more stack than a default test thread has because parsing
+/// is followed by recursive compilation and capture discovery over the same syntax tree
+fn on_parser_thread<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn parser thread")
+        .join()
+        .expect("parser thread finished")
+}
+
+fn nesting_error_spans(working_set: &StateWorkingSet) -> Vec<Span> {
+    working_set
+        .parse_errors
+        .iter()
+        .filter_map(|err| match err {
+            ParseError::NestingTooDeep(span) => Some(*span),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The LSP workspace scan parses every file in a folder through one working set
+#[test]
+fn nesting_diagnostic_is_reported_for_each_source() {
+    let (first, shallow_added, spans) = on_parser_thread(|| {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let deep = format!("{}{}", "[".repeat(200), "]".repeat(200));
+
+        parse(&mut working_set, Some("first.nu"), deep.as_bytes(), false);
+        let first = nesting_error_spans(&working_set).len();
+
+        // A shallow source in between must still parse This also shows the depth counter
+        // unwound a leaked depth would make even this trivial source hit the limit
+        let before = working_set.parse_errors.len();
+        parse(
+            &mut working_set,
+            Some("shallow.nu"),
+            b"[1 2 3] | length",
+            false,
+        );
+        let shallow_added = working_set.parse_errors.len() - before;
+
+        parse(&mut working_set, Some("second.nu"), deep.as_bytes(), false);
+        (first, shallow_added, nesting_error_spans(&working_set))
+    });
+
+    assert_eq!(first, 1, "first source reports one nesting error");
+    assert_eq!(shallow_added, 0, "shallow source parses cleanly");
+    assert_eq!(spans.len(), 2, "second source reports its own diagnostic");
+    assert!(spans[1].start > spans[0].start, "spans track their source");
+}
+
+#[test]
+fn one_nesting_diagnostic_per_source_with_several_deep_branches() {
+    let count = on_parser_thread(|| {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let deep = format!("{}{}", "[".repeat(200), "]".repeat(200));
+        parse(
+            &mut working_set,
+            Some("two_branches.nu"),
+            format!("{deep}\n{deep}").as_bytes(),
+            false,
+        );
+        nesting_error_spans(&working_set).len()
+    });
+
+    assert_eq!(count, 1);
+}
+
+/// `parse_paren_expr` speculatively parses and truncates `parse_errors` on failure so a nesting
+/// diagnostic discarded by that rollback must not silence the retry
+#[test]
+fn nesting_diagnostic_survives_speculative_rollback() {
+    let count = on_parser_thread(|| {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        let deep = format!("$\"{}1{}\"", "(1 + ".repeat(200), ")".repeat(200));
+        parse(&mut working_set, Some("interp.nu"), deep.as_bytes(), false);
+        nesting_error_spans(&working_set).len()
+    });
+
+    assert_eq!(count, 1);
+}

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -18,6 +18,12 @@ use std::{
 #[cfg(feature = "plugin")]
 use crate::{PluginIdentity, PluginRegistryItem, RegisteredPlugin};
 
+/// How deep the recursive-descent parser may nest before rejecting input
+///
+/// Without this bound deep enough input would exhaust the native stack instead of producing a
+/// diagnostic Parser threads size their stacks for it `PARSER_WORKER_STACK_SIZE`
+const MAX_PARSE_NESTING_DEPTH: usize = 64;
+
 /// A temporary extension to the global state. This handles bridging between the global state and the
 /// additional declarations and scope changes that are not yet part of the global scope.
 ///
@@ -37,6 +43,9 @@ pub struct StateWorkingSet<'a> {
     pub parse_errors: Vec<ParseError>,
     pub parse_warnings: Vec<ParseWarning>,
     pub compile_errors: Vec<CompileError>,
+    nesting_depth: usize,
+    /// Whether [`MAX_PARSE_NESTING_DEPTH`] has already been reported for this source
+    reported_nesting_limit: bool,
 }
 
 impl<'a> StateWorkingSet<'a> {
@@ -57,6 +66,8 @@ impl<'a> StateWorkingSet<'a> {
             parse_errors: vec![],
             parse_warnings: vec![],
             compile_errors: vec![],
+            nesting_depth: 0,
+            reported_nesting_limit: false,
         }
     }
 
@@ -70,6 +81,43 @@ impl<'a> StateWorkingSet<'a> {
 
     pub fn warning(&mut self, parse_warning: ParseWarning) {
         self.parse_warnings.push(parse_warning)
+    }
+
+    /// Descend one level of structural nesting
+    ///
+    /// Returns `false` once [`MAX_PARSE_NESTING_DEPTH`] is reached in which case the caller must
+    /// yield a placeholder rather than recurse and must not call [`Self::exit_nesting`] The
+    /// nesting error is recorded only once per source so that a single over-deep expression cannot
+    /// emit a diagnostic per remaining level
+    pub fn enter_nesting(&mut self, span: Span) -> bool {
+        if self.nesting_depth >= MAX_PARSE_NESTING_DEPTH {
+            if !self.reported_nesting_limit {
+                self.reported_nesting_limit = true;
+                // The full expression can run to the end of the input which makes for an
+                // unreadable label and does not survive being re-based into nuon text
+                let start = Span::new(span.start, span.end.min(span.start + 1));
+                self.error(ParseError::NestingTooDeep(start));
+            }
+            return false;
+        }
+
+        self.nesting_depth += 1;
+        true
+    }
+
+    pub fn exit_nesting(&mut self) {
+        self.nesting_depth = self.nesting_depth.saturating_sub(1);
+    }
+
+    /// Run `parse` with its own nesting report-once state restoring the callers afterwards
+    ///
+    /// One working set spans many parses the LSP scans a whole workspace through one and
+    /// `source` parses a nested file while its parent parse is still running
+    pub fn with_source_nesting_report<T>(&mut self, parse: impl FnOnce(&mut Self) -> T) -> T {
+        let enclosing = std::mem::replace(&mut self.reported_nesting_limit, false);
+        let parsed = parse(self);
+        self.reported_nesting_limit = enclosing;
+        parsed
     }
 
     pub fn num_files(&self) -> usize {

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -76,6 +76,15 @@ pub enum ParseError {
         String,
     ),
 
+    #[error("Nesting level too deep.")]
+    #[diagnostic(
+        code(nu::parser::nesting_too_deep),
+        help(
+            "Deeply nested code has to be broken up into smaller pieces, such as separate commands or variables."
+        )
+    )]
+    NestingTooDeep(#[label("nested too deeply")] Span),
+
     #[error("Parse mismatch: expected {0}.")]
     #[diagnostic(
         code(nu::parser::parse_mismatch),
@@ -711,6 +720,7 @@ impl ParseError {
             // Jump-to-error: prefer where the closer was expected (mid-file or EOF).
             ParseError::Unclosed(_, _open, end, _) => *end,
             ParseError::Unbalanced(_, _, close, _) => *close,
+            ParseError::NestingTooDeep(s) => *s,
             ParseError::Expected(_, s) => *s,
             ParseError::ExpectedWithStringMsg(_, s) => *s,
             ParseError::ExpectedWithDidYouMean(_, _, s) => *s,

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -968,6 +968,119 @@ fn performance_nested_modules() -> Result {
     Ok(())
 }
 
+// Parser nesting depth https://github.com/nushell/nushell/issues/15241
+//
+// The parser is recursive descent so structural nesting costs native stack frames The cases
+// below run `nu` as a child process on purpose An unguarded parser aborts the process outright
+// instead of reporting an error and reaching the limit still descends that far which is more
+// than the stack of a test worker thread can hold in a debug build
+
+/// The reproduction from the issue
+#[test]
+#[deps(NU)]
+fn deeply_nested_blocks_do_not_overflow_the_stack() -> Result {
+    Playground::setup("deeply_nested_blocks", |dirs, sandbox| -> Result {
+        let source = "{".repeat(2000);
+        sandbox.with_files(&[Stub::FileWithContent("deep.nu", &source)]);
+
+        let result: CompleteResult = test().cwd(dirs.test()).run("nu deep.nu | complete")?;
+
+        assert_eq!(result.exit_code, 1);
+        assert_contains("nu::parser::unclosed_delimiter", result.stderr);
+        Ok(())
+    })
+}
+
+/// Every recursive route through the parser is held to the same limit and each of these inputs
+/// overflowed the stack before that limit existed
+#[test]
+#[deps(NU)]
+fn excessive_nesting_is_rejected_on_every_recursion_route() -> Result {
+    let deep = |part: &str| part.repeat(200);
+    let routes = [
+        ("block.nu", format!("{}{}", deep("{"), deep("}"))),
+        ("list.nu", format!("{}{}", deep("["), deep("]"))),
+        ("record.nu", format!("{}1{}", deep("{a:"), deep("}"))),
+        ("table.nu", format!("[[c]; [{}{}]]", deep("["), deep("]"))),
+        ("parentheses.nu", format!("{}1{}", deep("("), deep(")"))),
+        ("closure.nu", format!("{}{}", deep("{||"), deep("}"))),
+        (
+            "interpolation.nu",
+            format!(r#"$"{}1{}""#, deep("(1 + "), deep(")")),
+        ),
+        (
+            "external.nu",
+            format!("^foo {}1{}", deep("(^foo "), deep(")")),
+        ),
+        (
+            "nuon.nu",
+            format!("'{}{}' | from nuon", deep("["), deep("]")),
+        ),
+    ];
+
+    Playground::setup("excessive_nesting_routes", |dirs, sandbox| -> Result {
+        let stubs: Vec<_> = routes
+            .iter()
+            .map(|(name, source)| Stub::FileWithContent(name, source))
+            .collect();
+        sandbox.with_files(&stubs);
+
+        let mut tester = test().cwd(dirs.test());
+        for (name, _) in &routes {
+            let result: CompleteResult = tester.run(format!("nu {name} | complete"))?;
+
+            assert_eq!(result.exit_code, 1, "{name} should have been rejected");
+            // `from nuon` reports through its own diagnostic so match the message rather than
+            // the error code which the boundary test below covers
+            assert_contains("Nesting level too deep", result.stderr);
+        }
+        Ok(())
+    })
+}
+
+/// Nesting a real program might use keeps working excessive nesting is refused rather than
+/// crashing The exact boundary is pinned by nu-lsps parser-worker test
+#[test]
+#[deps(NU)]
+fn ordinary_nesting_accepted_and_excessive_refused() -> Result {
+    let nested = |depth: usize| format!("{}{}", "[".repeat(depth), "]".repeat(depth));
+    let below = nested(32);
+    let at = nested(200);
+
+    Playground::setup("nesting_boundary", |dirs, sandbox| -> Result {
+        sandbox.with_files(&[
+            Stub::FileWithContent("below.nu", &below),
+            Stub::FileWithContent("at.nu", &at),
+        ]);
+
+        let mut tester = test().cwd(dirs.test());
+
+        let below: CompleteResult = tester.run("nu below.nu | complete")?;
+        assert_eq!(below.exit_code, 0);
+        assert_contains_not("nesting_too_deep", below.stderr);
+
+        let at: CompleteResult = tester.run("nu at.nu | complete")?;
+        assert_eq!(at.exit_code, 1);
+        assert_contains("nu::parser::nesting_too_deep", at.stderr);
+        Ok(())
+    })
+}
+
+/// Shallow malformed input keeps its own diagnostic instead of being blamed on nesting
+#[test]
+fn shallow_unclosed_delimiter_keeps_its_diagnostic() -> Result {
+    let err = test().run("[1 2").expect_parse_error()?;
+    assert_matches!(err, ParseError::Unclosed(delimiter, ..) if delimiter == "]");
+    Ok(())
+}
+
+#[test]
+fn ordinary_nesting_still_parses() -> Result {
+    test()
+        .run("[[a b]; [1 2] [3 4]] | each {|row| {sum: ($row.a + $row.b)} } | get sum | math sum")
+        .expect_value_eq(10)
+}
+
 #[test]
 fn unary_not_1() -> Result {
     test().run("not false").expect_value_eq(true)


### PR DESCRIPTION
## Description

Nushell’s parser uses recursive descent, so deeply nested code or data could exhaust the native stack and terminate the process without producing a parser diagnostic. This also affected data parsed through `from nuon`.

This change adds a nesting depth counter to `StateWorkingSet` and enforces it at the three roots of the parser’s mutual recursion:

* `parse_value` for lists, records and tables
* `parse_block` for blocks, closures, subexpressions and interpolation
* `parse_shape_name` for nested type shapes

The limit is 64. When exceeded, the parser reports one `NestingTooDeep` error per source and returns a placeholder instead of continuing to recurse. The report state is scoped so sequential files and nested `source` or `source-env` operations receive independent diagnostics without producing cascades.

Parsing is followed by recursive IR compilation and capture discovery passes. The completion worker and LSP workspace scanner therefore use explicit 8 MiB stacks, preventing those background workers from overflowing below the parser’s limit in debug builds.

All 169 `.nu` files in the repository continue to parse successfully.

## User facing changes

Deeply nested code or data now produces a normal parser error instead of terminating Nushell with a stack overflow:

```text
Error: nu::parser::nesting_too_deep

  x Nesting level too deep.
   ,-[deep.nu:1:64]
 1 | [[[[[[[...
   :                `-- nested too deeply
   `----
  help: Deeply nested code has to be broken up into smaller pieces, such as
        separate commands or variables.
```

## Testing

Added coverage for:

* Every recursive parser route
* The accepted and rejected nesting boundaries
* `from nuon`
* Reused `StateWorkingSet` instances
* Nested `source` and `source-env` parsing
* Multiple deep branches within one source
* Speculative parser rollback
* Completion and LSP background worker stack safety
* Load bearing behavior with the limit and worker stack sizing independently neutralized

Formatting, workspace checks and clippy pass cleanly. The affected parser, protocol, command, CLI, LSP, integration, regression and documentation test suites all pass.

## Additional notes

Fixes #15241
