### PR TITLE
Reject command names with irregular whitespace at definition time

### DIFF
--- a/crates/nu-parser/src/parse_alias.rs
+++ b/crates/nu-parser/src/parse_alias.rs
@@ -139,6 +139,7 @@ pub fn parse_alias(
                 || name.contains('%')
                 || name.parse::<bytesize::ByteSize>().is_ok()
                 || name.parse::<f64>().is_ok()
+                || name.split_ascii_whitespace().collect::<Vec<_>>().join(" ") != name
             {
                 working_set.error(ParseError::AliasNotValid(alias_name_expr.span));
                 return garbage_pipeline(working_set, spans);

--- a/crates/nu-parser/src/parse_def.rs
+++ b/crates/nu-parser/src/parse_def.rs
@@ -84,11 +84,14 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
         return;
     };
 
+    // A call is looked up by its words joined with single spaces, so a name
+    // with any other whitespace could never be called (#15539).
     if name.contains('#')
         || name.contains('^')
         || name.contains('%')
         || name.parse::<bytesize::ByteSize>().is_ok()
         || name.parse::<f64>().is_ok()
+        || name.split_ascii_whitespace().collect::<Vec<_>>().join(" ") != name
     {
         working_set.error(ParseError::CommandDefNotValid(spans[name_pos]));
         return;

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -840,6 +840,72 @@ pub fn parse_attributes_external_alias() {
     assert!(parse_error.contains("Encountered error during parse-time evaluation"));
 }
 
+#[rstest]
+#[case::double_space("foo  bar")]
+#[case::leading_space(" foo")]
+#[case::trailing_space("foo ")]
+#[case::tab("foo\tbar")]
+pub fn parse_rejects_irregular_whitespace_in_command_names(#[case] name: &str) {
+    // https://github.com/nushell/nushell/issues/15539
+    // A call is looked up by its words joined with single spaces, so a name
+    // with any other whitespace could never be called.
+    let first_error = |source: &str| {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(Def));
+        working_set.add_decl(Box::new(Alias));
+        working_set.add_decl(Box::new(AttrEcho));
+        let _ = parse(&mut working_set, None, source.as_bytes(), false);
+        working_set.parse_errors.first().cloned()
+    };
+
+    for source in [
+        format!("def \"{name}\" [] {{}}"),
+        format!("extern \"{name}\" []"),
+    ] {
+        assert!(
+            matches!(
+                first_error(&source),
+                Some(ParseError::CommandDefNotValid(_))
+            ),
+            "{source:?}"
+        );
+    }
+
+    let source = format!("alias \"{name}\" = attr echo");
+    assert!(
+        matches!(first_error(&source), Some(ParseError::AliasNotValid(_))),
+        "{source:?}"
+    );
+}
+
+#[test]
+pub fn parse_accepts_single_spaces_in_command_names() {
+    let mut engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    working_set.add_decl(Box::new(Def));
+    working_set.add_decl(Box::new(Alias));
+    working_set.add_decl(Box::new(AttrEcho));
+
+    let _ = engine_state.merge_delta(working_set.render());
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let source = br#"
+    def "foo bar" [] {}
+    alias "foo bar baz" = attr echo
+    "#;
+    let _ = parse(&mut working_set, None, source, false);
+
+    assert!(
+        working_set.parse_errors.is_empty(),
+        "{:?}",
+        working_set.parse_errors
+    );
+    assert!(working_set.find_decl(b"foo bar").is_some());
+    assert!(working_set.find_decl(b"foo bar baz").is_some());
+}
+
 #[test]
 pub fn parse_aliased_variable_in() {
     // https://github.com/nushell/nushell/issues/13706

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -299,13 +299,15 @@ pub enum ParseError {
     #[error("Alias name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid))]
     AliasNotValid(
-        #[label = "alias name can't be a number, a filesize, or contain #, ^, or %"] Span,
+        #[label = "alias name can't be a number, a filesize, contain #, ^, or %, or have whitespace other than single spaces between words"]
+         Span,
     ),
 
     #[error("Command name not supported.")]
     #[diagnostic(code(nu::parser::variable_not_valid))]
     CommandDefNotValid(
-        #[label = "command name can't be a number, a filesize, or contain #, ^, or %"] Span,
+        #[label = "command name can't be a number, a filesize, contain #, ^, or %, or have whitespace other than single spaces between words"]
+         Span,
     ),
 
     #[error("Module not found.")]


### PR DESCRIPTION
`def "foo  bar" [] {}` is accepted, but `foo  bar` can never be called: `command_name_from_spans` in `crates/nu-parser/src/parse_calls.rs` rebuilds the name from the lexed words with single spaces, so the call looks up `foo bar` and falls through to an external. Leading or trailing whitespace and tabs fail the same way. As sholderbach suggested on the issue, refusing such definitions is the sensible fix.

`def`, `extern` and `alias` now reject a name unless it equals its words joined by single spaces, reusing `CommandDefNotValid` and `AliasNotValid` with their labels extended. Parser tests cover the rejected shapes for all three keywords and check that single-space names still work; `cargo test -p nu-parser`, clippy with `-D warnings` on `nu-parser` and `nu-protocol`, and `cargo fmt --all -- --check` pass.

## User-facing changes (Release notes)

Defining a command or alias whose name contains consecutive, leading, or trailing whitespace is now a parse error, since such a command could never be called.

Fixes #15539
