### PR TITLE
ReportLog uses Vec<T>, which is bad practice in this context.

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -104,7 +104,7 @@ impl<'a> StyleComputer<'a> {
     // Used only by the `table` command.
     pub fn style_primitive(&self, value: &Value) -> TextStyle {
         use Alignment::*;
-        let s = self.compute(&value.get_type().get_non_specified_string(), value);
+        let s = self.compute(&value.get_type_shallow().get_non_specified_string(), value);
         match *value {
             Value::Bool { .. } => TextStyle::with_style(Left, s),
             Value::Int { .. } => TextStyle::with_style(Right, s),

--- a/crates/nu-protocol/src/errors/report_error.rs
+++ b/crates/nu-protocol/src/errors/report_error.rs
@@ -1,6 +1,7 @@
 //! This module manages the step of turning error types into printed error messages
 //!
 //! Relies on the `miette` crate for pretty layout
+use std::collections::HashSet;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -55,7 +56,7 @@ impl<'src> CliError<'src> {
 /// May rarely result in warnings incorrectly being unreported upon hash collision.
 #[derive(Default, derive_more::Debug)]
 #[debug("ReportLog([...])")]
-pub struct ReportLog(Vec<u64>);
+pub struct ReportLog(HashSet<u64>);
 
 /// How a warning/error should be reported
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -86,12 +87,11 @@ where
                 .lock()
                 .expect("report log lock is poisoned");
 
-            match report_log.0.contains(&hash) {
-                true => false,
-                false => {
-                    report_log.0.push(hash);
-                    true
-                }
+            if report_log.0.contains(&hash) {
+                false
+            } else {
+                report_log.0.insert(hash);
+                true
             }
         }
     }


### PR DESCRIPTION
## Description

- Provides Optimization to ReportLog. Originally uses `O(n)` time, but now on average can use `0(1)`

## User-facing changes (Release notes)

- Improved performance for report_error.rs by optimizing time complexity.


### Other Notes

Full local test suite completed & passed.