### PR TITLE
Add structured context support to std/log

### DIFF
--- a/crates/nu-std/std/log/mod.nu
+++ b/crates/nu-std/std/log/mod.nu
@@ -39,7 +39,7 @@ const LOG_SHORT_PREFIX = {
 export def log-short-prefix [] {$LOG_SHORT_PREFIX}
 
 const LOG_FORMATS = {
-    log: "%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
+    log: "%ANSI_START%%DATE%|%LEVEL%|%MSG%|%CONTEXT%%ANSI_STOP%"
     date: "%Y-%m-%dT%H:%M:%S%.3f"
 }
 
@@ -155,6 +155,7 @@ def handle-log [
     formatting: record,
     format_string: string,
     short: bool
+    context: record
 ] {
     let log_format = $format_string | default -e $env.NU_LOG_FORMAT? | default $LOG_FORMATS.log
 
@@ -164,7 +165,7 @@ def handle-log [
         $formatting.prefix
     }
 
-    custom $message $log_format $formatting.level --level-prefix $prefix --ansi $formatting.ansi
+    custom $message $log_format $formatting.level --context $context --level-prefix $prefix --ansi $formatting.ansi
 }
 
 # Logging module
@@ -174,6 +175,7 @@ def handle-log [
 # - %DATE%: date of log
 # - %LEVEL%: string prefix for the log level
 # - %ANSI_START%: ansi formatting
+# - %CONTEXT%: log context
 # - %ANSI_STOP%: literally (ansi reset)
 #
 # Note: All placeholders are optional, so "" is still a valid format
@@ -186,9 +188,11 @@ export def critical [
     message: string, # A message
     --short (-s) # Whether to use a short prefix
     --format (-f): string # A format (for further reference: help std log)
+    --context (-c): record # A record to add contextual information
 ] {
     let format = $format | default ""
-    handle-log $message ($LOG_TYPES.CRITICAL)  $format $short
+    let context = $context | default {}
+    handle-log $message ($LOG_TYPES.CRITICAL)  $format $short $context
 }
 
 # Log an error message
@@ -196,9 +200,11 @@ export def error [
     message: string, # A message
     --short (-s) # Whether to use a short prefix
     --format (-f): string # A format (for further reference: help std log)
+    --context (-c): record # A record to add contextual information
 ] {
     let format = $format | default ""
-    handle-log $message ($LOG_TYPES.ERROR) $format $short
+    let context = $context | default {}
+    handle-log $message ($LOG_TYPES.ERROR) $format $short $context
 }
 
 # Log a warning message
@@ -206,9 +212,11 @@ export def warning [
     message: string, # A message
     --short (-s) # Whether to use a short prefix
     --format (-f): string # A format (for further reference: help std log)
+    --context (-c): record # A record to add contextual information
 ] {
     let format = $format | default ""
-    handle-log $message ($LOG_TYPES.WARNING) $format $short
+    let context = $context | default {}
+    handle-log $message ($LOG_TYPES.WARNING) $format $short $context
 }
 
 # Log an info message
@@ -216,9 +224,11 @@ export def info [
     message: string, # A message
     --short (-s) # Whether to use a short prefix
     --format (-f): string # A format (for further reference: help std log)
+    --context (-c): record # A record to add contextual information
 ] {
     let format = $format | default ""
-    handle-log $message ($LOG_TYPES.INFO) $format $short
+    let context = $context | default {}
+    handle-log $message ($LOG_TYPES.INFO) $format $short $context
 }
 
 # Log a debug message
@@ -226,9 +236,11 @@ export def debug [
     message: string, # A message
     --short (-s) # Whether to use a short prefix
     --format (-f): string # A format (for further reference: help std log)
+    --context (-c): record # A record to add contextual information
 ] {
     let format = $format | default ""
-    handle-log $message ($LOG_TYPES.DEBUG) $format $short
+    let context = $context | default {}
+    handle-log $message ($LOG_TYPES.DEBUG) $format $short $context
 }
 
 def log-level-deduction-error [
@@ -256,6 +268,7 @@ export def custom [
     log_level: int # A log level (has to be one of the log-level values for correct ansi/prefix deduction)
     --level-prefix (-p): string # %LEVEL% placeholder extension
     --ansi (-a): string # %ANSI_START% placeholder extension
+    --context: record # A context record
 ] {
     if (current-log-level) > ($log_level) {
         return
@@ -279,6 +292,12 @@ export def custom [
     } else {
         $level_prefix
     }
+
+    let context = $context
+        | default {}
+        | transpose k v
+        | each {|e| $'($e.k)="($e.v)"'}
+        | str join ' '
 
     let use_color = ($env.config?.use_ansi_coloring? | $in != false)
     let ansi = if not $use_color {
@@ -306,6 +325,7 @@ export def custom [
             | str replace --all "%MSG%" $message
             | str replace --all "%DATE%" (now)
             | str replace --all "%LEVEL%" $prefix
+            | str replace --all "%CONTEXT%" $context
             | str replace --all "%ANSI_START%" $ansi
             | str replace --all "%ANSI_STOP%" (ansi reset)
 

--- a/crates/nu-std/std/log/mod.nu
+++ b/crates/nu-std/std/log/mod.nu
@@ -301,6 +301,8 @@ export def custom [
 
     let context = if ($context | is-not-empty) {
         " " + $context
+    } else {
+      ""
     }
 
     let use_color = ($env.config?.use_ansi_coloring? | $in != false)

--- a/crates/nu-std/std/log/mod.nu
+++ b/crates/nu-std/std/log/mod.nu
@@ -39,7 +39,7 @@ const LOG_SHORT_PREFIX = {
 export def log-short-prefix [] {$LOG_SHORT_PREFIX}
 
 const LOG_FORMATS = {
-    log: "%ANSI_START%%DATE%|%LEVEL%|%MSG%|%CONTEXT%%ANSI_STOP%"
+    log: "%ANSI_START%%DATE%|%LEVEL%|%MSG%%CONTEXT%%ANSI_STOP%"
     date: "%Y-%m-%dT%H:%M:%S%.3f"
 }
 
@@ -298,6 +298,10 @@ export def custom [
         | transpose k v
         | each {|e| $'($e.k)="($e.v)"'}
         | str join ' '
+
+    let context = if ($context | is-not-empty) {
+        " " + $context
+    }
 
     let use_color = ($env.config?.use_ansi_coloring? | $in != false)
     let ansi = if not $use_color {

--- a/crates/nu-std/tests/logger_tests/commons.nu
+++ b/crates/nu-std/tests/logger_tests/commons.nu
@@ -7,11 +7,20 @@ export def format-message [
     format: string
     prefix: string,
     ansi
+    --context: record
 ] {
-    [   
+
+    let context = $context
+        | default {}
+        | transpose k v
+        | each {|e| $'($e.k)="($e.v)"'}
+        | str join ' '
+
+    [
         ["%MSG%" $message]
         ["%DATE%" (now)]
         ["%LEVEL%" $prefix]
+        ["%CONTEXT%" $context]
         ["%ANSI_START%" $ansi]
         ["%ANSI_STOP%" (ansi reset)]
     ] | reduce --fold $format {

--- a/crates/nu-std/tests/logger_tests/commons.nu
+++ b/crates/nu-std/tests/logger_tests/commons.nu
@@ -18,6 +18,8 @@ export def format-message [
 
     let context = if ($context | is-not-empty) {
       " " + $context
+    } else {
+      ""
     }
 
     [

--- a/crates/nu-std/tests/logger_tests/commons.nu
+++ b/crates/nu-std/tests/logger_tests/commons.nu
@@ -16,6 +16,10 @@ export def format-message [
         | each {|e| $'($e.k)="($e.v)"'}
         | str join ' '
 
+    let context = if ($context | is-not-empty) {
+      " " + $context
+    }
+
     [
         ["%MSG%" $message]
         ["%DATE%" (now)]

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -3,14 +3,23 @@ use std/assert
 
 def run-command [
     system_level,
-    message_level
+    message_level,
+    --context :record
     --short
 ] {
+    mut args = []
+
     if $short {
-        ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) --short "test message"'
-    } else {
-        ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) "test message"'
+      $args = $args | append ["--short"]
     }
+
+    if $context != null {
+      $args = $args | append ["--context" ($context | to nuon)]
+    }
+
+    let args = $args | str join ' '
+
+    ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) ($args) "test message"'
     | complete | get --optional stderr
 }
 
@@ -42,6 +51,17 @@ def "assert message short" [
     assert str contains $output "test message"
 }
 
+def "assert context" [
+  system_level,
+  message_level,
+  message_level_str
+] {
+    let output = (run-command $system_level --context {varA: valueA varB: valueB} $message_level)
+    assert str contains $output $message_level_str
+    assert str contains $output "test message"
+    assert str contains $output 'varA="valueA" varB="valueB"'
+}
+
 @test
 def critical [] {
     assert no message 99 critical
@@ -51,6 +71,11 @@ def critical [] {
 @test
 def critical_short [] {
     assert message short CRITICAL critical C
+}
+
+@test
+def critical_context [] {
+    assert context CRITICAL critical CRT
 }
 
 @test
@@ -65,6 +90,11 @@ def error_short [] {
 }
 
 @test
+def error_context [] {
+    assert context ERROR error E
+}
+
+@test
 def warning [] {
     assert no message ERROR warning
     assert message WARNING warning WRN
@@ -73,6 +103,11 @@ def warning [] {
 @test
 def warning_short [] {
     assert message short WARNING warning W
+}
+
+@test
+def warning_context [] {
+    assert context WARNING warning W
 }
 
 @test
@@ -87,6 +122,11 @@ def info_short [] {
 }
 
 @test
+def info_context [] {
+    assert context INFO info I
+}
+
+@test
 def debug [] {
     assert no message INFO debug
     assert message DEBUG debug DBG
@@ -95,4 +135,9 @@ def debug [] {
 @test
 def debug_short [] {
     assert message short DEBUG debug D
+}
+
+@test
+def debug_context [] {
+    assert context DEBUG debug D
 }

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -8,18 +8,27 @@ def run-command [
     format: string,
     log_level: int,
     --level-prefix: string,
+    --context: record
     --ansi: string
 ] {
-    if ($level_prefix | is-empty) {
-        if ($ansi | is-empty) {
-            ^$nu.current-exe --no-config-file --commands $'use std/log; NU_LOG_LEVEL=($system_level) log custom "($message)" "($format)" ($log_level)'
-        } else {
-            ^$nu.current-exe --no-config-file --commands $'use std/log; NU_LOG_LEVEL=($system_level) log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
-        }
-    } else {
-        ^$nu.current-exe --no-config-file --commands $'use std/log; NU_LOG_LEVEL=($system_level) log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
-    }
-    | complete | get --optional stderr
+  mut args = []
+
+  if ($level_prefix | is-not-empty) {
+    $args = $args | append ["--level-prefix" $level_prefix]
+  }
+
+  if ($ansi | is-not-empty) {
+    $args = $args | append ["--ansi" $ansi]
+  }
+
+  if ($context | is-not-empty) {
+    $args = $args | append ["--context" ($context | to nuon)]
+  }
+
+  let args = $args | str join ' '
+
+  ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log custom ($args) "($message)" "($format)" ($log_level)'
+  | complete | get --optional stderr
 }
 
 @test
@@ -35,7 +44,8 @@ def valid_calls [] {
     assert equal (run-command "DEBUG" "msg" "%MSG%" 25 --level-prefix "abc" --ansi (ansi default) | str trim --right) "msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"((log-prefix).INFO) msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" --level-prefix "abc" 20 | str trim --right) "abc msg"
-    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG%%ANSI_STOP%" ((log-level).CRITICAL) | str trim --right) $"((log-ansi).CRITICAL)CRT msg(ansi reset)"
+    assert equal (run-command "DEBUG" "msg" "%LEVEL% %CONTEXT%" --level-prefix "abc" 20 | str trim --right) 'abc var="value"'
+    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG% %CONTEXT%%ANSI_STOP%" ((log-level).CRITICAL) --context {var: value} | str trim --right) $'((log-ansi).CRITICAL)CRT msg var="value"(ansi reset)'
 }
 
 @test

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -44,8 +44,8 @@ def valid_calls [] {
     assert equal (run-command "DEBUG" "msg" "%MSG%" 25 --level-prefix "abc" --ansi (ansi default) | str trim --right) "msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"((log-prefix).INFO) msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" --level-prefix "abc" 20 | str trim --right) "abc msg"
-    assert equal (run-command "DEBUG" "msg" "%LEVEL% %CONTEXT%" --level-prefix "abc" 20 | str trim --right) 'abc var="value"'
-    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG% %CONTEXT%%ANSI_STOP%" ((log-level).CRITICAL) --context {var: value} | str trim --right) $'((log-ansi).CRITICAL)CRT msg var="value"(ansi reset)'
+    assert equal (run-command "DEBUG" "msg" "%LEVEL%%CONTEXT%" --level-prefix "abc" 20 | str trim --right) 'abc var="value"'
+    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG%%CONTEXT%%ANSI_STOP%" ((log-level).CRITICAL) --context {var: value} | str trim --right) $'((log-ansi).CRITICAL)CRT msg var="value"(ansi reset)'
 }
 
 @test

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -18,7 +18,7 @@ def run-command [
   }
 
   if ($ansi | is-not-empty) {
-    $args = $args | append ["--ansi" $ansi]
+    $args = $args | append ["--ansi" $'"($ansi)"']
   }
 
   if ($context | is-not-empty) {

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -44,7 +44,8 @@ def valid_calls [] {
     assert equal (run-command "DEBUG" "msg" "%MSG%" 25 --level-prefix "abc" --ansi (ansi default) | str trim --right) "msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"((log-prefix).INFO) msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" --level-prefix "abc" 20 | str trim --right) "abc msg"
-    assert equal (run-command "DEBUG" "msg" "%LEVEL%%CONTEXT%" --level-prefix "abc" 20 | str trim --right) 'abc var="value"'
+    assert equal (run-command "DEBUG" "msg" "%LEVEL%%CONTEXT%" --level-prefix "abc" 20 | str trim --right) 'abc'
+    assert equal (run-command "DEBUG" "msg" "%LEVEL%%CONTEXT%" --level-prefix "abc" 20 --context {var: value} | str trim --right) 'abc var="value"'
     assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG%%CONTEXT%%ANSI_STOP%" ((log-level).CRITICAL) --context {var: value} | str trim --right) $'((log-ansi).CRITICAL)CRT msg var="value"(ansi reset)'
 }
 

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -9,13 +9,22 @@ def run-command [
     message_level,
     message,
     --format: string,
+    --context :record
     --short
 ] {
+    mut args = []
+
     if $short {
-        ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) --format "($format)" --short "($message)"'
-    } else {
-        ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) --format "($format)" "($message)"'
+      $args = $args | append ["--short"]
     }
+
+    if $context != null {
+      $args = $args | append ["--context" ($context | to nuon)]
+    }
+
+    let args = $args | str join ' '
+
+    ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) ($args) "($message)"'
     | complete | get --optional stderr
 }
 
@@ -24,9 +33,10 @@ def "assert formatted" [
     message: string,
     format: string,
     command_level: string
+    --context :record
     --short
 ] {
-    let output = (run-command "debug" $command_level $message --format $format)
+
     let prefix = if $short {
             (log-short-prefix | get ($command_level | str uppercase))
         } else {
@@ -38,7 +48,17 @@ def "assert formatted" [
             (log-ansi | get ($command_level | str uppercase))
         }
 
-    assert equal ($output | str trim --right) (format-message $message $format $prefix $ansi)
+    let output = if ($context | is-empty) {
+      (run-command "debug" $command_level $message --format $format)
+    } else {
+      (run-command "debug" $command_level $message --context $context --format $format)
+    }
+
+    if $context == null {
+      assert equal ($output | str trim --right) (format-message $message $format $prefix $ansi)
+    } else {
+      assert equal ($output | str trim --right) (format-message --context $context $message $format $prefix $ansi)
+    }
 }
 
 @test
@@ -53,4 +73,9 @@ def format_flag [] {
     assert formatted --short "test" "TEST %ANSI_START% %MSG%%ANSI_STOP%" warning
     assert formatted --short "test" "TEST %ANSI_START% %MSG%%ANSI_STOP%" info
     assert formatted --short "test" "TEST %ANSI_START% %MSG%%ANSI_STOP%" debug
+    assert formatted "test" --context {var: value} "TEST %ANSI_START% %MSG%%ANSI_STOP%" critical
+    assert formatted "test" --context {var: value} "TEST %ANSI_START% %MSG%%ANSI_STOP%" error
+    assert formatted "test" --context {var: value} "TEST %ANSI_START% %MSG%%ANSI_STOP%" warning
+    assert formatted "test" --context {var: value} "TEST %ANSI_START% %MSG%%ANSI_STOP%" info
+    assert formatted "test" --context {var: value} "TEST %ANSI_START% %MSG%%ANSI_STOP%" debug
 }

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -24,7 +24,7 @@ def run-command [
 
     let args = $args | str join ' '
 
-    ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) ($args) "($message)"'
+    ^$nu.current-exe --no-config-file --commands $'use std; use std/log; NU_LOG_LEVEL=($system_level) log ($message_level) --format "($format)" ($args) "($message)"'
     | complete | get --optional stderr
 }
 

--- a/crates/nu-std/tests/logger_tests/test_logger_env.nu
+++ b/crates/nu-std/tests/logger_tests/test_logger_env.nu
@@ -41,5 +41,5 @@ def env_log-short-prefix [] {
 
 @test
 def env_log_format [] {
-    assert equal $env.NU_LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
+    assert equal $env.NU_LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|%MSG%|%CONTEXT%ANSI_STOP%"
 }

--- a/crates/nu-std/tests/logger_tests/test_logger_env.nu
+++ b/crates/nu-std/tests/logger_tests/test_logger_env.nu
@@ -41,5 +41,5 @@ def env_log-short-prefix [] {
 
 @test
 def env_log_format [] {
-    assert equal $env.NU_LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|%MSG%|%CONTEXT%ANSI_STOP%"
+    assert equal $env.NU_LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|%MSG%%CONTEXT%%ANSI_STOP%"
 }


### PR DESCRIPTION
## Description
This PR adds support for structured context for std/log. 

## User-facing changes (Release notes)
- Adds a `--context` flag to all std/log emitters

Examples:
```
> log info 'hello' --context {user: Ana}
2026-09-05T15:39:01.826|INF|hello user="Ana"
```
