### PR TITLE
fix: propagate error stream values in length, columns, and is-empty

### DIFF
--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -80,10 +80,18 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
             let cols = match v {
                 Value::List {
                     vals: input_vals, ..
-                } => get_columns(&input_vals)
-                    .into_iter()
-                    .map(move |x| Value::string(x, span))
-                    .collect(),
+                } => {
+                    for val in &input_vals {
+                        // Propagate error values instead of returning an empty column list (see #18928).
+                        if let Value::Error { error, .. } = val {
+                            return Err(*error.clone());
+                        }
+                    }
+                    get_columns(&input_vals)
+                        .into_iter()
+                        .map(move |x| Value::string(x, span))
+                        .collect()
+                }
                 Value::Custom { val, .. } => {
                     // TODO: should we get CustomValue to expose columns in a more efficient way?
                     // Would be nice to be able to get columns without generating the whole value
@@ -116,6 +124,12 @@ fn getcol(head: Span, input: PipelineData) -> Result<PipelineData, ShellError> {
         }
         PipelineData::ListStream(stream, metadata) => {
             let values = stream.into_iter().collect::<Vec<_>>();
+            for val in &values {
+                // Propagate error values instead of returning an empty column list (see #18928).
+                if let Value::Error { error, .. } = val {
+                    return Err(*error.clone());
+                }
+            }
             let cols = get_columns(&values)
                 .into_iter()
                 .map(|s| Value::string(s, head))

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -55,7 +55,12 @@ pub fn empty(
                 }
             }
             PipelineData::ListStream(s, ..) => {
-                let empty = s.into_iter().next().is_none();
+                let mut iter = s.into_iter();
+                let empty = match iter.next() {
+                    Some(Value::Error { error, .. }) => return Err(*error),
+                    Some(_) => false,
+                    None => true,
+                };
                 if negate {
                     Ok(Value::bool(!empty, head).into_pipeline_data())
                 } else {
@@ -63,10 +68,14 @@ pub fn empty(
                 }
             }
             PipelineData::Value(value, ..) => {
+                let empty = match value {
+                    Value::Error { error, .. } => return Err(*error),
+                    val => val.is_empty(),
+                };
                 if negate {
-                    Ok(Value::bool(!value.is_empty(), head).into_pipeline_data())
+                    Ok(Value::bool(!empty, head).into_pipeline_data())
                 } else {
-                    Ok(Value::bool(value.is_empty(), head).into_pipeline_data())
+                    Ok(Value::bool(empty, head).into_pipeline_data())
                 }
             }
         }

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -103,7 +103,13 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             Ok(Value::int(vals.len() as i64, call.head).into_pipeline_data())
         }
         PipelineData::ListStream(stream, ..) => {
-            Ok(Value::int(stream.into_iter().count() as i64, call.head).into_pipeline_data())
+            let mut count = 0;
+            for value in stream {
+                // Propagate error values instead of silently counting them (see #18928).
+                value.unwrap_error()?;
+                count += 1;
+            }
+            Ok(Value::int(count, call.head).into_pipeline_data())
         }
         PipelineData::ByteStream(stream, ..) if stream.type_().is_binary_coercible() => {
             Ok(Value::int(

--- a/crates/nu-command/tests/commands/columns.rs
+++ b/crates/nu-command/tests/commands/columns.rs
@@ -1,0 +1,8 @@
+use nu_test_support::prelude::*;
+
+#[test]
+fn columns_propagates_error_values_in_stream() -> Result {
+    test()
+        .run("[[name size]; [a 100b] [b 200b]] | where size <= 150 | columns")
+        .expect_error_code_eq("nu::shell::operator_incompatible_types")
+}

--- a/crates/nu-command/tests/commands/empty.rs
+++ b/crates/nu-command/tests/commands/empty.rs
@@ -39,3 +39,16 @@ fn reports_nonemptiness_by_columns() -> Result {
 
     test().run(code).expect_value_eq(false)
 }
+
+#[test]
+fn is_empty_propagates_error_values_in_stream() -> Result {
+    let code = "
+        [[name size]; [a 100b] [b 200b]]
+        | where size <= 150
+        | is-empty
+    ";
+
+    test()
+        .run(code)
+        .expect_error_code_eq("nu::shell::operator_incompatible_types")
+}

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -33,3 +33,17 @@ fn length_byte_stream() -> Result {
             .expect_value_eq(4)
     })
 }
+
+#[test]
+fn length_propagates_error_values_in_stream() -> Result {
+    test()
+        .run("[[name size]; [a 100b] [b 200b]] | where size <= 150 | length")
+        .expect_error_code_eq("nu::shell::operator_incompatible_types")
+}
+
+#[test]
+fn length_propagates_explicit_closures_errors_in_stream() -> Result {
+    test()
+        .run("1..10 | each {|n| error make { msg: 'boom' } } | length")
+        .expect_error_code_eq("nu::shell::eval_block_with_input")
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -10,6 +10,7 @@ mod cal;
 mod cd;
 mod chunk_by;
 mod chunks;
+mod columns;
 mod compact;
 mod complete;
 mod config_env_default;

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -223,7 +223,11 @@ fn sqlite_database_operations(#[case] operation: &str, #[case] expected: impl In
 #[case::shuffle("shuffle | length", 5)]
 #[case::split_list("split list 2 | flatten | length", 5)]
 #[case::each_while("each while {|row| $row } | length", 5)]
-#[case::tee("tee {|x| $x | ignore } | flatten | length", 6)]
+// note: `tee`'s closure sees its input as `$in`; positional params are not bound for stream
+// inputs, which used to surface a `variable not found` error row that `length` swallowed and
+// counted (6 = 5 rows + 1 masked error). Since `length` now propagates stream errors, use
+// the `$in` idiom so the closure runs cleanly and the true row count (5) is reported.
+#[case::tee("tee { $in | ignore } | flatten | length", 5)]
 #[case::filter("filter {|row| $row.z > 100 } | length", 2)]
 fn sqlite_int_table_operations(
     #[case] operation: &str,

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -223,11 +223,11 @@ fn sqlite_database_operations(#[case] operation: &str, #[case] expected: impl In
 #[case::shuffle("shuffle | length", 5)]
 #[case::split_list("split list 2 | flatten | length", 5)]
 #[case::each_while("each while {|row| $row } | length", 5)]
-// note: `tee`'s closure sees its input as `$in`; positional params are not bound for stream
-// inputs, which used to surface a `variable not found` error row that `length` swallowed and
-// counted (6 = 5 rows + 1 masked error). Since `length` now propagates stream errors, use
-// the `$in` idiom so the closure runs cleanly and the true row count (5) is reported.
-#[case::tee("tee { $in | ignore } | flatten | length", 5)]
+// note: `tee`'s closure does not bind positional params for stream inputs, which used to
+// surface a `variable not found` error row that `length` swallowed and counted (6 = 5 rows
+// + 1 masked error). Since `length` now propagates stream errors, drop the row with a
+// closure that takes no arguments (`tee { ignore }`), keeping streaming intact.
+#[case::tee("tee { ignore } | flatten | length", 5)]
 #[case::filter("filter {|row| $row.z > 100 } | length", 2)]
 fn sqlite_int_table_operations(
     #[case] operation: &str,


### PR DESCRIPTION
# Description

Fixes #18928. `length`, `columns`, and `is-empty` (and `is-not-empty`) silently consumed `Value::Error` stream items instead of surfacing them, producing wrong, silent results (e.g. `where` with a type error → `length` reports the unfiltered row count, `columns` returns `[]`, `is-empty` returns the wrong boolean).

Now all three propagate the first error encountered in the input stream:

- `length`: the `ListStream` count loop calls `unwrap_error()` on each value, returning the inner `ShellError` instead of counting it.
- `columns`: scans both the `Value::List` and `ListStream` inputs for `Value::Error` before computing columns, returning the inner error (a list containing an error previously short-circuited `get_columns` to `[]`).
- `is-empty` / `is-not-empty`: the `ListStream` and `Value` branches of `empty()` return the inner error instead of treating an error item as "not empty" (a bare `Value::Error` input previously fell through to `is_empty()` → `false`).

This is consistent with the error propagation that #16738 established for stream-collecting commands (`into_value`, `unwrap_error`); these three commands bypassed it with manual iteration.

## Verification

- Three new integration tests (one per command), all asserted to raise the propagated error.
- Confirmed each test reproduces the bug pre-fix:
  - `columns` returned `List([])` instead of erroring
  - `length` returned the wrong count
  - `is-empty` returned the wrong boolean
- Post-fix all pass.
- `cargo fmt --check -p nu-command`: clean
- `cargo clippy -p nu-command --all-targets`: clean
- Full `nu-command` tests: 2884 pass, 22 fail — all pre-existing Windows symlink/privilege failures (e.g. `can not create symlink: A required privilege is not held by the client`), unrelated to this change.

# User-Facing Changes

`[[name size]; [a 100b] [b 200b]] | where size <= 150 | length` now errors with `nu::shell::operator_incompatible_types` instead of returning `2`, and likewise for `columns` / `is-empty`.

# Tests + Formatting

- Added tests under `crates/nu-command/tests/commands/` (`length.rs`, `empty.rs`, new `columns.rs`).
- `cargo fmt --check` and `cargo clippy` clean as noted above.

## AI disclosure

This change was authored with the assistance of an AI coding agent.