### PR TITLE
fix(eval): check runtime types for mutable aggregate cell paths

### DIFF
--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -1055,6 +1055,22 @@ fn eval_instruction<D: DebugContext>(
                 let new_val = if nu_experimental::ENFORCE_RUNTIME_ANNOTATIONS.get() {
                     let variable = ctx.engine_state.get_var(*var_id);
                     let expected_ty = variable.ty.follow_cell_path(&path.members);
+
+                    // Mutable aggregates can gain new members at runtime, which are not present in
+                    // the variable's static type. For example, `mut x = []` starts as `list<any>`
+                    // but `$x.0 = "hello"` changes its runtime type to `list<string>`, and further
+                    // assignments can widen it to `list<oneof<string, int, nothing>>`. The same
+                    // applies to fields added to mutable records; see #18951.
+                    let expected_ty = match expected_ty {
+                        Some(expected_ty) => Some(expected_ty),
+                        None => ctx
+                            .stack
+                            .get_var(*var_id, *span)?
+                            .follow_cell_path(&path.members)
+                            .ok()
+                            .map(|value| Cow::Owned(value.get_type())),
+                    };
+
                     if let Some(expected_ty) = expected_ty {
                         check_assignment_type(new_val, &expected_ty, *span)?
                     } else {

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -342,3 +342,160 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
         },
     )
 }
+
+// Regression tests for issue #18951
+
+#[rstest]
+#[case::mutable_record_existing_field(
+    "
+        mut r = {a: 1}
+        $r.a = 2
+        $r.a
+    ",
+    2
+)]
+#[case::mutable_record_new_field(
+    "
+        mut r = {a: 1}
+        $r.b = 1
+        $r.b = 2
+        $r.b
+    ",
+    2
+)]
+#[case::mutable_nested_record_existing_field(
+    "
+        mut r = {a: {b: 1}}
+        $r.a.b = 2
+        $r.a.b
+    ",
+    2
+)]
+#[case::mutable_nested_record_new_field(
+    "
+        mut r = {a: {b: 1}}
+        $r.a.c = 1
+        $r.a.c = 2
+        $r.a.c
+    ",
+    2
+)]
+#[case::mutable_table_existing_column(
+    "
+        mut t = [[a]; [1]]
+        $t.0.a = 2
+        $t.0.a
+    ",
+    2
+)]
+#[case::mutable_table_new_column(
+    "
+        mut t = [[a]; [1]]
+        $t.0.b = 1
+        $t.0.b = 2
+        $t.0.b
+    ",
+    2
+)]
+#[case::mutable_heterogeneous_list_cell_path_assignment(
+    r#"
+        mut l = [1 "a"]
+        $l.0 = "hello"
+        $l.0
+    "#,
+    "hello"
+)]
+#[case::mutable_list_of_records_existing_field(
+    "
+        mut l = [{a: 1}]
+        $l.0.a = 2
+        $l.0.a
+    ",
+    2
+)]
+#[case::mutable_list_of_records_new_field(
+    "
+        mut l = [{a: 1}]
+        $l.0.b = 1
+        $l.0.b = 2
+        $l.0.b
+    ",
+    2
+)]
+fn mutable_aggregate_cell_path_assignment(
+    #[case] code: &str,
+    #[case] expected: impl IntoValue,
+) -> Result {
+    test().run(code).expect_value_eq(expected)
+}
+
+#[rstest]
+#[case::mutable_record_existing_field(
+    r#"
+        mut r = {a: 1}
+        $r.a = "hello"
+    "#
+)]
+#[case::mutable_record_new_field(
+    r#"
+        mut r = {a: 1}
+        $r.b = 1
+        $r.b = "hello"
+    "#
+)]
+#[case::mutable_list_existing_element(
+    r#"
+        mut l = [1 2 3]
+        $l.0 = "hello"
+    "#
+)]
+#[case::mutable_list_out_of_bounds_element(
+    r#"
+        mut l = [1 2 3]
+        $l.3 = "hello"
+    "#
+)]
+#[case::mutable_nested_record_existing_field(
+    r#"
+        mut r = {a: {b: 1}}
+        $r.a.b = "hello"
+    "#
+)]
+#[case::mutable_nested_record_new_field(
+    r#"
+        mut r = {a: {b: 1}}
+        $r.a.c = 1
+        $r.a.c = "hello"
+    "#
+)]
+#[case::mutable_table_existing_column(
+    r#"
+        mut t = [[a]; [1]]
+        $t.0.a = "hello"
+    "#
+)]
+#[case::mutable_table_new_column(
+    r#"
+        mut t = [[a]; [1]]
+        $t.0.b = 1
+        $t.0.b = "hello"
+    "#
+)]
+#[case::mutable_list_of_records_existing_field(
+    r#"
+        mut l = [{a: 1}]
+        $l.0.a = "hello"
+    "#
+)]
+#[case::mutable_list_of_records_new_field(
+    r#"
+        mut l = [{a: 1}]
+        $l.0.b = 1
+        $l.0.b = "hello"
+    "#
+)]
+fn mutable_aggregate_cell_path_type_mismatch(#[case] code: &str) -> Result {
+    test()
+        .run(code)
+        .expect_error_code_eq("nu::shell::type_mismatch")
+}


### PR DESCRIPTION
## Description

In this PR, I fixed type checking for cell-path assignments on mutable records and other mutable aggregates.

Previously, when a cell path was not present in the variable's statically inferred type, the assignment was not type-checked. This caused newly-added fields on mutable records to behave inconsistently with fields that already existed.

For example:

### Before

```nu
mut r = {a: 1}

$r.b = 1
$r.b = "hello"
```

The first assignment adds `b` to the record, but the second assignment was not checked against the runtime type established by the first assignment.

The runtime value correctly evolves to:

```text
record<a: int, b: int>
```

but the static variable type remains:

```text
record<a: int>
```

so the type of the newly-added field could not be found through the static type.

### After

When the cell path cannot be resolved from the static type, the current runtime value is used to determine the expected type:

```nu
mut r = {a: 1}

$r.b = 1
$r.b = 2       # passes
$r.b = "hello" # type mismatch
```

Existing fields continue to use their statically inferred types:

```nu
mut r = {a: 1}

$r.a = 2       # passes
$r.a = "hello" # type mismatch
```

The static type remains authoritative when it can resolve the cell path. This is important for parametric types such as lists:

```nu
mut l = [1 "a"]

$l.0 = "hello"  # passes
$l.0 = {c: 1}   # type mismatch
```

Here the static type is `list<oneof<int, string>>`, so the assignment is checked against the list's element type rather than the concrete runtime type of `$l.0`.

Regression tests have been added covering mutable records, lists, nested records, tables, and lists of records, including existing and newly-created fields/elements.

All tests are passing.

## User-facing changes (Release notes)

Fixed an issue where cell-path assignments to newly-added members of mutable aggregates were not consistently type-checked against their runtime type.

## Additional notes

* fixes: #18951
