### PR TITLE
fix(std/help): pass external command words as separate args and only strip a leading sigil

### DIFF
--- a/crates/nu-std/std/help/mod.nu
+++ b/crates/nu-std/std/help/mod.nu
@@ -744,12 +744,14 @@ def scope-commands [
 def external-commands [
     ...command: string@"nu-complete list-commands",
 ] {
-    let target_command = $command | str join " " | str replace "^" "" | str replace "%" ""
-    print $"(ansi default_italic)Help pages from external command ($target_command | pretty-cmd):(ansi reset)"
+    # `^` (external) and `%` (built-in) are sigils only at the start of a command
+    # name, so strip at most one leading sigil instead of every occurrence
+    let target_command = $command | update 0 { str replace --regex '^[\^%]' "" }
+    print $"(ansi default_italic)Help pages from external command ($target_command | str join ' ' | pretty-cmd):(ansi reset)"
     if $env.NU_HELPER? == "--help" {
-        run-external ($target_command | split row " ") "--help" | if $nu.os-info.name == "windows" { collect } else {}
+        run-external ...$target_command "--help" | if $nu.os-info.name == "windows" { collect } else {}
     } else {
-        ^($env.NU_HELPER? | default "man") $target_command
+        ^($env.NU_HELPER? | default "man") ...$target_command
     }
 }
 
@@ -774,7 +776,8 @@ def pretty-cmd [] {
 #
 # `help word` searches for "word" in commands, aliases and modules, in that order.
 # If not found as internal to nushell, you can set `$env.NU_HELPER` to a program
-# (default: man) and "word" will be passed as the first argument.
+# (default: man) and the words you asked help for will be passed to it as separate
+# arguments.
 # Alternatively, you can set `$env.NU_HELPER` to `--help` and it will run "word" as
 # an external and pass `--help` as the last argument (this could cause unintended
 # behaviour if it doesn't support the flag, use it carefully).
@@ -819,5 +822,5 @@ export def main [
     }
     # use external tool (e.g: `man`) to search help for $target_item
     # the stdout and stderr of external tool will follow `main` call.
-    external-commands $target_item
+    external-commands ...$item
 }

--- a/crates/nu-std/tests/test_help.nu
+++ b/crates/nu-std/tests/test_help.nu
@@ -13,3 +13,31 @@ def show_help_on_error_make [] {
     let help_result = (help error make)
     assert ("Error: nu::shell::eval_block_with_input" not-in $help_result)
 }
+
+@test
+def show_help_on_external_command_with_sigil_in_name [] {
+    # `^` and `%` are sigils only at the start of a command name, not inside it
+    let dir = ($nu.temp-dir | path join $"test_help_(random uuid)")
+    mkdir $dir
+    let script = ($dir | path join "ext-%^-cmd.nu")
+    "print 'external help ok'" | save $script
+
+    let help_result = (with-env {NU_HELPER: $nu.current-exe} { help $script })
+    rm -r $dir
+
+    assert ("external help ok" in $help_result)
+}
+
+@test
+def show_help_on_external_command_passes_words_separately [] {
+    # `help foo bar` has to reach the helper as two arguments, not as `foo bar`
+    let dir = ($nu.temp-dir | path join $"test_help_(random uuid)")
+    mkdir $dir
+    let script = ($dir | path join "ext-cmd.nu")
+    "def main [word: string] { print $'external help ($word)' }" | save $script
+
+    let help_result = (with-env {NU_HELPER: $nu.current-exe} { help $script config })
+    rm -r $dir
+
+    assert ("external help config" in $help_result)
+}


### PR DESCRIPTION
## Description

`std/help` falls back to an external help program (`man` by default, or `$env.NU_HELPER`) when a word isn't an internal command, alias or module. Two problems in that fallback, both reported in #18939:

1. `external-commands` joined all the requested words into one string, so `help gh config` ran `man 'gh config'` — a single argument — rather than `man gh config`. `export def main` had the same bug independently: it passed the already-joined `$target_item` instead of forwarding its rest argument.
2. It stripped *every* `^` and `%` in the name, not just a leading sigil, so a command like `test-%.nu` was looked up as `test-.nu`.

The fix keeps `$command` as a list and spreads it into the helper (`^($env.NU_HELPER? | default "man") ...$target_command`, and likewise for the `run-external ... --help` branch), and strips at most one leading `^`/`%` from the first word with `update 0 { str replace --regex '^[\^%]' "" }`.

Only the external fallback changed. The internal command/alias/module lookups still use the joined `$target_item`, so name resolution stays identical to the built-in `help` and the two don't diverge.

## User-facing changes (Release notes)

Fixed `std/help` passing the whole command to the external help program as a single argument. `help gh config` now runs the helper as `gh config` (two arguments) instead of `'gh config'`, so multi-word lookups work with `man`, `tldr` and friends.

Fixed `std/help` deleting `^` and `%` from anywhere in an external command name. Only a single leading `^` or `%` sigil is stripped now, so `help test-%.nu` reports the command as `test-%.nu` instead of `test-.nu`.

## Additional notes

Fixes #18939

Tested with two new tests in `crates/nu-std/tests/test_help.nu` (one for a `%` and `^` inside the name, one asserting the helper receives two separate words); both fail before this change and pass after. Also checked by hand with `$env.NU_HELPER` pointed at a script that prints its argv — `help gh config` and `help ^gh config` both arrive as `argc=2`, `[gh]` `[config]` — and confirmed the default `man` path (`help ssh`) and the `$env.NU_HELPER = "--help"` path still work.
