### PR TITLE
update(style_computer.rs): fixed unessesary string allocations

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -104,7 +104,7 @@ impl<'a> StyleComputer<'a> {
     // Used only by the `table` command.
     pub fn style_primitive(&self, value: &Value) -> TextStyle {
         use Alignment::*;
-        let s = self.compute(&value.get_type().get_non_specified_string(), value);
+        let s = self.compute(&value.get_type_shallow().get_non_specified_string(), value);
         match *value {
             Value::Bool { .. } => TextStyle::with_style(Left, s),
             Value::Int { .. } => TextStyle::with_style(Right, s),


### PR DESCRIPTION
## Description
- improved string allocation by using a shallow value. Removing inner type specification of lists, tables and records.

## User-facing changes (Release notes)
Optimize style_computer.rs#style_primitive to use shallow_get_type() instead of get_type()

## Other
all tests pass (full local suite)