### PR TITLE
Revert "mkdir errors on already-created dir"

### DIFF
--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -6,6 +6,7 @@ use uucore::{localized_help_template, translate};
 #[derive(Clone)]
 pub struct UMkdir;
 
+const IS_RECURSIVE: bool = true;
 const DEFAULT_MODE: u32 = 0o777;
 
 #[cfg(target_family = "unix")]
@@ -101,40 +102,18 @@ impl Command for UMkdir {
             });
         }
 
-        let mode = Some(get_mode());
-        let verbose = false;
-        let set_security_context = false;
-        let context = None;
-
-        let config_recursive = uu_mkdir::Config {
-            recursive: true,
-            mode,
-            verbose,
-            set_security_context,
-            context,
-        };
-
-        let config_nonrecursive = uu_mkdir::Config {
-            recursive: false,
-            mode,
-            verbose,
-            set_security_context,
-            context,
+        let config = uu_mkdir::Config {
+            recursive: IS_RECURSIVE,
+            mode: Some(get_mode()),
+            verbose: false,
+            set_security_context: false,
+            context: None,
         };
 
         let mut verbose_out = Vec::new();
         let mut err = None;
         for (dir, dir_span) in directories {
-            // we create dirs in two steps to detect if the dir already exists.
-            // this is because we run with `recursive`,
-            // which would otherwise swallow this error
-            let result = if let Some(parent) = dir.parent() {
-                mkdir(parent, &config_recursive).and_then(|_| mkdir(&dir, &config_nonrecursive))
-            } else {
-                mkdir(&dir, &config_nonrecursive)
-            };
-
-            if let Err(error) = result {
+            if let Err(error) = mkdir(&dir, &config) {
                 let shell_error = ShellError::Generic(GenericError::new(
                     format!("{error}"),
                     translate!(&error.to_string()),
@@ -146,7 +125,7 @@ impl Command for UMkdir {
                         record! {
                             "path" => Value::string(dir.display().to_string(), call.head),
                             "created" => Value::bool(false, call.head),
-                            "error" => Value::string(translate!(&error.to_string()), call.head),
+                            "error" => Value::string(format!("{error}"), call.head),
                         }
                         .into_value(call.head),
                     )

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -1,6 +1,5 @@
 use nu_test_support::playground::Playground;
 use nu_test_support::prelude::*;
-use pretty_assertions::assert_matches;
 
 #[test]
 fn creates_directory() -> Result {
@@ -120,44 +119,6 @@ fn respects_cwd() -> Result {
         let expected = dirs.test().join("some_folder/another/deeper_one");
 
         assert!(expected.is_dir());
-        Ok(())
-    })
-}
-
-#[test]
-fn handles_existing_directory_two_calls() -> Result {
-    Playground::setup("mkdir_test_handles_existing_1", |dirs, _| {
-        let _ = test()
-            .cwd(dirs.test())
-            .run("mkdir foo; mkdir foo")
-            .expect_error()?;
-
-        assert!(dirs.test().join("foo").is_dir());
-
-        Ok(())
-    })
-}
-
-#[test]
-fn handles_existing_directory_verbose() -> Result {
-    Playground::setup("mkdir_test_handles_existing_2", |dirs, _| {
-        let actual: Value = test().cwd(dirs.test()).run("mkdir foo foo --verbose")?;
-
-        assert!(dirs.test().join("foo").is_dir());
-
-        let actual = actual.into_list()?;
-        let [dir1, dir2] = actual.as_slice() else {
-            panic!();
-        };
-
-        let dir1 = dir1.as_record()?;
-        let created = dir1.get("created").map(Value::as_bool).transpose()?;
-        assert_matches!(created, Some(true));
-
-        let dir2 = dir2.as_record()?;
-        let created = dir2.get("created").map(Value::as_bool).transpose()?;
-        assert_matches!(created, Some(false));
-
         Ok(())
     })
 }


### PR DESCRIPTION
Reverts nushell/nushell#19006

@pickx if you want to implement a new flag for this functionality instead of having it as default, have at it.