### PR TITLE
length, columns, is-empty: propagate error values from streams

### DIFF
--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -80,10 +80,17 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
             let cols = match v {
                 Value::List {
                     vals: input_vals, ..
-                } => get_columns(&input_vals)
-                    .into_iter()
-                    .map(move |x| Value::string(x, span))
-                    .collect(),
+                } => {
+                    for val in &input_vals {
+                        if let Value::Error { error, .. } = val {
+                            return Err(*error.clone());
+                        }
+                    }
+                    get_columns(&input_vals)
+                        .into_iter()
+                        .map(move |x| Value::string(x, span))
+                        .collect()
+                }
                 Value::Custom { val, .. } => {
                     // TODO: should we get CustomValue to expose columns in a more efficient way?
                     // Would be nice to be able to get columns without generating the whole value
@@ -115,7 +122,7 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
                 .set_metadata(metadata))
         }
         PipelineData::ListStream(stream, metadata) => {
-            let values = stream.into_iter().collect::<Vec<_>>();
+            let values = stream.into_value()?.into_list()?;
             let cols = get_columns(&values)
                 .into_iter()
                 .map(|s| Value::string(s, head))

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -14,6 +14,7 @@ pub fn empty(
 
     if !columns.is_empty() {
         for val in input {
+            let val = val.unwrap_error()?;
             for column in &columns {
                 if !val.follow_cell_path(&column.members)?.is_nothing() {
                     return Ok(Value::bool(negate, head).into_pipeline_data());
@@ -55,7 +56,13 @@ pub fn empty(
                 }
             }
             PipelineData::ListStream(s, ..) => {
-                let empty = s.into_iter().next().is_none();
+                let empty = match s.into_iter().next() {
+                    None => true,
+                    Some(val) => {
+                        val.unwrap_error()?;
+                        false
+                    }
+                };
                 if negate {
                     Ok(Value::bool(!empty, head).into_pipeline_data())
                 } else {
@@ -63,6 +70,17 @@ pub fn empty(
                 }
             }
             PipelineData::Value(value, ..) => {
+                match &value {
+                    Value::Error { error, .. } => return Err(*error.clone()),
+                    Value::List { vals, .. } => {
+                        for val in vals {
+                            if let Value::Error { error, .. } = val {
+                                return Err(*error.clone());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
                 if negate {
                     Ok(Value::bool(!value.is_empty(), head).into_pipeline_data())
                 } else {

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -99,11 +99,22 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             dst_span: call.head,
             src_span: internal_span,
         }),
+        PipelineData::Value(Value::Error { error, .. }, ..) => Err(*error),
         PipelineData::Value(Value::List { vals, .. }, ..) => {
+            for val in &vals {
+                if let Value::Error { error, .. } = val {
+                    return Err(*error.clone());
+                }
+            }
             Ok(Value::int(vals.len() as i64, call.head).into_pipeline_data())
         }
         PipelineData::ListStream(stream, ..) => {
-            Ok(Value::int(stream.into_iter().count() as i64, call.head).into_pipeline_data())
+            let mut n = 0i64;
+            for val in stream {
+                val.unwrap_error()?;
+                n += 1;
+            }
+            Ok(Value::int(n, call.head).into_pipeline_data())
         }
         PipelineData::ByteStream(stream, ..) if stream.type_().is_binary_coercible() => {
             Ok(Value::int(

--- a/crates/nu-command/tests/commands/columns.rs
+++ b/crates/nu-command/tests/commands/columns.rs
@@ -1,0 +1,21 @@
+use nu_test_support::prelude::*;
+
+#[test]
+fn columns_propagates_error_stream() -> Result {
+    let err = test()
+        .run(r#"1..3 | each {|n| error make {msg: "x"} } | columns"#)
+        .expect_shell_error()?;
+
+    assert_contains("x", format!("{err:?}"));
+    Ok(())
+}
+
+#[test]
+fn columns_propagates_where_predicate_type_errors() -> Result {
+    let err = test()
+        .run("[[name size]; [a 100b] [b 200b]] | where size <= 150 | columns")
+        .expect_shell_error()?;
+
+    assert_contains("compatible", format!("{err:?}"));
+    Ok(())
+}

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -31,6 +31,16 @@ fn reports_emptiness_by_columns() -> Result {
 }
 
 #[test]
+fn is_empty_propagates_error_stream() -> Result {
+    let err = test()
+        .run(r#"1..3 | each {|n| error make {msg: "x"} } | is-empty"#)
+        .expect_shell_error()?;
+
+    assert_contains("x", format!("{err:?}"));
+    Ok(())
+}
+
+#[test]
 fn reports_nonemptiness_by_columns() -> Result {
     let code = "
         [{a:1 b:null c:3} {a:null b:5 c:2}]

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -22,6 +22,26 @@ fn length_fails_on_echo_record() -> Result {
 }
 
 #[test]
+fn length_propagates_error_stream() -> Result {
+    let err = test()
+        .run(r#"1..3 | each {|n| error make {msg: "x"} } | length"#)
+        .expect_shell_error()?;
+
+    assert_contains("x", format!("{err:?}"));
+    Ok(())
+}
+
+#[test]
+fn length_propagates_where_predicate_type_errors() -> Result {
+    let err = test()
+        .run("[[name size]; [a 100b] [b 200b]] | where size <= 150 | length")
+        .expect_shell_error()?;
+
+    assert_contains("compatible", format!("{err:?}"));
+    Ok(())
+}
+
+#[test]
 fn length_byte_stream() -> Result {
     Playground::setup("length_bytes", |dirs, sandbox| {
         sandbox.mkdir("length_bytes");

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -10,6 +10,7 @@ mod cal;
 mod cd;
 mod chunk_by;
 mod chunks;
+mod columns;
 mod compact;
 mod complete;
 mod config_env_default;

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -223,7 +223,7 @@ fn sqlite_database_operations(#[case] operation: &str, #[case] expected: impl In
 #[case::shuffle("shuffle | length", 5)]
 #[case::split_list("split list 2 | flatten | length", 5)]
 #[case::each_while("each while {|row| $row } | length", 5)]
-#[case::tee("tee {|x| $x | ignore } | flatten | length", 6)]
+#[case::tee("tee { ignore } | length", 5)]
 #[case::filter("filter {|row| $row.z > 100 } | length", 2)]
 fn sqlite_int_table_operations(
     #[case] operation: &str,


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description

In this PR, I fixed `length`, `columns`, and `is-empty` silently consuming `Value::Error` items in list streams.

#16738 already raises when a stream with errors is collected into a value (`let items = ...`). These three commands never collect: they count, take the first item, or gather column names, so a pipeline such as

```nushell
[[name size]; [a 100b] [b 200b]] | where size <= 150 | length
```

returned `2` with exit 0 instead of the type error. `first`, `get`, and `to json` already propagate.

`length` and `is-empty` now fail on the first error value. `columns` uses `ListStream::into_value`, which already unwraps errors.

## User-facing changes (Release notes)

Fixed an issue where `length`, `columns`, and `is-empty` treated error values in a list stream as ordinary data. Those commands now propagate the error instead of returning a count, an empty column list, or `false`.

## Additional notes

Fixes #18928
