### PR TITLE
Replace `to yaml` `--compact-list-indent` with `--list-indent`

### DIFF
--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -46,10 +46,11 @@ impl Command for ToYamlLike {
                 "Configure the indent.",
                 Some('i'),
             )
-            .switch(
-                "compact-list-indent",
-                "Emit lists with a more compact indentation style.",
-                None,
+            .param(
+                Flag::new("list-indent")
+                    .arg(SyntaxShape::String)
+                    .desc("Nested list indentation style ('compact' (default) or 'indented')")
+                    .completion(Completion::new_list(&["compact", "indented"])),
             )
             .param(
                 Flag::new("quote")
@@ -104,7 +105,7 @@ impl Command for ToYamlLike {
         let add_directives = call.has_flag(engine_state, stack, "add-directives")?;
         let multiple = call.has_flag(engine_state, stack, "multiple")?;
         let indent = call.get_flag(engine_state, stack, "indent")?;
-        let compact_list_indent = call.get_flag(engine_state, stack, "compact-list-indent")?;
+        let list_indent_style = call.get_flag(engine_state, stack, "list-indent")?;
         let quote_style = call.get_flag(engine_state, stack, "quote")?;
         let non_roundtrip =
             call.get_flag::<Spanned<Option<String>>>(engine_state, stack, "non-roundtrip")?;
@@ -152,7 +153,7 @@ impl Command for ToYamlLike {
             .with_add_directives(add_directives)
             .with_multiple(multiple)
             .with_indent(indent.unwrap_or(defaults.indent))
-            .with_compact_list_indent(compact_list_indent.unwrap_or(defaults.compact_list_indent))
+            .with_list_indent_style(list_indent_style.unwrap_or(defaults.list_indent_style))
             .with_quote_style(quote_style.unwrap_or(defaults.quote_style));
 
         nu_heavy_utils::yaml::serialize(&value, call.head, options)

--- a/crates/nu-heavy-utils/src/yaml/serialize.rs
+++ b/crates/nu-heavy-utils/src/yaml/serialize.rs
@@ -90,9 +90,8 @@ pub struct SerializeOptions {
     #[default(2)]
     pub indent: usize,
 
-    /// Use compact indentation for nested lists.
-    #[default(true)]
-    pub compact_list_indent: bool,
+    /// List indentation style for nested lists.
+    pub list_indent_style: ListIndentStyle,
 
     /// Configure how strings are quoted.
     pub quote_style: QuoteStyle,
@@ -116,6 +115,17 @@ pub enum NonRoundtrip {
         /// Engine state is required to serialize closures this way.
         engine_state: Box<EngineState>,
     },
+}
+
+/// Configure how nested lists should be indented.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, FromValue)]
+pub enum ListIndentStyle {
+    /// Use the compact list indentation format. No extra indentation for list entries.
+    #[default]
+    Compact,
+
+    /// Indent list entries one level from their root.
+    Indented,
 }
 
 /// Configure how strings are quoted.
@@ -147,7 +157,10 @@ pub fn serialize(
 
     let ser_options = ser_options! {
         indent_step: options.indent,
-        compact_list_indent: options.compact_list_indent,
+        compact_list_indent: match options.list_indent_style {
+            ListIndentStyle::Compact => true,
+            ListIndentStyle::Indented => false,
+        },
         yaml_12: match spec {
             Spec::V1_1 => false,
             Spec::V1_2 => true,

--- a/crates/nu-heavy-utils/src/yaml/serialize.rs
+++ b/crates/nu-heavy-utils/src/yaml/serialize.rs
@@ -640,12 +640,12 @@ mod tests {
         let compact = serialize(
             &value,
             SPAN,
-            SerializeOptions::default().with_compact_list_indent(true),
+            SerializeOptions::default().with_list_indent_style(ListIndentStyle::Compact),
         )?;
         let expanded = serialize(
             &value,
             SPAN,
-            SerializeOptions::default().with_compact_list_indent(false),
+            SerializeOptions::default().with_list_indent_style(ListIndentStyle::Indented),
         )?;
         assert_ne!(compact, expanded);
         assert_contains("containers:\n- env:\n  - name: METHOD\n", compact);


### PR DESCRIPTION
## Description
Right now to disable compact list indents in `to yaml`, you have to pass `--compact-list-indent=false` which is unintuitive for the regular nushell user. To make this flag more straightforward it is replaced with `--list-indent` and now may take either `compact` or `indented` as arguments. The compact list indent style is still the default.

## User-facing changes (Release notes)
Replaced `to yaml`/`to yml`'s `--compact-list-indent` flag with `--list-indent` flag which takes either `compact` or `indented`.
