### PR TITLE
Don't go to tmp if --directory

### DIFF
--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -94,7 +94,7 @@ impl Command for Mktemp {
 
         let tmpdir = if tmpdir_path.is_some() {
             tmpdir_path
-        } else if directory || tmpdir {
+        } else if tmpdir {
             Some(std::env::temp_dir())
         } else {
             Some(engine_state.cwd(Some(stack))?.into_std_path_buf())


### PR DESCRIPTION
<!--
Thanks for contributing to Nushell!

Before submitting, please read the contributing guide:
https://github.com/nushell/nushell/blob/main/CONTRIBUTING.md

This template helps reviewers understand your changes and allows us to generate high-quality release notes.
-->

## Description
Fixes #18995

## User-facing changes (Release notes)
<!--
This section is used (mostly as-is) for https://www.nushell.sh/blog/

Describe how Nushell behavior changes from a user's perspective.
Do NOT describe internal Rust changes here.

Write in a release note style, for example:
- "Added support for..."
- "Fixed an issue where..."
- "Nushell now supports..."
- "Improved performance of..."

If your changes do NOT affect users (internal refactors, cleanup, etc.),
just write:
- "n/a"
- "nan"
- or similar

This tells us the change should not appear in the changelog.

Tips:
- Focus on observable behavior
- Include examples if helpful
- Keep it concise

You can:
- Write a short paragraph (will appear as a bullet point), OR
- Use headings (###) if your change needs more structure

Avoid writing things like:
- "In this PR, I refactored..."
- "This updates internal code..."

You may leave this blank until the PR is ready.
-->

mktemp --directory is now relative to the working directory if a template is passed

## Additional notes
<!--
Optional.

Examples:
- fixes #123
- closes #456
- related #789

Anything else reviewers should know.
Remove this section if not needed.
-->
This is a breaking change.

The alternative: Fix the docs, and use `-p .`. It will stay inconsistent between --directory and file, though