### PR TITLE
docs(tutor): add conditional(if, match, where) tutorials

### DIFF
--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -99,6 +99,10 @@ fn tutor(
         ),
         (vec!["block", "blocks"], block_tutor()),
         (
+            vec!["conditional", "conditionals", "if", "match", "where"],
+            conditional_tutorial(),
+        ),
+        (
             vec![
                 "custom-command",
                 "custom-commands",
@@ -396,6 +400,114 @@ while $x < 5 {
 One special feature of blocks is that they can modify mutable variables
 from the parent scope. For example, the `while` loop above mutates `$x`
 even though it was declared outside the block.
+"#
+}
+
+fn conditional_tutorial() -> &'static str {
+    r#"
+Conditional commands allow you to choose which code to run based on a value or
+condition.
+
+The `if` command runs a block when its condition is true:
+```
+if 5 > 3 {
+    print "5 is greater than 3"
+}
+```
+
+You can use `else` to run a different block when the condition is false:
+```
+let age = 20
+
+if $age >= 18 {
+    "adult"
+} else {
+    "minor"
+}
+```
+
+You can also chain multiple conditions with `else if`:
+```
+let score = 75
+
+if $score >= 90 {
+    "A"
+} else if $score >= 80 {
+    "B"
+} else if $score >= 70 {
+    "C"
+} else {
+    "F"
+}
+```
+
+The `if` command is an expression, so it can produce a value that you can
+store in a variable or use in a pipeline:
+```
+let result = if 10 > 5 { "yes" } else { "no" }
+$result
+```
+
+When you have several possible values to match, `match` can be more convenient.
+It checks a value against several patterns:
+```
+let number = 2
+
+match $number {
+    1 => "one",
+    2 => "two",
+    3 => "three",
+    _ => "something else"
+}
+```
+The `_` pattern acts as a catch-all for anything that did not match an earlier
+branch.
+
+`match` can also be used to unpack structured values:
+```
+let user = { name: "Alice", admin: true }
+
+match $user {
+    { admin: true } => "administrator",
+    { admin: false } => "regular user",
+    _ => "unknown"
+}
+```
+
+Conditions can also be used to filter values in a pipeline with `where`:
+```
+[1 2 3 4 5] | where $it > 2
+```
+This keeps only the values for which the condition is true:
+```
+╭───┬───╮
+│ 0 │ 3 │
+│ 1 │ 4 │
+│ 2 │ 5 │
+╰───┴───╯
+```
+
+For tables, `where` is particularly useful for selecting rows:
+```
+ls | where size > 1kb
+```
+
+You can learn more about filtering pipelines with:
+```
+help where
+```
+
+You can learn more about blocks, which are used by `if` and other control flow
+commands, by running:
+```
+tutor blocks
+```
+
+You can also see more details about `if` and `match` with:
+```
+help if
+help match
+```
 "#
 }
 

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -441,15 +441,15 @@ if $score >= 90 {
 }
 ```
 
-The `if` command is an expression, so it can produce a value that you can
-store in a variable or use in a pipeline:
+The `if` command returns a nushell value, so it can be store in a variable or
+use in a pipeline:
 ```
 let result = if 10 > 5 { "yes" } else { "no" }
 $result
 ```
 
-When you have several possible values to match, `match` can be more convenient.
-It checks a value against several patterns:
+When you have several possible values to match, the `match` command can be more
+convenient. It checks a value against several patterns:
 ```
 let number = 2
 
@@ -463,7 +463,7 @@ match $number {
 The `_` pattern acts as a catch-all for anything that did not match an earlier
 branch.
 
-`match` can also be used to unpack structured values:
+The `match` command can also be used to unpack structured values:
 ```
 let user = { name: "Alice", admin: true }
 
@@ -474,7 +474,8 @@ match $user {
 }
 ```
 
-Conditions can also be used to filter values in a pipeline with `where`:
+Conditions can also be used to filter values in a pipeline with the `where`
+command:
 ```
 [1 2 3 4 5] | where $it > 2
 ```
@@ -487,7 +488,7 @@ This keeps only the values for which the condition is true:
 ╰───┴───╯
 ```
 
-For tables, `where` is particularly useful for selecting rows:
+For tables, the `where` command is particularly useful for selecting rows:
 ```
 ls | where size > 1kb
 ```
@@ -497,13 +498,13 @@ You can learn more about filtering pipelines with:
 help where
 ```
 
-You can learn more about blocks, which are used by `if` and other control flow
-commands, by running:
+You can learn more about blocks, which are used by the `if` command and other
+control flow commands, by running:
 ```
 tutor blocks
 ```
 
-You can also see more details about `if` and `match` with:
+You can also see more details about the `if` and `match` commands with:
 ```
 help if
 help match


### PR DESCRIPTION
## Description

Add a new `tutor conditionals` tutorial covering conditional logic and pattern matching in Nushell.

The tutorial introduces:

* Using `if` / `else` / `else if` for conditional execution.
* Using `if` as an expression to produce a value.
* Using `match` for matching values against multiple patterns.
* Using `where` to conditionally filter values in a pipeline.

The tutorial is intended as an introduction to conditional logic rather than a complete reference, with `help if`, `help match`, and `help where` available for more details.

## User-facing changes

Added a new `tutor conditionals` tutorial for learning conditional logic, pattern matching, and conditional filtering.

<img width="634" height="898" alt="image" src="https://github.com/user-attachments/assets/a3935afc-a47c-4376-b292-6214763d6235" />
<img width="627" height="729" alt="image" src="https://github.com/user-attachments/assets/cb5c3217-4295-4e2c-91a7-19d8b508ba1d" />

## Additional notes

- related: #18895
