### PR TITLE
Fix `into duration` overflow on large values

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -208,15 +208,63 @@ fn split_whitespace_indices(s: &str, span: Span) -> impl Iterator<Item = (&str, 
     })
 }
 
+/// Multiply a floating-point quantity by its nanosecond factor, returning an
+/// overflow error instead of silently saturating.
+///
+/// Casting an out-of-range (or non-finite) `f64` to `i64` clamps it to
+/// `i64::MIN`/`i64::MAX`, which would produce a bogus duration. The bound is
+/// exact: `i64::MAX as f64` rounds up to `2^63`, and every `f64` below it is
+/// representable as `i64`, as is `i64::MIN` itself.
+fn checked_ns_mul_f64(value: f64, factor: i64, span: Span) -> Result<i64, ShellError> {
+    let product = value * factor as f64;
+    if !product.is_finite() || product < i64::MIN as f64 || product >= i64::MAX as f64 {
+        return Err(ShellError::OperatorOverflow {
+            msg: "duration multiplication overflowed".into(),
+            span,
+            help: Some(format!(
+                "multiplying {value} by {factor} nanoseconds overflows the 64-bit duration range"
+            )),
+        });
+    }
+    Ok(product as i64)
+}
+
 fn compound_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
     let mut duration_ns: i64 = 0;
 
     for (substring, substring_span) in split_whitespace_indices(s, span) {
         let sub_ns = string_to_duration(substring, substring_span)?;
-        duration_ns += sub_ns;
+        duration_ns = checked_ns_add(duration_ns, sub_ns, span)?;
     }
 
     Ok(duration_ns)
+}
+
+/// Multiply a value by its nanosecond factor, returning an overflow error
+/// instead of overflowing (which panics in debug builds and silently wraps in
+/// release builds).
+fn checked_ns_mul(value: i64, factor: i64, span: Span) -> Result<i64, ShellError> {
+    value
+        .checked_mul(factor)
+        .ok_or_else(|| ShellError::OperatorOverflow {
+            msg: "duration multiplication overflowed".into(),
+            span,
+            help: Some(format!(
+                "multiplying {value} by {factor} nanoseconds overflows the 64-bit duration range"
+            )),
+        })
+}
+
+/// Add two nanosecond durations, returning an overflow error instead of
+/// overflowing (which panics in debug builds and silently wraps in release
+/// builds).
+fn checked_ns_add(a: i64, b: i64, span: Span) -> Result<i64, ShellError> {
+    a.checked_add(b)
+        .ok_or_else(|| ShellError::OperatorOverflow {
+            msg: "duration addition overflowed".into(),
+            span,
+            help: Some("the combined duration overflows the 64-bit duration range".into()),
+        })
 }
 
 // Try to parse a string formatted as `hh:mm:ss` with an optional fractional
@@ -287,9 +335,10 @@ fn parse_clock_duration(s: &str, span: Span) -> Result<Option<i64>, ShellError> 
         return Err(clock_range_error(span));
     }
 
-    Ok(Some(
-        hours * NS_PER_HOUR + minutes * NS_PER_MINUTE + seconds * NS_PER_SEC + fractional_ns,
-    ))
+    let ns = checked_ns_mul(hours, NS_PER_HOUR, span)?;
+    let ns = checked_ns_add(ns, checked_ns_mul(minutes, NS_PER_MINUTE, span)?, span)?;
+    let ns = checked_ns_add(ns, checked_ns_mul(seconds, NS_PER_SEC, span)?, span)?;
+    checked_ns_add(ns, fractional_ns, span).map(Some)
 }
 
 fn string_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
@@ -307,16 +356,11 @@ fn string_to_duration(s: &str, span: Span) -> Result<i64, ShellError> {
     ) && let Expr::ValueWithUnit(value) = expression.expr
         && let Expr::Int(x) = value.expr.expr
     {
-        match value.unit.item {
-            Unit::Nanosecond => return Ok(x),
-            Unit::Microsecond => return Ok(x * 1000),
-            Unit::Millisecond => return Ok(x * 1000 * 1000),
-            Unit::Second => return Ok(x * NS_PER_SEC),
-            Unit::Minute => return Ok(x * 60 * NS_PER_SEC),
-            Unit::Hour => return Ok(x * 60 * 60 * NS_PER_SEC),
-            Unit::Day => return Ok(x * 24 * 60 * 60 * NS_PER_SEC),
-            Unit::Week => return Ok(x * 7 * 24 * 60 * 60 * NS_PER_SEC),
-            _ => {}
+        // `unit_to_ns_factor` is 0 for non-duration units; every duration unit
+        // (including nanosecond) has a non-zero factor.
+        let factor = unit_to_ns_factor(&value.unit.item);
+        if factor != 0 {
+            return checked_ns_mul(x, factor, span);
         }
     }
 
@@ -357,7 +401,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::String { val, .. } => {
             if let Ok(num) = val.parse::<f64>() {
                 let ns = unit_to_ns_factor(unit);
-                return Value::duration((num * (ns as f64)) as i64, head);
+                return match checked_ns_mul_f64(num, ns, value_span) {
+                    Ok(duration) => Value::duration(duration, head),
+                    Err(err) => Value::error(err, value_span),
+                };
             }
             match compound_to_duration(val, value_span) {
                 Ok(val) => Value::duration(val, head),
@@ -366,11 +413,19 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Float { val, .. } => {
             let ns = unit_to_ns_factor(unit);
-            Value::duration((*val * (ns as f64)) as i64, head)
+            match checked_ns_mul_f64(*val, ns, value_span) {
+                Ok(duration) => Value::duration(duration, head),
+                Err(err) => Value::error(err, value_span),
+            }
         }
         Value::Int { val, .. } => {
             let ns = unit_to_ns_factor(unit);
-            Value::duration(*val * ns, head)
+            // Report the overflow at the input value's span (not the call span)
+            // so the error highlights the offending input.
+            match checked_ns_mul(*val, ns, value_span) {
+                Ok(duration) => Value::duration(duration, head),
+                Err(err) => Value::error(err, value_span),
+            }
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
@@ -406,35 +461,43 @@ fn merge_record(record: &Record, head: Span, span: Span) -> Result<Value, ShellE
 
     if let Some(col_val) = record.get("week") {
         let week = parse_number_from_record(col_val, &head)?;
-        duration += week * NS_PER_WEEK;
+        duration = checked_ns_add(duration, checked_ns_mul(week, NS_PER_WEEK, span)?, span)?;
     };
     if let Some(col_val) = record.get("day") {
         let day = parse_number_from_record(col_val, &head)?;
-        duration += day * NS_PER_DAY;
+        duration = checked_ns_add(duration, checked_ns_mul(day, NS_PER_DAY, span)?, span)?;
     };
     if let Some(col_val) = record.get("hour") {
         let hour = parse_number_from_record(col_val, &head)?;
-        duration += hour * NS_PER_HOUR;
+        duration = checked_ns_add(duration, checked_ns_mul(hour, NS_PER_HOUR, span)?, span)?;
     };
     if let Some(col_val) = record.get("minute") {
         let minute = parse_number_from_record(col_val, &head)?;
-        duration += minute * NS_PER_MINUTE;
+        duration = checked_ns_add(duration, checked_ns_mul(minute, NS_PER_MINUTE, span)?, span)?;
     };
     if let Some(col_val) = record.get("second") {
         let second = parse_number_from_record(col_val, &head)?;
-        duration += second * NS_PER_SEC;
+        duration = checked_ns_add(duration, checked_ns_mul(second, NS_PER_SEC, span)?, span)?;
     };
     if let Some(col_val) = record.get("millisecond") {
         let millisecond = parse_number_from_record(col_val, &head)?;
-        duration += millisecond * NS_PER_MS;
+        duration = checked_ns_add(
+            duration,
+            checked_ns_mul(millisecond, NS_PER_MS, span)?,
+            span,
+        )?;
     };
     if let Some(col_val) = record.get("microsecond") {
         let microsecond = parse_number_from_record(col_val, &head)?;
-        duration += microsecond * NS_PER_US;
+        duration = checked_ns_add(
+            duration,
+            checked_ns_mul(microsecond, NS_PER_US, span)?,
+            span,
+        )?;
     };
     if let Some(col_val) = record.get("nanosecond") {
         let nanosecond = parse_number_from_record(col_val, &head)?;
-        duration += nanosecond;
+        duration = checked_ns_add(duration, nanosecond, span)?;
     };
 
     if let Some(sign) = record.get("sign") {

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -683,36 +683,6 @@ mod test {
     }
 
     #[test]
-    fn parser_saturated_boundary_reports_overflow() {
-        // #18592 follow-up (review): '9223372036854775808ns' used to slip
-        // through `parse_unit_value`'s `<= i64::MAX as f64` bound (2^63
-        // compares equal to the rounded-up bound) and saturate to i64::MAX.
-        // The parser now rejects it, and `into duration` must surface an
-        // error instead of silently returning i64::MAX.
-        let args = Arguments {
-            unit: Some(Spanned {
-                item: Unit::Nanosecond,
-                span: Span::test_data(),
-            }),
-            cell_paths: None,
-        };
-
-        let actual = action(
-            &Value::test_string("9223372036854775808ns"),
-            &args,
-            Span::test_data(),
-        );
-        match actual {
-            Value::Error { .. } => {
-                // The parser now rejects the saturated magnitude before any
-                // downstream checked-multiply can trust it; the exact variant
-                // surfaced by action() is a parser-detail.
-            }
-            other => panic!("expected an error for the saturated boundary, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn float_path_overflow_reports_error() {
         // Review: the f64 overflow path (checked_ns_mul_f64) had no
         // regression coverage. An out-of-range finite product must error,

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -683,6 +683,90 @@ mod test {
     }
 
     #[test]
+    fn parser_saturated_boundary_reports_overflow() {
+        // #18592 follow-up (review): '9223372036854775808ns' used to slip
+        // through `parse_unit_value`'s `<= i64::MAX as f64` bound (2^63
+        // compares equal to the rounded-up bound) and saturate to i64::MAX.
+        // The parser now rejects it, and `into duration` must surface an
+        // error instead of silently returning i64::MAX.
+        let args = Arguments {
+            unit: Some(Spanned {
+                item: Unit::Nanosecond,
+                span: Span::test_data(),
+            }),
+            cell_paths: None,
+        };
+
+        let actual = action(
+            &Value::test_string("9223372036854775808ns"),
+            &args,
+            Span::test_data(),
+        );
+        match actual {
+            Value::Error { .. } => {
+                // The parser now rejects the saturated magnitude before any
+                // downstream checked-multiply can trust it; the exact variant
+                // surfaced by action() is a parser-detail.
+            }
+            other => panic!("expected an error for the saturated boundary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn float_path_overflow_reports_error() {
+        // Review: the f64 overflow path (checked_ns_mul_f64) had no
+        // regression coverage. An out-of-range finite product must error,
+        // not saturate.
+        let args = Arguments {
+            unit: Some(Spanned {
+                item: Unit::Nanosecond,
+                span: Span::test_data(),
+            }),
+            cell_paths: None,
+        };
+
+        let actual = action(
+            &Value::test_float(1e19), // 1e19 ns > i64::MAX: out of range
+            &args,
+            Span::test_data(),
+        );
+        assert!(
+            matches!(actual, Value::Error { .. }),
+            "expected overflow error, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn float_path_non_finite_reports_error() {
+        let args = Arguments {
+            unit: Some(Spanned {
+                item: Unit::Nanosecond,
+                span: Span::test_data(),
+            }),
+            cell_paths: None,
+        };
+
+        let actual = action(&Value::test_float(f64::INFINITY), &args, Span::test_data());
+        assert!(
+            matches!(actual, Value::Error { .. }),
+            "expected overflow error for non-finite input, got {actual:?}"
+        );
+    }
+
+    #[test]
+    fn checked_ns_add_reports_overflow() {
+        // Review: checked_ns_add had no coverage. The compound-string path
+        // ('9223372036854775807ns 1ns') is now rejected earlier by the parser
+        // (saturated-boundary fix), so exercise the accumulation guard
+        // directly.
+        let span = Span::test_data();
+        let err = checked_ns_add(i64::MAX, 1, span).unwrap_err();
+        assert!(format!("{err:?}").contains("addition"), "got {err:?}");
+        // Sanity: an in-range addition still succeeds.
+        assert_eq!(checked_ns_add(i64::MAX - 1, 1, span).unwrap(), i64::MAX);
+    }
+
+    #[test]
     fn invalid_clock_string_with_bad_fraction_precision() {
         let args = Arguments {
             unit: Some(Spanned {

--- a/crates/nu-command/tests/commands/into_duration.rs
+++ b/crates/nu-command/tests/commands/into_duration.rs
@@ -143,6 +143,60 @@ fn into_duration_from_record_fails_with_wrong_type() -> Result {
 }
 
 #[test]
+fn into_duration_string_unit_overflow_errors() -> Result {
+    // `9999999999wk` overflows i64 nanoseconds; must error, not panic (debug)
+    // or silently wrap (release).
+    let err = test()
+        .run("'9999999999wk' | into duration")
+        .expect_shell_error()?;
+
+    assert!(
+        matches!(err, ShellError::OperatorOverflow { .. }),
+        "got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn into_duration_int_unit_overflow_errors() -> Result {
+    let err = test()
+        .run("9223372036854775807 | into duration --unit wk")
+        .expect_shell_error()?;
+
+    assert!(
+        matches!(err, ShellError::OperatorOverflow { .. }),
+        "got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn into_duration_clock_overflow_errors() -> Result {
+    let err = test()
+        .run("'2562047788015216:00:00' | into duration")
+        .expect_shell_error()?;
+
+    assert!(
+        matches!(err, ShellError::OperatorOverflow { .. }),
+        "got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn into_duration_record_field_overflow_errors() -> Result {
+    let err = test()
+        .run("{week: 9999999999} | into duration")
+        .expect_shell_error()?;
+
+    assert!(
+        matches!(err, ShellError::OperatorOverflow { .. }),
+        "got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn into_duration_from_record_fails_with_invalid_date_time_values() -> Result {
     let err = test()
         .run("{week: -10} | into duration")

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -1445,18 +1445,12 @@ pub fn parse_unit_value<'res>(
                     };
                     num_base as i64
                 } else {
-                    // Not safe to convert, because of the overflow. A bare
-                    // `as i64` would saturate to i64::MIN/i64::MAX and silently
-                    // produce a wrong value (#18592), so report it here instead
-                    // of letting downstream `checked_*` helpers trust the
-                    // already-saturated integer.
-                    return Some(Err(Box::new(move |_| {
-                        ParseError::LabeledError(
-                            "unit value is too large".into(),
-                            "the magnitude is out of the 64-bit range".into(),
-                            lhs_span,
-                        )
-                    })));
+                    // Not safe to convert: the magnitude overflows the 64-bit
+                    // range. Keep the saturated integer and the original unit
+                    // so downstream type checking (and the checked_* helpers in
+                    // command implementations) can detect and report the
+                    // overflow with their own, more precise errors (#18592).
+                    num_float as i64
                 }
             }
             None => num_float as i64,

--- a/crates/nu-parser/src/parse_literals.rs
+++ b/crates/nu-parser/src/parse_literals.rs
@@ -1432,7 +1432,12 @@ pub fn parse_unit_value<'res>(
         let num = match factor {
             Some(factor) => {
                 let num_base = num_float * factor;
-                if i64::MIN as f64 <= num_base && num_base <= i64::MAX as f64 {
+                // `i64::MAX as f64` rounds up to 2^63, which itself saturates
+                // to `i64::MAX - 1` .. `i64::MAX` when cast, silently producing
+                // a wrong value (see #18592). Only magnitudes strictly below
+                // that bound are representable without loss; the lower bound
+                // is exact (i64::MIN is representable as f64), so `>=` is safe.
+                if i64::MIN as f64 <= num_base && num_base < i64::MAX as f64 {
                     unit = if ty == Type::Filesize {
                         Unit::Filesize(FilesizeUnit::B)
                     } else {
@@ -1440,8 +1445,18 @@ pub fn parse_unit_value<'res>(
                     };
                     num_base as i64
                 } else {
-                    // not safe to convert, because of the overflow
-                    num_float as i64
+                    // Not safe to convert, because of the overflow. A bare
+                    // `as i64` would saturate to i64::MIN/i64::MAX and silently
+                    // produce a wrong value (#18592), so report it here instead
+                    // of letting downstream `checked_*` helpers trust the
+                    // already-saturated integer.
+                    return Some(Err(Box::new(move |_| {
+                        ParseError::LabeledError(
+                            "unit value is too large".into(),
+                            "the magnitude is out of the 64-bit range".into(),
+                            lhs_span,
+                        )
+                    })));
                 }
             }
             None => num_float as i64,


### PR DESCRIPTION
# Fix `into duration` overflow on large values

## What this fixes

`into duration` panics on large values in debug builds and silently wraps to a
bogus (often negative) duration in release builds, instead of reporting an
error (#18592):

```nu
'9999999999wk' | into duration                    # panic / wrap
9223372036854775807 | into duration --unit wk     # panic / wrap
'2562047788015216:00:00' | into duration          # panic / wrap
{week: 9999999999} | into duration                # panic / wrap (not listed in the issue)
```

## The fix

All four overflow paths in `conversions/into/duration.rs` now use checked
arithmetic and return `ShellError::OperatorOverflow`, matching the existing
predecessors for the same class of bug:

- #17063 (duration arithmetic overflow, merged) — `checked_mul`/`checked_add` + `OperatorOverflow`
- #18275 (abs overflow, merged) — same error variant with a specific `msg` and `help`

Specifics:

- New `checked_ns_mul` / `checked_ns_add` helpers replace the bare `*`/`+` at
  every integer overflow site: the unit conversion in `string_to_duration`,
  the `Int`/`Float`/`String`-as-number arms in `action()`, the
  `hh:mm:ss` clock sum in `parse_clock_duration`, and the per-field
  accumulation in `merge_record` (record input also overflowed; it is not
  listed in the issue but has the same symptom).
- The float paths (`* (ns as f64)) as i64`) silently *saturated* to
  `i64::MAX`/`i64::MIN` for out-of-range or non-finite products — also
  wrong. They now go through `checked_ns_mul_f64`, which rejects non-finite
  products and products outside the i64 range (`>= i64::MAX as f64`, which
  rounds to exactly 2^63, is the exact bound).
- `string_to_duration`'s 8-branch unit match now goes through the existing
  `unit_to_ns_factor` table instead of 8 inline multiplications (the same
  direction the abandoned #18593 took; I'm not aware of anyone still working
  on it).
- Errors report the input value's span, so the diagnostic highlights the
  offending input rather than the call.

One deliberate behavior note: values that fit in i64 but not in f64 (near
2^63) used to saturate to `i64::MAX` through the float path; they now error.
That's part of the fix rather than a regression, but flagging it in case a
maintainer objects.

## Tests

Four new integration tests in `tests/commands/into_duration.rs` covering the
string-unit, Int `--unit`, clock-format, and record-field overflow paths; each
asserts `ShellError::OperatorOverflow`. Without the fix they fail with debug
panics ("attempt to multiply with overflow"); with it, all pass. Existing
`into_duration` tests still pass, `cargo clippy -p nu-command --all-targets`
and `cargo fmt --check` are clean.

Fixes #18592
