### PR TITLE
Add fallback completion algorithm

### DIFF
--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -62,7 +62,7 @@ pub(crate) fn to_reedline_span(span: Span, offset: usize) -> reedline::Span {
     )
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct SemanticSuggestion {
     pub suggestion: Suggestion,
     pub kind: Option<SuggestionKind>,

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -108,9 +108,10 @@ impl CommandCompletion {
         context: &Context,
         suggestion_span: reedline::Span,
         matcher: &mut NuMatcher<SemanticSuggestion>,
-    ) -> HashSet<String> {
+    ) -> (HashSet<String>, Vec<SemanticSuggestion>) {
         let working_set = context.working_set;
         let mut internal_names = HashSet::new();
+        let mut internal_suggestions = Vec::new();
         let mut seen_names: HashSet<&str> = HashSet::new();
 
         (0..working_set.num_decls())
@@ -142,12 +143,13 @@ impl CommandCompletion {
                     )),
                 };
 
-                if matcher.add_semantic_suggestion(suggestion) {
+                if matcher.add_semantic_suggestion(suggestion.clone()) {
                     internal_names.insert(name);
+                    internal_suggestions.push(suggestion);
                 }
             });
 
-        internal_names
+        (internal_names, internal_suggestions)
     }
 
     /// Scans internal commands using the engine's built-in traversal
@@ -156,9 +158,10 @@ impl CommandCompletion {
         context: &Context,
         suggestion_span: reedline::Span,
         matcher: &mut NuMatcher<SemanticSuggestion>,
-    ) -> HashSet<String> {
+    ) -> (HashSet<String>, Vec<SemanticSuggestion>) {
         let working_set = context.working_set;
         let mut internal_names = HashSet::new();
+        let mut internal_suggestions = Vec::new();
 
         working_set.traverse_commands(|name_bytes, declaration_id| {
             let command = working_set.get_decl(declaration_id);
@@ -191,12 +194,13 @@ impl CommandCompletion {
                 )),
             };
 
-            if matcher.add_semantic_suggestion(suggestion) {
+            if matcher.add_semantic_suggestion(suggestion.clone()) {
                 internal_names.insert(name);
+                internal_suggestions.push(suggestion);
             }
         });
 
-        internal_names
+        (internal_names, internal_suggestions)
     }
 
     /// Walks `PATH` once, offering collisions `^`-prefixed and collecting external matches.
@@ -204,7 +208,7 @@ impl CommandCompletion {
         &self,
         context: &Context,
         suggestion_span: reedline::Span,
-        internal_suggestions: &mut Vec<SemanticSuggestion>,
+        internal_suggestions: &[SemanticSuggestion],
         internal_names: &HashSet<String>,
         matcher: &mut NuMatcher<SemanticSuggestion>,
     ) {
@@ -234,6 +238,17 @@ impl CommandCompletion {
 
             if is_collision {
                 collisions.insert(file_name.clone());
+
+                // Match against the original name: `%` selects the built-in command scope; it is not part of the name.
+                // Add it before the external alternative to preserve their existing relative order.
+                for suggestion in internal_suggestions
+                    .iter()
+                    .filter(|suggestion| suggestion.suggestion.value == file_name)
+                {
+                    let mut percent_prefixed = suggestion.clone();
+                    percent_prefixed.suggestion.value = format!("%{}", suggestion.suggestion.value);
+                    matcher.add(&suggestion.suggestion.value, percent_prefixed);
+                }
             }
 
             if wants_suggestion {
@@ -258,22 +273,6 @@ impl CommandCompletion {
                 }
             }
         }
-
-        // Add `%`-prefixed copies of collided internal suggestions.
-        let percent_prefixed_suggestions: Vec<SemanticSuggestion> = internal_suggestions
-            .iter()
-            .filter(|suggestion| collisions.contains(&suggestion.suggestion.value))
-            .map(|suggestion| {
-                let mut prefixed = suggestion.suggestion.clone();
-                prefixed.value = format!("%{}", suggestion.suggestion.value);
-                SemanticSuggestion {
-                    suggestion: prefixed,
-                    kind: suggestion.kind.clone(),
-                }
-            })
-            .collect();
-
-        internal_suggestions.extend(percent_prefixed_suggestions);
     }
 }
 
@@ -282,9 +281,11 @@ impl Completer for CommandCompletion {
         let suggestion_span = to_reedline_span(context.span, context.offset);
         let scope = self.scope.enabled_in(context);
         let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
-        let internal_names = match scope {
-            CommandScope::ExternalsOnly => HashSet::new(),
-            CommandScope::BuiltinsOnly => self.collect_builtins(context, suggestion_span, &mut matcher),
+        let (internal_names, internal_suggestions) = match scope {
+            CommandScope::ExternalsOnly => (HashSet::new(), Vec::new()),
+            CommandScope::BuiltinsOnly => {
+                self.collect_builtins(context, suggestion_span, &mut matcher)
+            }
             CommandScope::All | CommandScope::InternalsOnly => {
                 self.collect_visible_internals(context, suggestion_span, &mut matcher)
             }
@@ -293,16 +294,16 @@ impl Completer for CommandCompletion {
         // Only a `PATH` scan is expensive enough to be worth caching.
         let externals = scope.externals();
         if externals {
-            let external_suggestions = self.process_external_commands(
+            self.process_external_commands(
                 context,
                 suggestion_span,
-                &mut suggestions,
+                &internal_suggestions,
                 &internal_names,
                 &mut matcher,
             );
-            suggestions.extend(external_suggestions);
         }
 
+        let suggestions = matcher.suggestion_results();
         match externals {
             true => Fetched::Cacheable(suggestions),
             false => Fetched::Pure(suggestions),

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -107,9 +107,9 @@ impl CommandCompletion {
         &self,
         context: &Context,
         suggestion_span: reedline::Span,
-    ) -> (Vec<SemanticSuggestion>, HashSet<String>) {
+        matcher: &mut NuMatcher<SemanticSuggestion>,
+    ) -> HashSet<String> {
         let working_set = context.working_set;
-        let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
         let mut internal_names = HashSet::new();
         let mut seen_names: HashSet<&str> = HashSet::new();
 
@@ -147,7 +147,7 @@ impl CommandCompletion {
                 }
             });
 
-        (matcher.suggestion_results(), internal_names)
+        internal_names
     }
 
     /// Scans internal commands using the engine's built-in traversal
@@ -155,9 +155,9 @@ impl CommandCompletion {
         &self,
         context: &Context,
         suggestion_span: reedline::Span,
-    ) -> (Vec<SemanticSuggestion>, HashSet<String>) {
+        matcher: &mut NuMatcher<SemanticSuggestion>,
+    ) -> HashSet<String> {
         let working_set = context.working_set;
-        let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
         let mut internal_names = HashSet::new();
 
         working_set.traverse_commands(|name_bytes, declaration_id| {
@@ -196,7 +196,7 @@ impl CommandCompletion {
             }
         });
 
-        (matcher.suggestion_results(), internal_names)
+        internal_names
     }
 
     /// Walks `PATH` once, offering collisions `^`-prefixed and collecting external matches.
@@ -206,7 +206,8 @@ impl CommandCompletion {
         suggestion_span: reedline::Span,
         internal_suggestions: &mut Vec<SemanticSuggestion>,
         internal_names: &HashSet<String>,
-    ) -> Vec<SemanticSuggestion> {
+        matcher: &mut NuMatcher<SemanticSuggestion>,
+    ) {
         let working_set = context.working_set;
         let maximum_results = working_set
             .permanent_state
@@ -214,7 +215,6 @@ impl CommandCompletion {
             .completions
             .external
             .max_results as usize;
-        let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
 
         let mut external_commands: HashSet<String> = HashSet::new();
         let mut collisions: HashSet<String> = HashSet::new();
@@ -274,7 +274,6 @@ impl CommandCompletion {
             .collect();
 
         internal_suggestions.extend(percent_prefixed_suggestions);
-        matcher.suggestion_results()
     }
 }
 
@@ -282,12 +281,12 @@ impl Completer for CommandCompletion {
     fn fetch(&mut self, context: &Context) -> Fetched {
         let suggestion_span = to_reedline_span(context.span, context.offset);
         let scope = self.scope.enabled_in(context);
-
-        let (mut suggestions, internal_names) = match scope {
-            CommandScope::ExternalsOnly => (Vec::new(), HashSet::new()),
-            CommandScope::BuiltinsOnly => self.collect_builtins(context, suggestion_span),
+        let mut matcher = NuMatcher::new(context.prefix_str(), context.options, true);
+        let internal_names = match scope {
+            CommandScope::ExternalsOnly => HashSet::new(),
+            CommandScope::BuiltinsOnly => self.collect_builtins(context, suggestion_span, &mut matcher),
             CommandScope::All | CommandScope::InternalsOnly => {
-                self.collect_visible_internals(context, suggestion_span)
+                self.collect_visible_internals(context, suggestion_span, &mut matcher)
             }
         };
 
@@ -299,6 +298,7 @@ impl Completer for CommandCompletion {
                 suggestion_span,
                 &mut suggestions,
                 &internal_names,
+                &mut matcher,
             );
             suggestions.extend(external_suggestions);
         }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
 };
 use reedline::Suggestion;
 
-use super::{SemanticSuggestion, completion_options::NuMatcher};
+use super::{MatchAlgorithm, SemanticSuggestion, completion_options::NuMatcher};
 
 /// Which command declarations a [`CommandCompletion`] offers.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -222,12 +222,25 @@ impl CommandCompletion {
 
         let mut external_commands: HashSet<String> = HashSet::new();
         let mut collisions: HashSet<String> = HashSet::new();
+        // Track match classes separately so fuzzy matches cannot hide later prefix matches.
+        let mut prefix_count = 0;
+        let mut fuzzy_count = 0;
+        let uses_fallback = context.options.match_algorithm == MatchAlgorithm::Fallback;
 
         for (file_name, file_path) in self.get_executable_files(working_set) {
             let is_collision =
                 internal_names.contains(&file_name) && !collisions.contains(&file_name);
-            let wants_suggestion = external_commands.len() < maximum_results
-                && matcher.check_match(&file_name).is_some();
+            let is_prefix_match = uses_fallback && matcher.has_prefix_match(&file_name);
+            let has_capacity = if uses_fallback {
+                if is_prefix_match {
+                    prefix_count < maximum_results
+                } else {
+                    fuzzy_count < maximum_results
+                }
+            } else {
+                external_commands.len() < maximum_results
+            };
+            let wants_suggestion = has_capacity && matcher.check_match(&file_name).is_some();
 
             // `is_executable_command` stats the file, which dominates the scan on slow
             // filesystems (e.g. WSL's 9P mounts to Windows `PATH` directories), so only
@@ -258,7 +271,7 @@ impl CommandCompletion {
                 };
 
                 if external_commands.insert(command_value.clone()) {
-                    matcher.add(
+                    let added = matcher.add(
                         file_name,
                         SemanticSuggestion {
                             suggestion: Suggestion {
@@ -270,6 +283,14 @@ impl CommandCompletion {
                             kind: Some(SuggestionKind::Command(CommandType::External, None)),
                         },
                     );
+
+                    if added && uses_fallback {
+                        if is_prefix_match {
+                            prefix_count += 1;
+                        } else {
+                            fuzzy_count += 1;
+                        }
+                    }
                 }
             }
         }

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,5 +1,9 @@
 use crate::completions::{
-    ArgValueCompletion, AttributableCompletion, AttributeCompletion, CellPathCompletion, CommandCompletion, CommandScope, Completer, CompletionOptions, CustomCompletion, DotNuCompletion, EnvVarCompletion, FileCompletion, FlagCompletion, MatchAlgorithm, NuMatcher, OperatorCompletion, VariableCompletion, base::{Fetched, SemanticSuggestion},
+    ArgValueCompletion, AttributableCompletion, AttributeCompletion, CellPathCompletion,
+    CommandCompletion, CommandScope, Completer, CompletionOptions, CustomCompletion,
+    DotNuCompletion, EnvVarCompletion, FileCompletion, FlagCompletion, MatchAlgorithm, NuMatcher,
+    OperatorCompletion, VariableCompletion,
+    base::{Fetched, SemanticSuggestion},
 };
 use lru::LruCache;
 use nu_parser::{parse, parse_shorter_head_reading};
@@ -2410,6 +2414,29 @@ mod completer_tests {
 
     /// A cached answer stands in for the computed one, so the two must agree on order.
     /// Re-sorting the cache put `config/` after `config.nu`, inverting every keystroke.
+    #[test]
+    fn narrowing_cache_skips_fallback_matches() {
+        let cache = NarrowingCache::default();
+        let env = CacheEnv::of(&test_engine(), &Stack::new());
+        let span = reedline::Span::new(3, 6);
+        let cached = vec![Suggestion {
+            value: "foobar".to_string(),
+            span,
+            ..Suggestion::default()
+        }]
+        .into();
+        let options = CompletionOptions {
+            match_algorithm: MatchAlgorithm::Fallback,
+            ..Default::default()
+        };
+
+        cache.store(CompletionQuery::new("ls foo", 6), env, cached);
+
+        let narrowed = cache.narrowed_fallback(&CompletionQuery::new("ls fooz", 7), env, &options);
+
+        assert!(narrowed.is_empty());
+    }
+
     #[test]
     fn a_narrowed_cache_answer_keeps_the_order_it_was_given() {
         let cache = NarrowingCache::default();

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -1,9 +1,5 @@
 use crate::completions::{
-    ArgValueCompletion, AttributableCompletion, AttributeCompletion, CellPathCompletion,
-    CommandCompletion, CommandScope, Completer, CompletionOptions, CustomCompletion,
-    DotNuCompletion, EnvVarCompletion, FileCompletion, FlagCompletion, NuMatcher,
-    OperatorCompletion, VariableCompletion,
-    base::{Fetched, SemanticSuggestion},
+    ArgValueCompletion, AttributableCompletion, AttributeCompletion, CellPathCompletion, CommandCompletion, CommandScope, Completer, CompletionOptions, CustomCompletion, DotNuCompletion, EnvVarCompletion, FileCompletion, FlagCompletion, MatchAlgorithm, NuMatcher, OperatorCompletion, VariableCompletion, base::{Fetched, SemanticSuggestion},
 };
 use lru::LruCache;
 use nu_parser::{parse, parse_shorter_head_reading};
@@ -427,6 +423,11 @@ impl NarrowingCache {
         environment: CacheEnv,
         options: &CompletionOptions,
     ) -> Suggestions {
+        // Fallback may discard fuzzy results that a longer query needs, so cached suggestions
+        // cannot safely answer a narrowed query.
+        if options.match_algorithm == MatchAlgorithm::Fallback {
+            return Suggestions::default();
+        }
         let Some((base_suggestions, ref_span, search_token)) =
             self.entries.lock().ok().and_then(|guard| {
                 let (_, entry, span) = guard

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -38,7 +38,7 @@ pub struct MatchedPart {
 /// * `isdir`: whether the current partial path has a trailing slash.
 ///   Parsing a path string into a pathbuf loses that bit of information.
 /// * `enable_exact_match`: Whether exact directory matches should take priority.
-///   Enabled for prefix matching and its fuzzy-fallback variant.
+///   Enabled for prefix matching.
 fn complete_rec(
     partial: &[&str],
     built_paths: &[PathBuiltFromString],
@@ -171,6 +171,45 @@ fn complete_rec(
     } else {
         completion_iter.collect()
     }
+}
+
+/// Completes path components using the configured algorithm.
+///
+/// Fallback applies to the whole path: the full traversal is retried with fuzzy matching only
+/// when prefix matching produces no final suggestions.
+fn complete_components(
+    partial: &[&str],
+    built_paths: &[PathBuiltFromString],
+    options: &CompletionOptions,
+    want_directory: bool,
+    isdir: bool,
+) -> Vec<PathBuiltFromString> {
+    let complete_with_options = |options: &CompletionOptions| {
+        complete_rec(
+            partial,
+            built_paths,
+            options,
+            want_directory,
+            isdir,
+            options.match_algorithm == MatchAlgorithm::Prefix,
+        )
+    };
+
+    // single-pass completion if we're not using fallback
+    if options.match_algorithm != MatchAlgorithm::Fallback {
+        return complete_with_options(options);
+    }
+
+    // try prefix first and only fall back to fuzzy if it produces no completions
+    let mut options = options.clone();
+    options.match_algorithm = MatchAlgorithm::Prefix;
+    let prefix_matches = complete_with_options(&options);
+    if !prefix_matches.is_empty() {
+        return prefix_matches;
+    }
+
+    options.match_algorithm = MatchAlgorithm::Fuzzy;
+    complete_with_options(&options)
 }
 
 #[derive(Debug)]
@@ -343,7 +382,7 @@ pub fn complete_item(
         .filter(|s| !s.is_empty())
         .collect();
 
-    complete_rec(
+    complete_components(
         partial.as_slice(),
         &cwds
             .into_iter()
@@ -356,10 +395,6 @@ pub fn complete_item(
         options,
         want_directory,
         isdir,
-        matches!(
-            options.match_algorithm,
-            MatchAlgorithm::Prefix | MatchAlgorithm::Fallback
-        ),
     )
     .into_iter()
     .map(|mut p| {

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -37,8 +37,8 @@ pub struct MatchedPart {
 ///   like `ls` can be run on regular files as well.
 /// * `isdir`: whether the current partial path has a trailing slash.
 ///   Parsing a path string into a pathbuf loses that bit of information.
-/// * `enable_exact_match`: Whether match algorithm is Prefix and all previous components
-///   of the path matched a directory exactly.
+/// * `enable_exact_match`: Whether exact directory matches should take priority.
+///   Enabled for prefix matching and its fuzzy-fallback variant.
 fn complete_rec(
     partial: &[&str],
     built_paths: &[PathBuiltFromString],
@@ -356,7 +356,10 @@ pub fn complete_item(
         options,
         want_directory,
         isdir,
-        options.match_algorithm == MatchAlgorithm::Prefix,
+        matches!(
+            options.match_algorithm,
+            MatchAlgorithm::Prefix | MatchAlgorithm::Fallback
+        ),
     )
     .into_iter()
     .map(|mut p| {

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -193,6 +193,27 @@ impl<T> NuMatcher<'_, T> {
         })
     }
 
+    fn fuzzy_matches(
+        haystack: &str,
+        atom: &Atom,
+        matcher: &mut Matcher,
+        offset: usize,
+    ) -> Option<(Vec<usize>, u16)> {
+        let mut haystack_buf = Vec::new();
+        let haystack_utf32 = Utf32Str::new(haystack, &mut haystack_buf);
+        let mut indices = Vec::new();
+        let score = atom.indices(haystack_utf32, matcher, &mut indices)?;
+        Some((
+            indices
+                .iter()
+                .map(|i| {
+                    offset + usize::try_from(*i).expect("should be on at least a 32-bit system")
+                })
+                .collect(),
+            score,
+        ))
+    }
+
     /// Returns whether or not the haystack matches the needle. If it does, `item` is added
     /// to the list of matches (if given).
     ///
@@ -224,25 +245,16 @@ impl<T> NuMatcher<'_, T> {
                 atom,
                 matches,
             } => {
-                let mut haystack_buf = Vec::new();
-                let haystack_utf32 = Utf32Str::new(haystack, &mut haystack_buf);
-                let mut indices = Vec::new();
-                let score = atom.indices(haystack_utf32, matcher, &mut indices)?;
-                let indices: Vec<usize> = indices
-                    .iter()
-                    .map(|i| {
-                        offset + usize::try_from(*i).expect("should be on at least a 32-bit system")
-                    })
-                    .collect();
+                let (match_indices, score) = Self::fuzzy_matches(haystack, atom, matcher, offset)?;
                 if let Some(item) = item {
                     matches.push(FuzzyMatch {
                         item,
                         haystack: haystack.to_string(),
                         score,
-                        match_indices: indices.clone(),
+                        match_indices: match_indices.clone(),
                     });
                 }
-                Some(indices)
+                Some(match_indices)
             }
             State::Fallback {
                 matcher,
@@ -268,26 +280,17 @@ impl<T> NuMatcher<'_, T> {
                     return Some(match_indices);
                 }
 
-                // fuzzy
-                let mut haystack_buf = Vec::new();
-                let haystack_utf32 = Utf32Str::new(haystack, &mut haystack_buf);
-                let mut indices = Vec::new();
-                let score = atom.indices(haystack_utf32, matcher, &mut indices)?;
-                let indices: Vec<usize> = indices
-                    .iter()
-                    .map(|i| {
-                        offset + usize::try_from(*i).expect("should be on at least a 32-bit system")
-                    })
-                    .collect();
+                // fallback to fuzzy
+                let (match_indices, score) = Self::fuzzy_matches(haystack, atom, matcher, offset)?;
                 if let Some(item) = item {
                     fuzzy_matches.push(FuzzyMatch {
                         item,
                         haystack: haystack.to_string(),
                         score,
-                        match_indices: indices.clone(),
+                        match_indices: match_indices.clone(),
                     });
                 }
-                Some(indices)
+                Some(match_indices)
             }
         }
     }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -29,11 +29,12 @@ pub enum MatchAlgorithm {
     /// Example:
     /// "git checkout" is matched by "gco"
     Fuzzy,
-    /// Shows prefix matches when any exist; otherwise falls back to fuzzy matches.
+
+    /// Shows prefix matches when any exist; otherwise falls back to fuzzy matches
     ///
     /// Examples:
-    /// - "git sw" matches "git switch" by prefix.
-    /// - "gco" matches "git checkout" by fuzzy matching when no prefix matches exist.
+    /// - "git sw" matches "git switch" by prefix
+    /// - "gco" matches "git checkout" by fuzzy matching when no prefix matches exist
     Fallback,
 }
 
@@ -240,17 +241,9 @@ impl<T> NuMatcher<'_, T> {
                 } else {
                     Cow::Owned(haystack.to_folded_case())
                 };
-                let match_start = match self.options.match_algorithm {
-                    MatchAlgorithm::Prefix => {
-                        if haystack_folded.starts_with(self.needle.as_str()) {
-                            Some(0)
-                        } else {
-                            None
-                        }
-                    }
-                    MatchAlgorithm::Substring => haystack_folded.find(self.needle.as_str()),
-                    _ => unreachable!("Only prefix and substring algorithms don't use score"),
-                };
+                let match_start = haystack_folded
+                    .starts_with(self.needle.as_str())
+                    .then_some(0);
                 if let Some(byte_start) = match_start {
                     let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
                     // TODO this doesn't account for lowercasing changing the length of the haystack

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -485,6 +485,8 @@ impl Default for CompletionOptions {
 mod test {
     use rstest::rstest;
 
+    use nu_protocol::CompletionSort;
+
     use super::{CompletionOptions, MatchAlgorithm, NuMatcher};
 
     #[rstest]
@@ -523,6 +525,84 @@ mod test {
         } else {
             assert_ne!(vec![haystack], results);
         }
+    }
+
+    #[test]
+    fn fallback_prefers_and_sorts_prefix_matches() {
+        let options = CompletionOptions {
+            match_algorithm: MatchAlgorithm::Fallback,
+            sort: CompletionSort::Smart,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("foo", &options, true);
+        matcher.add("barfoo", "barfoo");
+        matcher.add("fooz", "fooz");
+        matcher.add("fooa", "fooa");
+
+        assert_eq!(
+            vec![("fooa", vec![0, 1, 2]), ("fooz", vec![0, 1, 2])],
+            matcher.results()
+        );
+    }
+
+    #[test]
+    fn fallback_uses_fuzzy_matches_without_prefix_matches() {
+        let options = CompletionOptions {
+            match_algorithm: MatchAlgorithm::Fallback,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("fob", &options, true);
+        matcher.add("foo/bar", "foo/bar");
+        matcher.add("foo bar", "foo bar");
+
+        assert_eq!(
+            vec![("foo bar", vec![0, 1, 4]), ("foo/bar", vec![0, 1, 4]),],
+            matcher.results()
+        );
+    }
+
+    #[test]
+    fn fallback_matches_prefixes_case_insensitively() {
+        let options = CompletionOptions {
+            case_sensitive: false,
+            match_algorithm: MatchAlgorithm::Fallback,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("FOO", &options, true);
+        matcher.add("barfoo", "barfoo");
+        matcher.add("FooBar", "FooBar");
+
+        assert_eq!(vec![("FooBar", vec![0, 1, 2])], matcher.results());
+    }
+
+    #[rstest]
+    #[case::smart(
+        CompletionSort::Smart,
+        vec!["z fob", "foo bar", "foo/bar"]
+    )]
+    #[case::alphabetical(
+        CompletionSort::Alphabetical,
+        vec!["foo bar", "foo/bar", "z fob"]
+    )]
+    fn fallback_sorts_fuzzy_matches(#[case] sort: CompletionSort, #[case] expected: Vec<&str>) {
+        let options = CompletionOptions {
+            match_algorithm: MatchAlgorithm::Fallback,
+            sort,
+            ..Default::default()
+        };
+        let mut matcher = NuMatcher::new("fob", &options, true);
+        for candidate in ["foo/bar", "z fob", "foo bar"] {
+            matcher.add(candidate, candidate);
+        }
+
+        assert_eq!(
+            expected,
+            matcher
+                .results()
+                .into_iter()
+                .map(|(candidate, _)| candidate)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -29,6 +29,12 @@ pub enum MatchAlgorithm {
     /// Example:
     /// "git checkout" is matched by "gco"
     Fuzzy,
+    /// Shows prefix matches when any exist; otherwise falls back to fuzzy matches.
+    ///
+    /// Examples:
+    /// - "git sw" matches "git switch" by prefix.
+    /// - "gco" matches "git checkout" by fuzzy matching when no prefix matches exist.
+    Fallback,
 }
 
 pub struct NuMatcher<'a, T> {
@@ -44,6 +50,12 @@ enum State<T> {
         matcher: Matcher,
         atom: Atom,
         matches: Vec<FuzzyMatch<T>>,
+    },
+    Fallback {
+        matcher: Matcher,
+        atom: Atom,
+        prefix_matches: Vec<UnscoredMatch<T>>,
+        fuzzy_matches: Vec<FuzzyMatch<T>>,
     },
 }
 
@@ -78,7 +90,7 @@ impl<T> NuMatcher<'_, T> {
         let needle = needle.as_ref().trim_matches(QUOTES);
         match options.match_algorithm {
             MatchAlgorithm::Prefix | MatchAlgorithm::Substring => {
-                let lowercase_needle = if options.case_sensitive {
+                let needle = if options.case_sensitive {
                     needle.to_owned()
                 } else {
                     needle.to_folded_case()
@@ -86,7 +98,7 @@ impl<T> NuMatcher<'_, T> {
                 NuMatcher {
                     options,
                     should_sort,
-                    needle: lowercase_needle,
+                    needle,
                     state: State::Unscored(Vec::new()),
                 }
             }
@@ -114,6 +126,35 @@ impl<T> NuMatcher<'_, T> {
                         }),
                         atom,
                         matches: Vec::new(),
+                    },
+                }
+            }
+            MatchAlgorithm::Fallback => {
+                let atom = Atom::new(
+                    needle,
+                    if options.case_sensitive {
+                        CaseMatching::Respect
+                    } else {
+                        CaseMatching::Ignore
+                    },
+                    Normalization::Smart,
+                    AtomKind::Fuzzy,
+                    false,
+                );
+                let needle = if options.case_sensitive {
+                    needle.to_owned()
+                } else {
+                    needle.to_folded_case()
+                };
+                NuMatcher {
+                    options,
+                    should_sort,
+                    needle,
+                    state: State::Fallback {
+                        matcher: Matcher::new(Config::DEFAULT),
+                        atom,
+                        prefix_matches: Vec::new(),
+                        fuzzy_matches: Vec::new(),
                     },
                 }
             }
@@ -187,6 +228,66 @@ impl<T> NuMatcher<'_, T> {
                 }
                 Some(indices)
             }
+            State::Fallback {
+                matcher,
+                atom,
+                prefix_matches,
+                fuzzy_matches,
+            } => {
+                // prefix
+                let haystack_folded = if self.options.case_sensitive {
+                    Cow::Borrowed(haystack)
+                } else {
+                    Cow::Owned(haystack.to_folded_case())
+                };
+                let match_start = match self.options.match_algorithm {
+                    MatchAlgorithm::Prefix => {
+                        if haystack_folded.starts_with(self.needle.as_str()) {
+                            Some(0)
+                        } else {
+                            None
+                        }
+                    }
+                    MatchAlgorithm::Substring => haystack_folded.find(self.needle.as_str()),
+                    _ => unreachable!("Only prefix and substring algorithms don't use score"),
+                };
+                if let Some(byte_start) = match_start {
+                    let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
+                    // TODO this doesn't account for lowercasing changing the length of the haystack
+                    let grapheme_len = self.needle.graphemes(true).count();
+                    let match_indices: Vec<usize> =
+                        (offset + grapheme_start..offset + grapheme_start + grapheme_len).collect();
+                    if let Some(item) = item {
+                        prefix_matches.push(UnscoredMatch {
+                            item,
+                            haystack: haystack.to_string(),
+                            match_indices: match_indices.clone(),
+                        });
+                    }
+                    return Some(match_indices);
+                }
+
+                // fuzzy
+                let mut haystack_buf = Vec::new();
+                let haystack_utf32 = Utf32Str::new(haystack, &mut haystack_buf);
+                let mut indices = Vec::new();
+                let score = atom.indices(haystack_utf32, matcher, &mut indices)?;
+                let indices: Vec<usize> = indices
+                    .iter()
+                    .map(|i| {
+                        offset + usize::try_from(*i).expect("should be on at least a 32-bit system")
+                    })
+                    .collect();
+                if let Some(item) = item {
+                    fuzzy_matches.push(FuzzyMatch {
+                        item,
+                        haystack: haystack.to_string(),
+                        score,
+                        match_indices: indices.clone(),
+                    });
+                }
+                Some(indices)
+            }
         }
     }
 
@@ -227,6 +328,36 @@ impl<T> NuMatcher<'_, T> {
                     matches.sort_by(|a, b| b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack)));
                 }
             },
+            State::Fallback {
+                prefix_matches,
+                fuzzy_matches,
+                ..
+            } => {
+                if prefix_matches.is_empty() {
+                    match self.options.sort {
+                        CompletionSort::Alphabetical => {
+                            fuzzy_matches.sort_by(|a, b| a.haystack.cmp(&b.haystack));
+                        }
+                        CompletionSort::Smart => {
+                            fuzzy_matches.sort_by(|a, b| {
+                                b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack))
+                            });
+                        }
+                    }
+                } else {
+                    prefix_matches.sort_by(|a, b| {
+                        let cmp_sensitive = a.haystack.cmp(&b.haystack);
+                        if self.options.case_sensitive {
+                            cmp_sensitive
+                        } else {
+                            a.haystack
+                                .to_folded_case()
+                                .cmp(&b.haystack.to_folded_case())
+                                .then(cmp_sensitive)
+                        }
+                    });
+                }
+            }
         }
     }
 
@@ -244,6 +375,23 @@ impl<T> NuMatcher<'_, T> {
                 .into_iter()
                 .map(|mat| (mat.item, mat.match_indices))
                 .collect::<Vec<_>>(),
+            State::Fallback {
+                prefix_matches,
+                fuzzy_matches,
+                ..
+            } => {
+                if prefix_matches.is_empty() {
+                    fuzzy_matches
+                        .into_iter()
+                        .map(|mat| (mat.item, mat.match_indices))
+                        .collect()
+                } else {
+                    prefix_matches
+                        .into_iter()
+                        .map(|mat| (mat.item, mat.match_indices))
+                        .collect()
+                }
+            }
         }
     }
 }
@@ -272,6 +420,7 @@ impl From<CompletionAlgorithm> for MatchAlgorithm {
             CompletionAlgorithm::Prefix => MatchAlgorithm::Prefix,
             CompletionAlgorithm::Substring => MatchAlgorithm::Substring,
             CompletionAlgorithm::Fuzzy => MatchAlgorithm::Fuzzy,
+            CompletionAlgorithm::Fallback => MatchAlgorithm::Fallback,
         }
     }
 }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -152,7 +152,11 @@ impl<T> NuMatcher<'_, T> {
                     should_sort,
                     needle,
                     state: State::Fallback {
-                        matcher: Matcher::new(Config::DEFAULT),
+                        matcher: Matcher::new({
+                            let mut cfg = Config::DEFAULT;
+                            cfg.prefer_prefix = true;
+                            cfg
+                        }),
                         atom,
                         prefix_matches: Vec::new(),
                         fuzzy_matches: Vec::new(),
@@ -437,6 +441,7 @@ impl TryFrom<String> for MatchAlgorithm {
             "prefix" => Ok(Self::Prefix),
             "substring" => Ok(Self::Substring),
             "fuzzy" => Ok(Self::Fuzzy),
+            "fallback" => Ok(Self::Fallback),
             _ => Err(InvalidMatchAlgorithm::Unknown),
         }
     }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -89,6 +89,26 @@ impl<T> NuMatcher<'_, T> {
         // NOTE: Should match `'bar baz'` when completing `foo "b<tab>`
         // https://github.com/nushell/nushell/issues/16860#issuecomment-3402016955
         let needle = needle.as_ref().trim_matches(QUOTES);
+        let make_atom = || {
+            Atom::new(
+                needle,
+                if options.case_sensitive {
+                    CaseMatching::Respect
+                } else {
+                    CaseMatching::Ignore
+                },
+                Normalization::Smart,
+                AtomKind::Fuzzy,
+                false,
+            )
+        };
+        let make_matcher = || {
+            Matcher::new({
+                let mut cfg = Config::DEFAULT;
+                cfg.prefer_prefix = true;
+                cfg
+            })
+        };
         match options.match_algorithm {
             MatchAlgorithm::Prefix | MatchAlgorithm::Substring => {
                 let needle = if options.case_sensitive {
@@ -103,45 +123,17 @@ impl<T> NuMatcher<'_, T> {
                     state: State::Unscored(Vec::new()),
                 }
             }
-            MatchAlgorithm::Fuzzy => {
-                let atom = Atom::new(
-                    needle,
-                    if options.case_sensitive {
-                        CaseMatching::Respect
-                    } else {
-                        CaseMatching::Ignore
-                    },
-                    Normalization::Smart,
-                    AtomKind::Fuzzy,
-                    false,
-                );
-                NuMatcher {
-                    options,
-                    should_sort,
-                    needle: needle.to_owned(),
-                    state: State::Fuzzy {
-                        matcher: Matcher::new({
-                            let mut cfg = Config::DEFAULT;
-                            cfg.prefer_prefix = true;
-                            cfg
-                        }),
-                        atom,
-                        matches: Vec::new(),
-                    },
-                }
-            }
+            MatchAlgorithm::Fuzzy => NuMatcher {
+                options,
+                should_sort,
+                needle: needle.to_owned(),
+                state: State::Fuzzy {
+                    matcher: make_matcher(),
+                    atom: make_atom(),
+                    matches: Vec::new(),
+                },
+            },
             MatchAlgorithm::Fallback => {
-                let atom = Atom::new(
-                    needle,
-                    if options.case_sensitive {
-                        CaseMatching::Respect
-                    } else {
-                        CaseMatching::Ignore
-                    },
-                    Normalization::Smart,
-                    AtomKind::Fuzzy,
-                    false,
-                );
                 let needle = if options.case_sensitive {
                     needle.to_owned()
                 } else {
@@ -152,12 +144,8 @@ impl<T> NuMatcher<'_, T> {
                     should_sort,
                     needle,
                     state: State::Fallback {
-                        matcher: Matcher::new({
-                            let mut cfg = Config::DEFAULT;
-                            cfg.prefer_prefix = true;
-                            cfg
-                        }),
-                        atom,
+                        matcher: make_matcher(),
+                        atom: make_atom(),
                         prefix_matches: Vec::new(),
                         fuzzy_matches: Vec::new(),
                     },

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -302,56 +302,39 @@ impl<T> NuMatcher<'_, T> {
     }
 
     fn sort(&mut self) {
-        match &mut self.state {
-            State::Unscored(matches) => {
-                matches.sort_by(|a, b| {
-                    let cmp_sensitive = a.haystack.cmp(&b.haystack);
-                    if self.options.case_sensitive {
-                        cmp_sensitive
-                    } else {
-                        a.haystack
-                            .to_folded_case()
-                            .cmp(&b.haystack.to_folded_case())
-                            .then(cmp_sensitive)
-                    }
-                });
+        let sort_unscored = |matches: &mut [UnscoredMatch<T>]| {
+            matches.sort_by(|a, b| {
+                let cmp_sensitive = a.haystack.cmp(&b.haystack);
+                if self.options.case_sensitive {
+                    cmp_sensitive
+                } else {
+                    a.haystack
+                        .to_folded_case()
+                        .cmp(&b.haystack.to_folded_case())
+                        .then(cmp_sensitive)
+                }
+            });
+        };
+        let sort_fuzzy = |matches: &mut [FuzzyMatch<T>]| match self.options.sort {
+            CompletionSort::Alphabetical => {
+                matches.sort_by(|a, b| a.haystack.cmp(&b.haystack));
             }
-            State::Fuzzy { matches, .. } => match self.options.sort {
-                CompletionSort::Alphabetical => {
-                    matches.sort_by(|a, b| a.haystack.cmp(&b.haystack));
-                }
-                CompletionSort::Smart => {
-                    matches.sort_by(|a, b| b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack)));
-                }
-            },
+            CompletionSort::Smart => {
+                matches.sort_by(|a, b| b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack)));
+            }
+        };
+        match &mut self.state {
+            State::Unscored(matches) => sort_unscored(matches),
+            State::Fuzzy { matches, .. } => sort_fuzzy(matches),
             State::Fallback {
                 prefix_matches,
                 fuzzy_matches,
                 ..
             } => {
                 if prefix_matches.is_empty() {
-                    match self.options.sort {
-                        CompletionSort::Alphabetical => {
-                            fuzzy_matches.sort_by(|a, b| a.haystack.cmp(&b.haystack));
-                        }
-                        CompletionSort::Smart => {
-                            fuzzy_matches.sort_by(|a, b| {
-                                b.score.cmp(&a.score).then(a.haystack.cmp(&b.haystack))
-                            });
-                        }
-                    }
+                    sort_fuzzy(fuzzy_matches);
                 } else {
-                    prefix_matches.sort_by(|a, b| {
-                        let cmp_sensitive = a.haystack.cmp(&b.haystack);
-                        if self.options.case_sensitive {
-                            cmp_sensitive
-                        } else {
-                            a.haystack
-                                .to_folded_case()
-                                .cmp(&b.haystack.to_folded_case())
-                                .then(cmp_sensitive)
-                        }
-                    });
+                    sort_unscored(prefix_matches);
                 }
             }
         }

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -483,6 +483,12 @@ mod test {
     #[case(MatchAlgorithm::Fuzzy, "example text", "ext", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mplxt", true)]
     #[case(MatchAlgorithm::Fuzzy, "example text", "mpp", false)]
+    #[case(MatchAlgorithm::Fallback, "example text", "", true)]
+    #[case(MatchAlgorithm::Fallback, "example text", "examp", true)]
+    #[case(MatchAlgorithm::Fallback, "example text", "text", true)]
+    #[case(MatchAlgorithm::Fallback, "example text", "ext", true)]
+    #[case(MatchAlgorithm::Fallback, "example text", "mplxt", true)]
+    #[case(MatchAlgorithm::Fallback, "example text", "mpp", false)]
     fn match_algorithm_simple(
         #[case] match_algorithm: MatchAlgorithm,
         #[case] haystack: &str,

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -294,6 +294,21 @@ impl<T> NuMatcher<'_, T> {
         self.matches_aux(haystack.as_ref(), Some(item)).is_some()
     }
 
+    /// Returns whether the haystack matches the needle using prefix matching.
+    pub(crate) fn has_prefix_match(&self, orig_haystack: &str) -> bool {
+        let haystack = orig_haystack.trim_start_matches(QUOTES);
+        let offset = orig_haystack.len() - haystack.len();
+        let haystack = haystack.trim_end_matches(QUOTES);
+        Self::unscored_matches(
+            haystack,
+            self.needle.as_str(),
+            MatchAlgorithm::Prefix,
+            offset,
+            self.options.case_sensitive,
+        )
+        .is_some()
+    }
+
     /// Check if the given haystack matches the needle without adding it as a result.
     ///
     /// Returns match indices if it matched, None if it didn't.

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -162,6 +162,37 @@ impl<T> NuMatcher<'_, T> {
         }
     }
 
+    fn unscored_matches(
+        haystack: &str,
+        needle: &str,
+        match_algorithm: MatchAlgorithm,
+        offset: usize,
+        case_sensitive: bool,
+    ) -> Option<Vec<usize>> {
+        let haystack_folded = if case_sensitive {
+            Cow::Borrowed(haystack)
+        } else {
+            Cow::Owned(haystack.to_folded_case())
+        };
+        let match_start = match match_algorithm {
+            MatchAlgorithm::Prefix => {
+                if haystack_folded.starts_with(needle) {
+                    Some(0)
+                } else {
+                    None
+                }
+            }
+            MatchAlgorithm::Substring => haystack_folded.find(needle),
+            MatchAlgorithm::Fuzzy | MatchAlgorithm::Fallback => None,
+        };
+        match_start.map(|byte_start| {
+            let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
+            // TODO this doesn't account for lowercasing changing the length of the haystack
+            let grapheme_len = needle.graphemes(true).count();
+            (offset + grapheme_start..offset + grapheme_start + grapheme_len).collect()
+        })
+    }
+
     /// Returns whether or not the haystack matches the needle. If it does, `item` is added
     /// to the list of matches (if given).
     ///
@@ -172,37 +203,21 @@ impl<T> NuMatcher<'_, T> {
         let haystack = haystack.trim_end_matches(QUOTES);
         match &mut self.state {
             State::Unscored(matches) => {
-                let haystack_folded = if self.options.case_sensitive {
-                    Cow::Borrowed(haystack)
-                } else {
-                    Cow::Owned(haystack.to_folded_case())
-                };
-                let match_start = match self.options.match_algorithm {
-                    MatchAlgorithm::Prefix => {
-                        if haystack_folded.starts_with(self.needle.as_str()) {
-                            Some(0)
-                        } else {
-                            None
-                        }
-                    }
-                    MatchAlgorithm::Substring => haystack_folded.find(self.needle.as_str()),
-                    _ => unreachable!("Only prefix and substring algorithms don't use score"),
-                };
-                match_start.map(|byte_start| {
-                    let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
-                    // TODO this doesn't account for lowercasing changing the length of the haystack
-                    let grapheme_len = self.needle.graphemes(true).count();
-                    let match_indices: Vec<usize> =
-                        (offset + grapheme_start..offset + grapheme_start + grapheme_len).collect();
-                    if let Some(item) = item {
-                        matches.push(UnscoredMatch {
-                            item,
-                            haystack: haystack.to_string(),
-                            match_indices: match_indices.clone(),
-                        });
-                    }
-                    match_indices
-                })
+                let match_indices = Self::unscored_matches(
+                    haystack,
+                    self.needle.as_str(),
+                    self.options.match_algorithm,
+                    offset,
+                    self.options.case_sensitive,
+                )?;
+                if let Some(item) = item {
+                    matches.push(UnscoredMatch {
+                        item,
+                        haystack: haystack.to_string(),
+                        match_indices: match_indices.clone(),
+                    });
+                }
+                Some(match_indices)
             }
             State::Fuzzy {
                 matcher,
@@ -236,20 +251,13 @@ impl<T> NuMatcher<'_, T> {
                 fuzzy_matches,
             } => {
                 // prefix
-                let haystack_folded = if self.options.case_sensitive {
-                    Cow::Borrowed(haystack)
-                } else {
-                    Cow::Owned(haystack.to_folded_case())
-                };
-                let match_start = haystack_folded
-                    .starts_with(self.needle.as_str())
-                    .then_some(0);
-                if let Some(byte_start) = match_start {
-                    let grapheme_start = haystack_folded[0..byte_start].graphemes(true).count();
-                    // TODO this doesn't account for lowercasing changing the length of the haystack
-                    let grapheme_len = self.needle.graphemes(true).count();
-                    let match_indices: Vec<usize> =
-                        (offset + grapheme_start..offset + grapheme_start + grapheme_len).collect();
+                if let Some(match_indices) = Self::unscored_matches(
+                    haystack,
+                    self.needle.as_str(),
+                    MatchAlgorithm::Prefix,
+                    offset,
+                    self.options.case_sensitive,
+                ) {
                     if let Some(item) = item {
                         prefix_matches.push(UnscoredMatch {
                             item,

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -1,6 +1,6 @@
 use crate::completions::{
-    Completer, Context, Fetched, SemanticSuggestion, completion_common::FileSuggestion,
-    completion_options::NuMatcher, to_reedline_span,
+    Completer, CompletionOptions, Context, Fetched, MatchAlgorithm, SemanticSuggestion,
+    completion_common::FileSuggestion, completion_options::NuMatcher, to_reedline_span,
 };
 use nu_path::expand_tilde;
 use nu_protocol::{SuggestionKind, engine::VirtualPath};
@@ -14,12 +14,15 @@ pub struct DotNuCompletion {
     pub std_virtual_path: bool,
 }
 
-impl Completer for DotNuCompletion {
-    fn fetch(&mut self, ctx: &Context) -> Fetched {
+impl DotNuCompletion {
+    fn complete_with_options(
+        &self,
+        ctx: &Context,
+        options: &CompletionOptions,
+    ) -> Vec<SemanticSuggestion> {
         let working_set = ctx.working_set;
         let stack = ctx.stack;
         let span = ctx.span;
-        let options = ctx.options;
         let prefix = ctx.prefix_str();
         let reedline_span = to_reedline_span(span, ctx.offset);
         // Modules that are already loaded go first
@@ -161,6 +164,27 @@ impl Completer for DotNuCompletion {
                 .collect::<Vec<_>>(),
         );
 
-        Fetched::Cacheable(all_results)
+        all_results
+    }
+}
+
+impl Completer for DotNuCompletion {
+    fn fetch(&mut self, ctx: &Context) -> Fetched {
+        let suggestions = if ctx.options.match_algorithm == MatchAlgorithm::Fallback {
+            let mut options = ctx.options.clone();
+            options.match_algorithm = MatchAlgorithm::Prefix;
+
+            let prefix_matches = self.complete_with_options(ctx, &options);
+            if prefix_matches.is_empty() {
+                options.match_algorithm = MatchAlgorithm::Fuzzy;
+                self.complete_with_options(ctx, &options)
+            } else {
+                prefix_matches
+            }
+        } else {
+            self.complete_with_options(ctx, ctx.options)
+        };
+
+        Fetched::Cacheable(suggestions)
     }
 }

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -30,22 +30,20 @@ impl Completer for ExportableCompletion<'_> {
         );
         let span = to_reedline_span(ctx.span, ctx.offset);
         // TODO: use matcher.add_lazy to lazy evaluate an item if it matches the prefix
-        let mut maybe_add_suggestion =
+        let make_suggestion =
             |value: String,
              description: Option<String>,
              extra: Option<Vec<String>>,
-             kind: SuggestionKind| {
-                matcher.add_semantic_suggestion(SemanticSuggestion {
-                    suggestion: Suggestion {
-                        value,
-                        span,
-                        description,
-                        extra,
-                        match_indices: None,
-                        ..Suggestion::default()
-                    },
-                    kind: Some(kind),
-                });
+             kind: SuggestionKind| SemanticSuggestion {
+                suggestion: Suggestion {
+                    value,
+                    span,
+                    description,
+                    extra,
+                    match_indices: None,
+                    ..Suggestion::default()
+                },
+                kind: Some(kind),
             };
 
         let working_set = self.temp_working_set.as_ref().unwrap_or(working_set);
@@ -53,39 +51,51 @@ impl Completer for ExportableCompletion<'_> {
 
         for (name, decl_id) in &module.decls {
             let name = String::from_utf8_lossy(name).into_owned();
+            if matcher.check_match(&name).is_none() {
+                continue;
+            }
+
             let cmd = working_set.get_decl(*decl_id);
-            maybe_add_suggestion(
+            matcher.add_semantic_suggestion(make_suggestion(
                 wrapped_name(name),
                 Some(cmd.description().to_string()),
                 None,
                 // `None` here avoids arguments being expanded by snippet edit style for lsp
                 SuggestionKind::Command(cmd.command_type(), None),
-            );
+            ));
         }
         for (name, module_id) in &module.submodules {
             let name = String::from_utf8_lossy(name).into_owned();
+            if matcher.check_match(&name).is_none() {
+                continue;
+            }
+
             let (desc, extra) = working_set
                 .get_module_comments(*module_id)
                 .map(|spans| working_set.build_desc(spans))
                 .unzip();
-            maybe_add_suggestion(
+            matcher.add_semantic_suggestion(make_suggestion(
                 wrapped_name(name),
                 desc.or_else(|| Some("Submodule".into())),
                 extra.map(|s| vec![s]),
                 SuggestionKind::Module,
-            );
+            ));
         }
         for (name, var_id) in &module.constants {
             let name = String::from_utf8_lossy(name).into_owned();
+            if matcher.check_match(&name).is_none() {
+                continue;
+            }
+
             let var = working_set.get_variable(*var_id);
-            maybe_add_suggestion(
+            matcher.add_semantic_suggestion(make_suggestion(
                 wrapped_name(name),
                 var.const_val
                     .as_ref()
                     .and_then(|v| v.clone().coerce_into_string().ok()),
                 None,
                 SuggestionKind::Variable,
-            );
+            ));
         }
         Fetched::Pure(matcher.suggestion_results())
     }

--- a/crates/nu-cli/src/completions/exportable_completions.rs
+++ b/crates/nu-cli/src/completions/exportable_completions.rs
@@ -23,76 +23,70 @@ impl Completer for ExportableCompletion<'_> {
     fn fetch(&mut self, ctx: &Context) -> Fetched {
         let working_set = ctx.working_set;
         let prefix = ctx.prefix_str();
-        let mut matcher = NuMatcher::<()>::new(surround_remove(prefix.as_ref()), ctx.options, true);
-        let mut results = Vec::new();
+        let mut matcher = NuMatcher::<SemanticSuggestion>::new(
+            surround_remove(prefix.as_ref()),
+            ctx.options,
+            false,
+        );
         let span = to_reedline_span(ctx.span, ctx.offset);
         // TODO: use matcher.add_lazy to lazy evaluate an item if it matches the prefix
-        let mut add_suggestion = |value: String,
-                                  description: Option<String>,
-                                  extra: Option<Vec<String>>,
-                                  match_indices: Vec<usize>,
-                                  kind: SuggestionKind| {
-            results.push(SemanticSuggestion {
-                suggestion: Suggestion {
-                    value,
-                    span,
-                    description,
-                    extra,
-                    match_indices: Some(match_indices),
-                    ..Suggestion::default()
-                },
-                kind: Some(kind),
-            });
-        };
+        let mut maybe_add_suggestion =
+            |value: String,
+             description: Option<String>,
+             extra: Option<Vec<String>>,
+             kind: SuggestionKind| {
+                matcher.add_semantic_suggestion(SemanticSuggestion {
+                    suggestion: Suggestion {
+                        value,
+                        span,
+                        description,
+                        extra,
+                        match_indices: None,
+                        ..Suggestion::default()
+                    },
+                    kind: Some(kind),
+                });
+            };
 
         let working_set = self.temp_working_set.as_ref().unwrap_or(working_set);
         let module = working_set.get_module(self.module_id);
 
         for (name, decl_id) in &module.decls {
             let name = String::from_utf8_lossy(name).into_owned();
-            if let Some(match_indices) = matcher.check_match(&name) {
-                let cmd = working_set.get_decl(*decl_id);
-                add_suggestion(
-                    wrapped_name(name),
-                    Some(cmd.description().to_string()),
-                    None,
-                    match_indices,
-                    // `None` here avoids arguments being expanded by snippet edit style for lsp
-                    SuggestionKind::Command(cmd.command_type(), None),
-                );
-            }
+            let cmd = working_set.get_decl(*decl_id);
+            maybe_add_suggestion(
+                wrapped_name(name),
+                Some(cmd.description().to_string()),
+                None,
+                // `None` here avoids arguments being expanded by snippet edit style for lsp
+                SuggestionKind::Command(cmd.command_type(), None),
+            );
         }
         for (name, module_id) in &module.submodules {
             let name = String::from_utf8_lossy(name).into_owned();
-            if let Some(match_indices) = matcher.check_match(&name) {
-                let (desc, extra) = working_set
-                    .get_module_comments(*module_id)
-                    .map(|spans| working_set.build_desc(spans))
-                    .unzip();
-                add_suggestion(
-                    wrapped_name(name),
-                    desc.or_else(|| Some("Submodule".into())),
-                    extra.map(|s| vec![s]),
-                    match_indices,
-                    SuggestionKind::Module,
-                );
-            }
+            let (desc, extra) = working_set
+                .get_module_comments(*module_id)
+                .map(|spans| working_set.build_desc(spans))
+                .unzip();
+            maybe_add_suggestion(
+                wrapped_name(name),
+                desc.or_else(|| Some("Submodule".into())),
+                extra.map(|s| vec![s]),
+                SuggestionKind::Module,
+            );
         }
         for (name, var_id) in &module.constants {
             let name = String::from_utf8_lossy(name).into_owned();
-            if let Some(match_indices) = matcher.check_match(&name) {
-                let var = working_set.get_variable(*var_id);
-                add_suggestion(
-                    wrapped_name(name),
-                    var.const_val
-                        .as_ref()
-                        .and_then(|v| v.clone().coerce_into_string().ok()),
-                    None,
-                    match_indices,
-                    SuggestionKind::Variable,
-                );
-            }
+            let var = working_set.get_variable(*var_id);
+            maybe_add_suggestion(
+                wrapped_name(name),
+                var.const_val
+                    .as_ref()
+                    .and_then(|v| v.clone().coerce_into_string().ok()),
+                None,
+                SuggestionKind::Variable,
+            );
         }
-        Fetched::Pure(results)
+        Fetched::Pure(matcher.suggestion_results())
     }
 }

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -12,7 +12,8 @@ use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_path::{AbsolutePathBuf, expand_tilde};
 use nu_protocol::{
-    Config, ParseError, PipelineData, Value, debugger::WithoutDebug, engine::StateWorkingSet,
+    CompletionAlgorithm, Config, ParseError, PipelineData, Value, debugger::WithoutDebug,
+    engine::StateWorkingSet,
 };
 use nu_std::load_standard_library;
 
@@ -827,6 +828,53 @@ fn fallback_command_completion_prefers_prefix_matches() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let suggestions = completer.complete_blocking("slp", 3);
     match_suggestions(&vec!["slping"], &suggestions);
+}
+
+#[test]
+fn fallback_external_limit_preserves_prefix_matches() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fuzzy_dir = dir.path().join("fuzzy");
+    let prefix_dir = dir.path().join("prefix");
+    std::fs::create_dir(&fuzzy_dir).expect("create fuzzy directory");
+    std::fs::create_dir(&prefix_dir).expect("create prefix directory");
+
+    let (fuzzy_name, prefix_name) = if cfg!(windows) {
+        ("sleep.exe", "slping.exe")
+    } else {
+        ("sleep", "slping")
+    };
+    let fuzzy_path = fuzzy_dir.join(fuzzy_name);
+    let prefix_path = prefix_dir.join(prefix_name);
+    std::fs::write(&fuzzy_path, "").expect("write fuzzy command");
+    std::fs::write(&prefix_path, "").expect("write prefix command");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(&fuzzy_path, std::fs::Permissions::from_mode(0o755))
+            .expect("make fuzzy command executable");
+        std::fs::set_permissions(&prefix_path, std::fs::Permissions::from_mode(0o755))
+            .expect("make prefix command executable");
+    }
+
+    let pwd = AbsolutePathBuf::try_from(dir.path().to_path_buf()).expect("absolute tempdir");
+    let (_, _, mut engine, stack) = new_engine_helper(pwd);
+    engine.add_env_var(
+        "PATH".to_string(),
+        Value::test_list(vec![
+            Value::test_string(fuzzy_dir.to_string_lossy()),
+            Value::test_string(prefix_dir.to_string_lossy()),
+        ]),
+    );
+    let mut config = engine.get_config().as_ref().clone();
+    config.completions.algorithm = CompletionAlgorithm::Fallback;
+    config.completions.external.max_results = 1;
+    engine.set_config(config);
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let input = "^slp";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions(&vec![prefix_name], &suggestions);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -305,6 +305,21 @@ fn customcompletions_inherit_options() {
 }
 
 #[test]
+fn customcompletions_use_fallback_algorithm() {
+    let mut completer = custom_completer_with_options(
+        r#"$env.config.completions.algorithm = "prefix""#,
+        r#"completion_algorithm: "fallback""#,
+        &["barfoo", "foobar"],
+    );
+
+    let suggestions = completer.complete_blocking("my-command foo", 14);
+    match_suggestions(&vec!["foobar"], &suggestions);
+
+    let suggestions = completer.complete_blocking("my-command rfo", 14);
+    match_suggestions(&vec!["barfoo"], &suggestions);
+}
+
+#[test]
 fn customcompletions_no_sort() {
     let mut completer = custom_completer_with_options(
         "",
@@ -812,6 +827,52 @@ fn fallback_command_completion_prefers_prefix_matches() {
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
     let suggestions = completer.complete_blocking("slp", 3);
     match_suggestions(&vec!["slping"], &suggestions);
+}
+
+#[test]
+fn fallback_path_completion_prefers_prefix_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("parent-one/child")).expect("create directory");
+    std::fs::create_dir_all(dir.path().join("parent-two/fuzzy-child")).expect("create directory");
+
+    let pwd = AbsolutePathBuf::try_from(dir.path().to_path_buf()).expect("absolute tempdir");
+    let (_, _, mut engine, mut stack) = new_engine_helper(pwd);
+    assert!(
+        support::merge_input(
+            br#"$env.config.completions.algorithm = "fallback""#,
+            &mut engine,
+            &mut stack,
+        )
+        .is_ok()
+    );
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let input = "cd parent/child";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions_by_string(&[folder("parent-one/child")], &suggestions);
+}
+
+#[test]
+fn fallback_path_completion_uses_fuzzy_paths_without_prefix_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("parent-one/nope")).expect("create directory");
+    std::fs::create_dir_all(dir.path().join("xparent/child")).expect("create directory");
+
+    let pwd = AbsolutePathBuf::try_from(dir.path().to_path_buf()).expect("absolute tempdir");
+    let (_, _, mut engine, mut stack) = new_engine_helper(pwd);
+    assert!(
+        support::merge_input(
+            br#"$env.config.completions.algorithm = "fallback""#,
+            &mut engine,
+            &mut stack,
+        )
+        .is_ok()
+    );
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let input = "cd parent/child";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions_by_string(&[folder("xparent/child")], &suggestions);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1255,6 +1255,25 @@ fn module_name_completions() {
 }
 
 #[test]
+fn dotnu_fallback_prefers_prefix_across_sources() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("barfoo.nu"), "").expect("write module file");
+
+    let pwd = AbsolutePathBuf::try_from(dir.path().to_path_buf()).expect("absolute tempdir");
+    let (_, _, mut engine, mut stack) = new_engine_helper(pwd);
+    let code = r#"
+        $env.config.completions.algorithm = "fallback"
+        module foobar {}
+    "#;
+    assert!(support::merge_input(code.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let input = "use foo";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions(&vec!["foobar"], &suggestions);
+}
+
+#[test]
 fn dotnu_stdlib_completions() {
     let (_, _, mut engine, stack) = new_dotnu_engine();
     assert!(load_standard_library(&mut engine).is_ok());

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -800,6 +800,21 @@ fn external_commands() {
 }
 
 #[test]
+fn fallback_command_completion_prefers_prefix_matches() {
+    let mut engine = new_external_engine();
+    let mut stack = nu_protocol::engine::Stack::new();
+    let setup = r#"
+        $env.config.completions.algorithm = "fallback"
+        def slping [] {}
+    "#;
+    assert!(support::merge_input(setup.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+    let suggestions = completer.complete_blocking("slp", 3);
+    match_suggestions(&vec!["slping"], &suggestions);
+}
+
+#[test]
 fn percent_completion_only_shows_builtins() {
     let (_, _, mut engine, mut stack) = new_engine();
     let setup = "

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -1208,6 +1208,29 @@ fn exportable_completions() {
 }
 
 #[test]
+fn exportable_completions_use_fallback_matching() {
+    let (_, _, mut engine, mut stack) = new_engine();
+    let code = r#"
+        $env.config.completions.algorithm = "fallback"
+        export module hybrid {
+            export def foobar [] {}
+            export def barfoo [] {}
+        }
+    "#;
+    assert!(support::merge_input(code.as_bytes(), &mut engine, &mut stack).is_ok());
+
+    let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
+
+    let input = "use hybrid foo";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions(&vec!["foobar"], &suggestions);
+
+    let input = "use hybrid rfo";
+    let suggestions = completer.complete_blocking(input, input.len());
+    match_suggestions(&vec!["barfoo"], &suggestions);
+}
+
+#[test]
 fn dotnu_completions_const_nu_lib_dirs() {
     let (_, _, engine, stack) = new_dotnu_engine();
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));

--- a/crates/nu-config/default_files/doc_config.nu
+++ b/crates/nu-config/default_files/doc_config.nu
@@ -244,13 +244,15 @@ $env.config.hinter.closure = null
 # "prefix": Match from the beginning of the text.
 # "substring": Match anywhere in the text.
 # "fuzzy": Match using fuzzy matching algorithm.
+# "fallback": Use prefix matches when any exist; otherwise use fuzzy matches.
 # Default: "prefix"
 $env.config.completions.algorithm = "prefix"
 
 # completions.sort (string): How completion results are sorted.
 # "smart": Sort order depends on the algorithm setting.
 # "alphabetical": Always sort alphabetically.
-# In "smart",  mode: prefix/substring use alphabetical; fuzzy uses match score.
+# In "smart" mode: prefix/substring use alphabetical order; fuzzy uses match score.
+# Fallback uses alphabetical order for prefix results and fuzzy match score otherwise.
 # Default: "smart"
 $env.config.completions.sort = "smart"
 

--- a/crates/nu-protocol/src/config/completions.rs
+++ b/crates/nu-protocol/src/config/completions.rs
@@ -8,6 +8,7 @@ pub enum CompletionAlgorithm {
     Prefix,
     Substring,
     Fuzzy,
+    Fallback,
 }
 
 impl FromStr for CompletionAlgorithm {
@@ -18,7 +19,8 @@ impl FromStr for CompletionAlgorithm {
             "prefix" => Ok(Self::Prefix),
             "substring" => Ok(Self::Substring),
             "fuzzy" => Ok(Self::Fuzzy),
-            _ => Err("'prefix' or 'fuzzy' or 'substring'"),
+            "fallback" => Ok(Self::Fallback),
+            _ => Err("'prefix' or 'fuzzy' or 'substring' or 'fallback'"),
         }
     }
 }


### PR DESCRIPTION
   ## Description

   Adds the `fallback` completion algorithm for #11211.

   With `completions.algorithm = "fallback"`, Nushell shows prefix
 matches when available and falls back to fuzzy matches only when there
 are no prefix matches.

   ## User-facing changes (Release notes)

   Added a `"fallback"` completion algorithm. It prefers prefix matches
 and uses fuzzy matching only when no prefix matches exist.

   ## Additional notes

   Fixes #11211