### PR TITLE
chore: bump reedline 06bf606

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7659,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.51.0"
-source = "git+https://github.com/nushell/reedline?branch=main#a8e93641b927600fb49f71525b39585cb5410273"
+source = "git+https://github.com/nushell/reedline?branch=main#06bf606a9de9744585ecf7010333f5c1ee827a43"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -952,6 +952,7 @@ fn event_from_record(
             let menu = extract_value("name", record, span)?;
             ReedlineEvent::Menu(menu.to_expanded_string("", config))
         }
+        Ok(RED::MenuAccept) => ReedlineEvent::MenuAccept,
         Ok(RED::MenuNext) => ReedlineEvent::MenuNext,
         Ok(RED::MenuPrevious) => ReedlineEvent::MenuPrevious,
         Ok(RED::MenuUp) => ReedlineEvent::MenuUp,
@@ -1024,6 +1025,7 @@ pub(crate) fn display_reedline_event(event: ReedlineEventDiscriminants) -> Optio
         RED::Multiple => "event: { send: list<event> }",
         RED::UntilFound => "event: { until: list<event> }",
         RED::Menu => "Menu name: <string>",
+        RED::MenuAccept => "MenuAccept",
         RED::MenuNext => "MenuNext",
         RED::MenuPrevious => "MenuPrevious",
         RED::MenuUp => "MenuUp",


### PR DESCRIPTION
## Description

Bumps `reedline` from `a8e9364` to `06bf606`:

- `3eb9942` fix(history): match cwd prefix literally in sqlite search (nushell/reedline#778)
- `b582ddb` feat(editor): add access to the command line selection (nushell/reedline#1200)
- `aae283d` feat(editor): make copy selection report failure without selection (nushell/reedline#1166)
- `87f4d79` fix(painter): re-use a bottom-row prompt if the cursor returns unmoved (nushell/reedline#1201)
- `1585b51` feat(menu): add MenuAccept to take a completion without submitting (nushell/reedline#1203)
- `06bf606` feat(vi): read an unbound Alt-<char> as Esc then <char> (nushell/reedline#1207)

`MenuAccept` is the only new event in that range, thus the second commit wires it into `reedline_config.rs`.

## User-facing changes (Release notes)

Added the `MenuAccept` keybinding event.
It takes the highlighted completion into the buffer and closes the menu without submitting the line.