### PR TITLE
mkdir errors on already-created dir

### DIFF
--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -6,7 +6,6 @@ use uucore::{localized_help_template, translate};
 #[derive(Clone)]
 pub struct UMkdir;
 
-const IS_RECURSIVE: bool = true;
 const DEFAULT_MODE: u32 = 0o777;
 
 #[cfg(target_family = "unix")]
@@ -102,18 +101,40 @@ impl Command for UMkdir {
             });
         }
 
-        let config = uu_mkdir::Config {
-            recursive: IS_RECURSIVE,
-            mode: Some(get_mode()),
-            verbose: false,
-            set_security_context: false,
-            context: None,
+        let mode = Some(get_mode());
+        let verbose = false;
+        let set_security_context = false;
+        let context = None;
+
+        let config_recursive = uu_mkdir::Config {
+            recursive: true,
+            mode,
+            verbose,
+            set_security_context,
+            context,
+        };
+
+        let config_nonrecursive = uu_mkdir::Config {
+            recursive: false,
+            mode,
+            verbose,
+            set_security_context,
+            context,
         };
 
         let mut verbose_out = Vec::new();
         let mut err = None;
         for (dir, dir_span) in directories {
-            if let Err(error) = mkdir(&dir, &config) {
+            // we create dirs in two steps to detect if the dir already exists.
+            // this is because we run with `recursive`,
+            // which would otherwise swallow this error
+            let result = if let Some(parent) = dir.parent() {
+                mkdir(parent, &config_recursive).and_then(|_| mkdir(&dir, &config_nonrecursive))
+            } else {
+                mkdir(&dir, &config_nonrecursive)
+            };
+
+            if let Err(error) = result {
                 let shell_error = ShellError::Generic(GenericError::new(
                     format!("{error}"),
                     translate!(&error.to_string()),
@@ -125,7 +146,7 @@ impl Command for UMkdir {
                         record! {
                             "path" => Value::string(dir.display().to_string(), call.head),
                             "created" => Value::bool(false, call.head),
-                            "error" => Value::string(format!("{error}"), call.head),
+                            "error" => Value::string(translate!(&error.to_string()), call.head),
                         }
                         .into_value(call.head),
                     )

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -1,5 +1,6 @@
 use nu_test_support::playground::Playground;
 use nu_test_support::prelude::*;
+use pretty_assertions::assert_matches;
 
 #[test]
 fn creates_directory() -> Result {
@@ -119,6 +120,44 @@ fn respects_cwd() -> Result {
         let expected = dirs.test().join("some_folder/another/deeper_one");
 
         assert!(expected.is_dir());
+        Ok(())
+    })
+}
+
+#[test]
+fn handles_existing_directory_two_calls() -> Result {
+    Playground::setup("mkdir_test_handles_existing_1", |dirs, _| {
+        let _ = test()
+            .cwd(dirs.test())
+            .run("mkdir foo; mkdir foo")
+            .expect_error()?;
+
+        assert!(dirs.test().join("foo").is_dir());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn handles_existing_directory_verbose() -> Result {
+    Playground::setup("mkdir_test_handles_existing_2", |dirs, _| {
+        let actual: Value = test().cwd(dirs.test()).run("mkdir foo foo --verbose")?;
+
+        assert!(dirs.test().join("foo").is_dir());
+
+        let actual = actual.into_list()?;
+        let [dir1, dir2] = actual.as_slice() else {
+            panic!();
+        };
+
+        let dir1 = dir1.as_record()?;
+        let created = dir1.get("created").map(Value::as_bool).transpose()?;
+        assert_matches!(created, Some(true));
+
+        let dir2 = dir2.as_record()?;
+        let created = dir2.get("created").map(Value::as_bool).transpose()?;
+        assert_matches!(created, Some(false));
+
         Ok(())
     })
 }


### PR DESCRIPTION
## Description
closes #19003. tl;dr: since we always run `mkdir` with implied `--parents`, dirs are always created and errors are never thrown. however, we forgot to detect when dirs are not created because they already exist.

note also that we now use `translate` in the `error` field when `--verbose` is passed. this can pretty easily run into #19004 (for example if `mktemp` was used beforehand). this also keeps the dir name in the error, so you can have something like `path: /foo/bar, created: false, error: /foo/bar: File exists`. in other words, we repeat the path. tell me if that's not what we want.

## User-facing changes (Release notes)
`nushell` will now error when a dir already exists. nushell's `--verbose` will no longer report a dir as created when it already exists. however, if multiple dirs are created in the same command (e.g. `mkdir dir1 dir2/dir3 dir4`) and some of them already exist, the non-existing ones will still be created. this matches the behavior of typical `mkdir` implementations.

## Disclosure
AI was consulted while creating this, but did not generate code.