### PR TITLE
fix(nu-plugin): add socket feature flag to handle `--no-default-features` correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ nu-lsp = { path = "crates/nu-lsp", version = "0.115.2", default-features = false
 nu-mcp = { path = "crates/nu-mcp", version = "0.115.2", default-features = false }
 nu-parser = { path = "crates/nu-parser", version = "0.115.2", default-features = false }
 nu-path = { path = "crates/nu-path", version = "0.115.2", default-features = false }
-nu-plugin = { path = "crates/nu-plugin", version = "0.115.2", default-features = false }
+nu-plugin = { path = "crates/nu-plugin", version = "0.115.2", default-features = false, features = ["local-socket"] }
 nu-plugin-core = { path = "crates/nu-plugin-core", version = "0.115.2", default-features = false }
 nu-plugin-engine = { path = "crates/nu-plugin-engine", version = "0.115.2", default-features = false }
 nu-plugin-protocol = { path = "crates/nu-plugin-protocol", version = "0.115.2", default-features = false }


### PR DESCRIPTION
## Description

Fixed compilation error resulting from  `local-socket` feature flag being undeclared on nu-plugin:

```sh-session
$ cargo check --workspace --no-default-features --features "plugin" -q
error[E0004]: non-exhaustive patterns: `Ok(ClientCommunicationIo::LocalSocket { .. })` not covered
   --> crates/nu-plugin/src/plugin/mod.rs:331:24
    |
331 |     let result = match mode.connect_as_client() {
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `Ok(ClientCommunicationIo::LocalSocket { .. })` not covered
    |
note: `Result<ClientCommunicationIo, nu_protocol::ShellError>` defined here
   --> /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library/core/src/result.rs:557:0
   ::: /rustc/31fca3adb283cc9dfd56b49cdee9a96eb9c96ffd/library/core/src/result.rs:561:4
    |
    = note: not covered
    = note: the matched value is of type `Result<ClientCommunicationIo, nu_protocol::ShellError>`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
364 ~         },
365 +         Ok(ClientCommunicationIo::LocalSocket { .. }) => todo!()
    |

For more information about this error, try `rustc --explain E0004`.
error: could not compile `nu-plugin` (lib) due to 1 previous error
```

## User-facing changes (Release notes)

Fixed an issue in workspace compilation where using the "plugin" feature flag that would result in a compilation error.


## Additional notes

`cargo build -p nu_plugin_inc -p nu-plugin-engine --no-default-features --features "nu-plugin-engine/local-socket"` will also reproduce the issue.