### PR TITLE
ide: report file read failures from --ide-check

### DIFF
--- a/src/ide.rs
+++ b/src/ide.rs
@@ -77,13 +77,23 @@ fn read_in_file<'a>(
     (file, working_set)
 }
 
-pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value) {
+pub fn check(
+    engine_state: &mut EngineState,
+    file_path: &str,
+    max_errors: &Value,
+) -> Result<(), ShellError> {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
     engine_state.generate_nu_constant();
 
     let mut working_set = StateWorkingSet::new(engine_state);
-    let file = std::fs::read(file_path);
+    let contents = std::fs::read(file_path).map_err(|err| {
+        ShellError::Io(IoError::new_internal_with_path(
+            err.not_found_as(NotFound::File),
+            "Could not read file",
+            PathBuf::from(file_path),
+        ))
+    })?;
 
     let max_errors = if let Ok(max_errors) = max_errors.as_int() {
         max_errors as usize
@@ -91,56 +101,56 @@ pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value
         100
     };
 
-    if let Ok(contents) = file {
-        let offset = working_set.next_span_start();
-        // Top-level IDE check — no source location triggered this file load
-        let _ = working_set.files.push(file_path.into(), Span::unknown());
-        let block = parse(&mut working_set, Some(file_path), &contents, false);
+    let offset = working_set.next_span_start();
+    // Top-level IDE check — no source location triggered this file load
+    let _ = working_set.files.push(file_path.into(), Span::unknown());
+    let block = parse(&mut working_set, Some(file_path), &contents, false);
 
-        for (idx, err) in working_set.parse_errors.iter().enumerate() {
-            if idx >= max_errors {
-                // eprintln!("Too many errors, stopping here. idx: {idx} max_errors: {max_errors}");
-                break;
-            }
-            let mut span = err.span();
-            span.start -= offset;
-            span.end -= offset;
+    for (idx, err) in working_set.parse_errors.iter().enumerate() {
+        if idx >= max_errors {
+            // eprintln!("Too many errors, stopping here. idx: {idx} max_errors: {max_errors}");
+            break;
+        }
+        let mut span = err.span();
+        span.start -= offset;
+        span.end -= offset;
 
-            let msg = err.to_string();
+        let msg = err.to_string();
 
+        println!(
+            "{}",
+            json!({
+                "type": "diagnostic",
+                "severity": "Error",
+                "message": msg,
+                "span": {
+                    "start": span.start,
+                    "end": span.end
+                }
+            })
+        );
+    }
+
+    let flattened = flatten_block(&working_set, &block);
+
+    for flat in flattened {
+        if let FlatShape::VarDecl(var_id) = flat.1 {
+            let var = working_set.get_variable(var_id);
             println!(
                 "{}",
                 json!({
-                    "type": "diagnostic",
-                    "severity": "Error",
-                    "message": msg,
-                    "span": {
-                        "start": span.start,
-                        "end": span.end
+                    "type": "hint",
+                    "typename": var.ty.to_string(),
+                    "position": {
+                        "start": flat.0.start - offset,
+                        "end": flat.0.end - offset
                     }
                 })
             );
         }
-
-        let flattened = flatten_block(&working_set, &block);
-
-        for flat in flattened {
-            if let FlatShape::VarDecl(var_id) = flat.1 {
-                let var = working_set.get_variable(var_id);
-                println!(
-                    "{}",
-                    json!({
-                        "type": "hint",
-                        "typename": var.ty.to_string(),
-                        "position": {
-                            "start": flat.0.start - offset,
-                            "end": flat.0.end - offset
-                        }
-                    })
-                );
-            }
-        }
     }
+
+    Ok(())
 }
 
 pub fn goto_def(engine_state: &mut EngineState, file_path: &str, location: &Value) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -507,7 +507,7 @@ fn main() -> Result<()> {
 
         return Ok(());
     } else if let Some(max_errors) = parsed_nu_cli_args.ide_check {
-        ide::check(&mut engine_state, &script_name, &max_errors);
+        ide::check(&mut engine_state, &script_name, &max_errors)?;
 
         return Ok(());
     } else if parsed_nu_cli_args.ide_ast.is_some() {

--- a/tests/integration/cli.rs
+++ b/tests/integration/cli.rs
@@ -593,6 +593,24 @@ fn ide_flags_accept_values() -> TestResult {
 }
 
 #[test]
+fn ide_check_missing_file_reports_error() -> TestResult {
+    let script_path = unique_temp_script_path("ide_check_missing");
+    let mut cmd = Command::new(cargo_bin!());
+    let output = cmd
+        .args(["--no-config-file", "--no-std-lib", "--ide-check", "5"])
+        .arg(&script_path)
+        .output()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("Could not read file"));
+    assert!(stderr.contains("File not found"));
+    assert!(stderr.contains("does not exist"));
+
+    Ok(())
+}
+
+#[test]
 fn ide_ast_flag_runs() -> TestResult {
     let mut cmd = Command::new(cargo_bin!());
     let output = cmd


### PR DESCRIPTION

## Description

In this PR, I fixed an issue where `--ide-check` silently succeeded when the input file could not be read.

`ide::check` previously ignored errors from `std::fs::read(file_path)` by only handling the successful result. The caller then returned `Ok(())`, making missing or unreadable files appear as if no diagnostics were found.

The check now returns the file read error to the CLI entry point, preserving the existing Nushell I/O error reporting behavior.

For example:

```text
nu --ide-check 5 does-not-exist.nu
```

now exits with a non-zero status and reports `nu::shell::io::file_not_found`.

A CLI integration test was added for this behavior.

## User-facing changes (Release notes)

Fixed an issue where `--ide-check` silently succeeded when the target file could not be read. Nushell now reports the file read error and exits with a non-zero status.

## Additional notes

