### PR TITLE
fix(nix): bump rust-overlay so the 1.96.1 toolchain resolves

### DIFF
--- a/scripts/nix/flake.lock
+++ b/scripts/nix/flake.lock
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780370483,
-        "narHash": "sha256-7mDa7OBAaf7MU6ZovT9ENfD62kH911SsSazBb4KTDF0=",
+        "lastModified": 1788851328,
+        "narHash": "sha256-YOwlUD0Lt/3SulKhZ7z0Jmgbq/DWh8SjnGwUlFSw+YM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4a408e1fc99ad517b4cb402fd0de7464f40c05e1",
+        "rev": "6ae57a71bcb0bebc7a66cc2bd76942c4cf649167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

#18968 bumped `rust-toolchain.toml` to 1.96.1, but the `rust-overlay` rev locked in `scripts/nix/flake.lock` predates that release, so `fromRustupToolchainFile` fails with `error: Stable 1.96.1 is not available` and the flake will not evaluate.

Bumps `rust-overlay` `4a408e1` -> `6ae57a7`, lock file only.
`nixpkgs` left alone, since nothing forces it.

Checked on `x86_64-linux`: the toolchain resolves to `rust-default-1.96.1` and the default package evaluates again.

## User-facing changes (Release notes)

n/a

## Additional notes

Follow-up to #18968.